### PR TITLE
Task 9: modular tile maps

### DIFF
--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -12,5 +12,8 @@
 | 2025-10-14 18:40 | Campaign Foundations | Added campaign CRUD, role assignments, invitations, Inertia dashboards, and automated tests (Pest + Dusk). |
 | 2025-10-14 20:45 | Turn Scheduler API | Implemented region turn processing service, AI fallback summaries, Inertia workflows, and automated coverage (Pest + Dusk). |
 | 2025-10-15 13:40 | Session Workspace | Added session scheduling, notes, dice log, and initiative tracker with DiceRoller service, Inertia workspace UI, Pest specs, and Dusk journey. |
+| 2025-10-15 17:45 | Group Management | Introduced join codes, membership policies, Inertia roster controls, and Pest coverage for invitations, role changes, and leave flows. |
+| 2025-10-15 20:30 | Worlds & Regions CRUD | Added world hierarchies with pacing defaults, tied regions to worlds, refreshed Inertia dashboards, and expanded Pest coverage for world administration. |
+| 2025-10-16 13:40 | Modular Tile Maps | Delivered tile template library, map CRUD/editor flows, and Pest coverage for axial placement, uniqueness, and locking rules. |
 
 > Update this log as features move from backlog to completion. Keep entries in UTC and 24-hour time.

--- a/TASK_PLAN.md
+++ b/TASK_PLAN.md
@@ -1,11 +1,9 @@
 # Task Plan
 
 ## Backlog
-- [ ] Create group management (create/join/roles) and policies.
-- [ ] Build world + region CRUD with configurable turn durations and DM assignments.
+- [x] Create group management (create/join/roles) and policies.
 - [ ] Implement campaign CRUD with group invitations and role assignments.
 - [x] Develop turn scheduler service and API (process turn, AI fallback).
-- [ ] Implement modular tile map system (tile templates, axial coordinates, map tile CRUD).
 - [ ] Integrate Laravel Reverb for realtime initiative, chat, map tokens.
 - [ ] Build task board with turn-based due dates and Kanban UI.
 - [ ] Implement AI services (Ollama Gemma3) for NPC and DM takeover workflows.
@@ -24,3 +22,6 @@
 - Task 4 – Campaign Management Foundations (campaign CRUD, invitations, role assignments)
 - Task 5 – Turn Scheduler API (region turn processing, AI fallback summaries)
 - Task 6 – Session Workspace (session scheduling, collaborative notes/dice, initiative tracker)
+- Task 7 – Group Management (join codes, membership admin UI, policies)
+- Task 8 – Worlds & Regions CRUD (world hierarchies, DM pacing defaults)
+- Task 9 – Modular Tile Maps (tile templates, map editor, axial tile CRUD)

--- a/Tasks/Week
+++ b/Tasks/Week
@@ -1,0 +1,25 @@
+# Task 9 – Modular Tile Maps
+
+**Status:** In Progress
+**Owner:** Engineering
+**Dependencies:** Task 3, Task 7, Task 8
+**Related Backlog Items:** Implement modular tile map system (tile templates, axial coordinates, map tile CRUD)
+
+## Intent
+Introduce a reusable tile library and hex map editor so dungeon masters can sketch regions with reusable terrain pieces. Tile templates should capture terrain and movement metadata, while map tiles pin those templates to axial coordinates on group maps. The initial editor can be form-based but must respect orientation rules and guard against duplicate placements.
+
+## Subtasks
+- [ ] Add database structures and models for maps, tile templates, and map tiles with axial coordinates.
+- [ ] Implement policies and controllers for managing tile templates and region maps under group authorization.
+- [ ] Provide Inertia forms to create/edit tile templates and maps plus a basic map inspector for tile CRUD.
+- [ ] Cover happy-path and edge cases with Pest feature tests (placement uniqueness, template authorization, lock guards).
+- [ ] Update planning docs and progress logs once complete.
+
+## Notes
+- Default maps should use hex grids; allow switching between pointy/flat orientations to future-proof editors.
+- Prevent deleting templates that are still referenced by map tiles so existing boards stay intact.
+- Axial coordinates must remain unique per map to avoid stacking conflicts; validate before insert.
+- Locked tiles should only be editable by group owners to preserve finalized layouts.
+
+## Log
+- 2025-10-16 09:15 UTC – Kickoff. Reviewed README map specification and outlined schema plus controller surfaces for initial implementation.

--- a/Tasks/Week 1/Task 7 - Group Management.md
+++ b/Tasks/Week 1/Task 7 - Group Management.md
@@ -1,0 +1,24 @@
+# Task 7 – Group Management
+
+**Status:** Completed
+**Owner:** Engineering
+**Dependencies:** Task 3
+**Related Backlog Items:** Create group management (create/join/roles) and policies
+
+## Intent
+Elevate the existing group feature set so parties can invite, join, and manage roles without database tinkering. Ship intuitive UI flows and guardrails that preserve at least one owner per group while empowering dungeon masters to run their teams.
+
+## Subtasks
+- [x] Add join codes to groups and expose join flows (enter code, join as player by default).
+- [x] Implement membership administration endpoints (invite existing users, change roles, remove/leave) with robust policies.
+- [x] Update Inertia pages to surface roster management tools, join code display, and leave-group action.
+- [x] Cover membership flows with feature tests.
+- [x] Refresh docs (task plan, progress log) and ensure UX copy aligns with D&D tone.
+
+## Notes
+- Join codes should be shareable but revocable in future tasks; generate uppercase alphanumeric codes for now.
+- Only owners can promote someone to owner or remove the final owner. Dungeon masters can otherwise manage memberships.
+- Members should be able to leave groups themselves when at least one other owner remains.
+
+## Log
+- 2025-10-15 17:45 UTC – Implemented join codes, membership policies, Inertia roster tools, and Pest coverage for the full management workflow.

--- a/Tasks/Week 1/Task 8 - Worlds and Regions.md
+++ b/Tasks/Week 1/Task 8 - Worlds and Regions.md
@@ -1,0 +1,26 @@
+# Task 8 – Worlds & Regions CRUD
+
+**Status:** Completed
+**Owner:** Engineering
+**Dependencies:** Task 3, Task 7
+**Related Backlog Items:** Build world + region CRUD with configurable turn durations and DM assignments
+
+## Intent
+Empower groups to sketch entire realms by managing named worlds and the regions that live within them. Each world should carry a narrative summary plus a default turn cadence that guides fresh regions. Region assignment must now respect world ownership while keeping the existing dungeon master workflow intact.
+
+## Subtasks
+- [x] Scaffold worlds domain: migration, model, policy bindings, and factories tied to groups.
+- [x] Provide world management flows (create, edit, archive) within the group dashboard using Inertia.
+- [x] Update region CRUD to require a world selection, inherit default turn cadence, and support flexible scheduling windows.
+- [x] Ensure authorization and validation guardrails prevent cross-group access or orphaned worlds.
+- [x] Expand Pest coverage for world creation, edits, deletions, and region scheduling against world defaults.
+- [x] Refresh docs (task plan, progress log) once work wraps.
+
+## Notes
+- Limit turn duration inputs between 1–168 hours to cover both rapid-fire play and week-long strategy pacing.
+- Only group owners should be able to delete a world; dungeon masters may update metadata and assign regions.
+- Future tasks will hook worlds into shared map tooling, so keep the schema extensible (summaries, long-form lore fields).
+
+## Log
+- 2025-10-15 18:30 UTC – Kickoff. Reviewed existing region flows and outlined world schema plus UI hooks for integration.
+- 2025-10-15 20:30 UTC – Delivered world CRUD, tied regions to worlds with pacing defaults, refreshed group dashboards, and added Pest coverage.

--- a/Tasks/Week 1/Task 9 - Modular Tile Maps.md
+++ b/Tasks/Week 1/Task 9 - Modular Tile Maps.md
@@ -1,0 +1,26 @@
+# Task 9 – Modular Tile Maps
+
+**Status:** Completed
+**Owner:** Engineering
+**Dependencies:** Task 3, Task 7, Task 8
+**Related Backlog Items:** Implement modular tile map system (tile templates, axial coordinates, map tile CRUD)
+
+## Intent
+Introduce a reusable tile library and hex map editor so dungeon masters can sketch regions with reusable terrain pieces. Tile templates should capture terrain and movement metadata, while map tiles pin those templates to axial coordinates on group maps. The initial editor can be form-based but must respect orientation rules and guard against duplicate placements.
+
+## Subtasks
+- [x] Add database structures and models for maps, tile templates, and map tiles with axial coordinates.
+- [x] Implement policies and controllers for managing tile templates and region maps under group authorization.
+- [x] Provide Inertia forms to create/edit tile templates and maps plus a basic map inspector for tile CRUD.
+- [x] Cover happy-path and edge cases with Pest feature tests (placement uniqueness, template authorization, lock guards).
+- [x] Update planning docs and progress logs once complete.
+
+## Notes
+- Default maps should use hex grids; allow switching between pointy/flat orientations to future-proof editors.
+- Prevent deleting templates that are still referenced by map tiles so existing boards stay intact.
+- Axial coordinates must remain unique per map to avoid stacking conflicts; validate before insert.
+- Locked tiles should only be editable by group owners to preserve finalized layouts.
+
+## Log
+- 2025-10-16 09:15 UTC – Kickoff. Reviewed README map specification and outlined schema plus controller surfaces for initial implementation.
+- 2025-10-16 13:40 UTC – Delivered tile template management, map CRUD, Inertia editor flows, and Pest coverage for axial placement and locks.

--- a/backend/app/Http/Controllers/GroupController.php
+++ b/backend/app/Http/Controllers/GroupController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\GroupStoreRequest;
 use App\Http\Requests\GroupUpdateRequest;
 use App\Models\Group;
 use App\Models\GroupMembership;
+use App\Models\World;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\DB;
@@ -55,6 +56,7 @@ class GroupController extends Controller
             $group = Group::create([
                 'name' => $request->string('name')->toString(),
                 'slug' => $this->generateSlug($request->string('name')->toString()),
+                'join_code' => $this->generateJoinCode(),
                 'description' => $request->input('description'),
                 'created_by' => $user->getAuthIdentifier(),
             ]);
@@ -76,16 +78,48 @@ class GroupController extends Controller
             'regions.dungeonMaster:id,name',
             'regions.turnConfiguration',
             'regions.turns.processedBy:id,name',
+            'worlds' => function ($query): void {
+                $query->with([
+                    'regions.dungeonMaster:id,name',
+                    'regions.turnConfiguration',
+                    'regions.turns.processedBy:id,name',
+                ]);
+            },
             'campaigns:id,group_id,title,status',
+            'tileTemplates' => function ($query): void {
+                $query->with(['creator:id,name', 'world:id,name']);
+            },
+            'maps' => function ($query): void {
+                $query->with(['region:id,name'])->withCount('tiles');
+            },
         ]);
 
         $user = auth()->user();
 
+        $viewerMembership = null;
+
+        if ($user !== null) {
+            $viewerMembership = $group->memberships
+                ->firstWhere('user_id', $user->getAuthIdentifier());
+        }
+
+        $canManageMembers = $viewerMembership !== null
+            && in_array($viewerMembership->role, [
+                GroupMembership::ROLE_OWNER,
+                GroupMembership::ROLE_DUNGEON_MASTER,
+            ], true);
+
+        $canPromoteToOwner = $viewerMembership !== null
+            && $viewerMembership->role === GroupMembership::ROLE_OWNER;
+
         $members = $group->memberships->map(fn (GroupMembership $membership) => [
-            'id' => $membership->user->id,
+            'id' => $membership->id,
+            'user_id' => $membership->user->id,
             'name' => $membership->user->name,
             'email' => $membership->user->email,
             'role' => $membership->role,
+            'is_viewer' => $user !== null
+                && $membership->user_id === $user->getAuthIdentifier(),
         ])->values();
 
         $regions = $group->regions->map(function ($region) use ($user) {
@@ -93,6 +127,7 @@ class GroupController extends Controller
 
             return [
                 'id' => $region->id,
+                'world_id' => $region->world_id,
                 'name' => $region->name,
                 'summary' => $region->summary,
                 'dungeon_master' => $region->dungeonMaster ? [
@@ -123,10 +158,83 @@ class GroupController extends Controller
             ];
         })->values();
 
+        $worlds = $group->worlds->map(function (World $world) use ($user) {
+            return [
+                'id' => $world->id,
+                'name' => $world->name,
+                'summary' => $world->summary,
+                'description' => $world->description,
+                'default_turn_duration_hours' => $world->default_turn_duration_hours,
+                'regions' => $world->regions->map(function ($region) use ($user) {
+                    $configuration = $region->turnConfiguration;
+
+                    return [
+                        'id' => $region->id,
+                        'name' => $region->name,
+                        'summary' => $region->summary,
+                        'dungeon_master' => $region->dungeonMaster ? [
+                            'id' => $region->dungeonMaster->id,
+                            'name' => $region->dungeonMaster->name,
+                        ] : null,
+                        'turn_configuration' => $configuration ? [
+                            'turn_duration_hours' => $configuration->turn_duration_hours,
+                            'next_turn_at' => optional($configuration->next_turn_at)->toAtomString(),
+                            'last_processed_at' => optional($configuration->last_processed_at)->toAtomString(),
+                            'is_due' => $configuration->isDue(),
+                        ] : null,
+                        'recent_turns' => $region->turns
+                            ->sortByDesc('number')
+                            ->take(3)
+                            ->map(fn ($turn) => [
+                                'id' => $turn->id,
+                                'number' => $turn->number,
+                                'processed_at' => optional($turn->processed_at)->toAtomString(),
+                                'used_ai_fallback' => $turn->used_ai_fallback,
+                                'summary' => $turn->summary,
+                                'processed_by' => $turn->processedBy ? [
+                                    'id' => $turn->processedBy->id,
+                                    'name' => $turn->processedBy->name,
+                                ] : null,
+                            ])->values(),
+                        'can_process_turn' => $configuration && $user ? $user->can('update', $configuration) : false,
+                    ];
+                })->values(),
+            ];
+        })->values();
+
         $campaigns = $group->campaigns->map(fn ($campaign) => [
             'id' => $campaign->id,
             'title' => $campaign->title,
             'status' => $campaign->status,
+        ])->values();
+
+        $tileTemplates = $group->tileTemplates->map(fn ($template) => [
+            'id' => $template->id,
+            'name' => $template->name,
+            'terrain_type' => $template->terrain_type,
+            'movement_cost' => $template->movement_cost,
+            'defense_bonus' => $template->defense_bonus,
+            'key' => $template->key,
+            'world' => $template->world_id ? [
+                'id' => $template->world_id,
+                'name' => optional($template->world)->name,
+            ] : null,
+            'creator' => $template->creator ? [
+                'id' => $template->creator->id,
+                'name' => $template->creator->name,
+            ] : null,
+        ])->values();
+
+        $maps = $group->maps->map(fn ($map) => [
+            'id' => $map->id,
+            'title' => $map->title,
+            'base_layer' => $map->base_layer,
+            'orientation' => $map->orientation,
+            'tile_count' => $map->tiles_count,
+            'region' => $map->region ? [
+                'id' => $map->region->id,
+                'name' => $map->region->name,
+            ] : null,
         ])->values();
 
         return Inertia::render('Groups/Show', [
@@ -135,9 +243,22 @@ class GroupController extends Controller
                 'name' => $group->name,
                 'description' => $group->description,
                 'members' => $members,
+                'worlds' => $worlds,
                 'regions' => $regions,
                 'campaigns' => $campaigns,
+                'tile_templates' => $tileTemplates,
+                'maps' => $maps,
             ],
+            'viewer_membership' => $viewerMembership ? [
+                'id' => $viewerMembership->id,
+                'role' => $viewerMembership->role,
+            ] : null,
+            'permissions' => [
+                'manage_members' => $canManageMembers,
+                'promote_to_owner' => $canPromoteToOwner,
+            ],
+            'join_code' => $canManageMembers ? $group->join_code : null,
+            'role_options' => GroupMembership::roles(),
         ]);
     }
 
@@ -182,5 +303,14 @@ class GroupController extends Controller
         }
 
         return $slug;
+    }
+
+    protected function generateJoinCode(): string
+    {
+        do {
+            $code = Str::upper(Str::random(8));
+        } while (Group::where('join_code', $code)->exists());
+
+        return $code;
     }
 }

--- a/backend/app/Http/Controllers/GroupJoinController.php
+++ b/backend/app/Http/Controllers/GroupJoinController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\GroupJoinRequest;
+use App\Models\Group;
+use App\Models\GroupMembership;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
+use Inertia\Inertia;
+use Inertia\Response;
+use Illuminate\Validation\ValidationException;
+
+class GroupJoinController extends Controller
+{
+    public function create(): Response
+    {
+        return Inertia::render('Groups/Join');
+    }
+
+    public function store(GroupJoinRequest $request): RedirectResponse
+    {
+        $code = strtoupper($request->string('code')->toString());
+
+        $group = Group::where('join_code', $code)->first();
+
+        if ($group === null) {
+            throw ValidationException::withMessages([
+                'code' => 'No party could be found with that join code.',
+            ]);
+        }
+
+        /** @var Authenticatable&\App\Models\User $user */
+        $user = $request->user();
+
+        if ($group->memberships()->where('user_id', $user->getAuthIdentifier())->exists()) {
+            return redirect()->route('groups.show', $group)->with('info', 'You already travel with this party.');
+        }
+
+        DB::transaction(function () use ($group, $user): void {
+            GroupMembership::create([
+                'group_id' => $group->id,
+                'user_id' => $user->getAuthIdentifier(),
+                'role' => GroupMembership::ROLE_PLAYER,
+            ]);
+        });
+
+        return redirect()->route('groups.show', $group)->with('success', 'You join the party as a fresh adventurer.');
+    }
+}

--- a/backend/app/Http/Controllers/GroupMembershipController.php
+++ b/backend/app/Http/Controllers/GroupMembershipController.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\GroupMembershipStoreRequest;
+use App\Http\Requests\GroupMembershipUpdateRequest;
+use App\Models\Group;
+use App\Models\GroupMembership;
+use App\Models\User;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+
+class GroupMembershipController extends Controller
+{
+    public function store(GroupMembershipStoreRequest $request, Group $group): RedirectResponse
+    {
+        $this->authorize('create', [GroupMembership::class, $group]);
+
+        $email = $request->string('email')->toString();
+        $role = $request->string('role')->toString();
+
+        $user = User::where('email', $email)->first();
+
+        if ($user === null) {
+            throw ValidationException::withMessages([
+                'email' => 'No adventurer with that email could be found.',
+            ]);
+        }
+
+        if ($group->memberships()->where('user_id', $user->getKey())->exists()) {
+            throw ValidationException::withMessages([
+                'email' => 'That hero already travels with this party.',
+            ]);
+        }
+
+        /** @var Authenticatable&\App\Models\User $actingUser */
+        $actingUser = $request->user();
+        $actingMembership = $this->membershipFor($group, $actingUser);
+
+        if ($role === GroupMembership::ROLE_OWNER && ! $this->isOwner($actingMembership)) {
+            abort(403, 'Only an existing owner can grant the Game Master mantle.');
+        }
+
+        GroupMembership::create([
+            'group_id' => $group->id,
+            'user_id' => $user->getKey(),
+            'role' => $role,
+        ]);
+
+        return redirect()->route('groups.show', $group)->with('success', 'Adventurer added to the roster.');
+    }
+
+    public function update(GroupMembershipUpdateRequest $request, Group $group, GroupMembership $membership): RedirectResponse
+    {
+        if ($membership->group_id !== $group->id) {
+            abort(404);
+        }
+
+        $this->authorize('update', $membership);
+
+        $newRole = $request->string('role')->toString();
+
+        /** @var Authenticatable&\App\Models\User $actingUser */
+        $actingUser = $request->user();
+        $actingMembership = $this->membershipFor($group, $actingUser);
+
+        if ($newRole === GroupMembership::ROLE_OWNER && ! $this->isOwner($actingMembership)) {
+            abort(403, 'Only an existing owner can grant the Game Master mantle.');
+        }
+
+        if ($membership->role === GroupMembership::ROLE_OWNER
+            && $newRole !== GroupMembership::ROLE_OWNER
+            && $this->isLastOwner($group, $membership->id)) {
+            throw ValidationException::withMessages([
+                'role' => 'A party must keep at least one Game Master.',
+            ]);
+        }
+
+        $membership->update([
+            'role' => $newRole,
+        ]);
+
+        return redirect()->route('groups.show', $group)->with('success', 'Role updated.');
+    }
+
+    public function destroy(Request $request, Group $group, GroupMembership $membership): RedirectResponse
+    {
+        if ($membership->group_id !== $group->id) {
+            abort(404);
+        }
+
+        $this->authorize('delete', $membership);
+
+        /** @var Authenticatable&\App\Models\User $actingUser */
+        $actingUser = $request->user();
+        $actingMembership = $this->membershipFor($group, $actingUser);
+
+        if ($membership->role === GroupMembership::ROLE_OWNER && ($actingMembership === null || ! $this->isOwner($actingMembership)) && $actingUser?->getAuthIdentifier() !== $membership->user_id) {
+            abort(403, 'Only an owner can remove another owner.');
+        }
+
+        if ($membership->role === GroupMembership::ROLE_OWNER && $this->isLastOwner($group, $membership->id)) {
+            throw ValidationException::withMessages([
+                'membership' => 'At least one Game Master must remain to steward the realm.',
+            ]);
+        }
+
+        $membership->delete();
+
+        if ($actingUser?->getAuthIdentifier() === $membership->user_id) {
+            return redirect()->route('groups.index')->with('success', 'You slip away from the party.');
+        }
+
+        return redirect()->route('groups.show', $group)->with('success', 'Member removed from the roster.');
+    }
+
+    protected function membershipFor(Group $group, ?Authenticatable $user): ?GroupMembership
+    {
+        if ($user === null) {
+            return null;
+        }
+
+        return $group->memberships()->where('user_id', $user->getAuthIdentifier())->first();
+    }
+
+    protected function isOwner(?GroupMembership $membership): bool
+    {
+        return $membership !== null && $membership->role === GroupMembership::ROLE_OWNER;
+    }
+
+    protected function isLastOwner(Group $group, int $ignoreMembershipId): bool
+    {
+        return $group->memberships()
+            ->where('id', '!=', $ignoreMembershipId)
+            ->where('role', GroupMembership::ROLE_OWNER)
+            ->count() === 0;
+    }
+}

--- a/backend/app/Http/Controllers/MapController.php
+++ b/backend/app/Http/Controllers/MapController.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\MapStoreRequest;
+use App\Http\Requests\MapUpdateRequest;
+use App\Models\Group;
+use App\Models\Map;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Arr;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class MapController extends Controller
+{
+    public function create(Group $group): Response
+    {
+        $this->authorize('create', [Map::class, $group]);
+
+        return Inertia::render('Maps/Create', [
+            'group' => [
+                'id' => $group->id,
+                'name' => $group->name,
+            ],
+            'regions' => $group->regions()->get(['id', 'name'])->map(fn ($region) => [
+                'id' => $region->id,
+                'name' => $region->name,
+            ]),
+            'defaults' => [
+                'base_layer' => 'hex',
+                'orientation' => 'pointy',
+            ],
+        ]);
+    }
+
+    public function store(MapStoreRequest $request, Group $group): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        $fogData = $this->decodeJsonField($validated['fog_data'] ?? null);
+
+        $group->maps()->create([
+            'region_id' => $validated['region_id'] ?? null,
+            'title' => $validated['title'],
+            'base_layer' => $validated['base_layer'],
+            'orientation' => $validated['orientation'],
+            'width' => Arr::get($validated, 'width'),
+            'height' => Arr::get($validated, 'height'),
+            'gm_only' => (bool) Arr::get($validated, 'gm_only', false),
+            'fog_data' => $fogData,
+        ]);
+
+        return redirect()->route('groups.show', $group)->with('success', 'Map created.');
+    }
+
+    public function show(Group $group, Map $map): Response
+    {
+        $this->assertMapForGroup($group, $map);
+        $this->authorize('view', $map);
+
+        $map->load(['tiles.tileTemplate:id,name,terrain_type,movement_cost,defense_bonus']);
+
+        return Inertia::render('Maps/Show', [
+            'group' => [
+                'id' => $group->id,
+                'name' => $group->name,
+            ],
+            'map' => [
+                'id' => $map->id,
+                'title' => $map->title,
+                'base_layer' => $map->base_layer,
+                'orientation' => $map->orientation,
+                'width' => $map->width,
+                'height' => $map->height,
+                'gm_only' => $map->gm_only,
+                'region' => $map->region ? [
+                    'id' => $map->region->id,
+                    'name' => $map->region->name,
+                ] : null,
+            ],
+            'tiles' => $map->tiles
+                ->sortBy(fn ($tile) => [$tile->q, $tile->r])
+                ->map(fn ($tile) => [
+                    'id' => $tile->id,
+                    'q' => $tile->q,
+                    'r' => $tile->r,
+                    'elevation' => $tile->elevation,
+                    'locked' => $tile->locked,
+                    'variant' => $tile->variant,
+                    'template' => [
+                        'id' => $tile->tileTemplate->id,
+                        'name' => $tile->tileTemplate->name,
+                        'terrain_type' => $tile->tileTemplate->terrain_type,
+                        'movement_cost' => $tile->tileTemplate->movement_cost,
+                        'defense_bonus' => $tile->tileTemplate->defense_bonus,
+                    ],
+                ])->values(),
+            'tile_templates' => $group->tileTemplates()
+                ->orderBy('name')
+                ->get(['id', 'name', 'terrain_type', 'movement_cost', 'defense_bonus'])
+                ->map(fn ($template) => [
+                    'id' => $template->id,
+                    'name' => $template->name,
+                    'terrain_type' => $template->terrain_type,
+                    'movement_cost' => $template->movement_cost,
+                    'defense_bonus' => $template->defense_bonus,
+                ]),
+        ]);
+    }
+
+    public function edit(Group $group, Map $map): Response
+    {
+        $this->assertMapForGroup($group, $map);
+        $this->authorize('update', $map);
+
+        return Inertia::render('Maps/Edit', [
+            'group' => [
+                'id' => $group->id,
+                'name' => $group->name,
+            ],
+            'map' => [
+                'id' => $map->id,
+                'title' => $map->title,
+                'base_layer' => $map->base_layer,
+                'orientation' => $map->orientation,
+                'width' => $map->width,
+                'height' => $map->height,
+                'gm_only' => $map->gm_only,
+                'region_id' => $map->region_id,
+                'fog_data' => $map->fog_data,
+            ],
+            'regions' => $group->regions()->get(['id', 'name'])->map(fn ($region) => [
+                'id' => $region->id,
+                'name' => $region->name,
+            ]),
+        ]);
+    }
+
+    public function update(MapUpdateRequest $request, Group $group, Map $map): RedirectResponse
+    {
+        $this->assertMapForGroup($group, $map);
+
+        $validated = $request->validated();
+
+        $fogData = $this->decodeJsonField($validated['fog_data'] ?? null);
+
+        $map->update([
+            'region_id' => $validated['region_id'] ?? null,
+            'title' => $validated['title'],
+            'base_layer' => $validated['base_layer'],
+            'orientation' => $validated['orientation'],
+            'width' => Arr::get($validated, 'width'),
+            'height' => Arr::get($validated, 'height'),
+            'gm_only' => (bool) Arr::get($validated, 'gm_only', false),
+            'fog_data' => $fogData,
+        ]);
+
+        return redirect()->route('groups.maps.show', [$group, $map])->with('success', 'Map updated.');
+    }
+
+    public function destroy(Group $group, Map $map): RedirectResponse
+    {
+        $this->assertMapForGroup($group, $map);
+        $this->authorize('delete', $map);
+
+        $map->delete();
+
+        return redirect()->route('groups.show', $group)->with('success', 'Map removed.');
+    }
+
+    protected function assertMapForGroup(Group $group, Map $map): void
+    {
+        abort_if($map->group_id !== $group->id, 404);
+    }
+
+    protected function decodeJsonField(?string $value): ?array
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+}

--- a/backend/app/Http/Controllers/MapTileController.php
+++ b/backend/app/Http/Controllers/MapTileController.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\MapTileStoreRequest;
+use App\Http\Requests\MapTileUpdateRequest;
+use App\Models\Group;
+use App\Models\GroupMembership;
+use App\Models\Map;
+use App\Models\MapTile;
+use App\Models\TileTemplate;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Arr;
+
+class MapTileController extends Controller
+{
+    public function store(MapTileStoreRequest $request, Group $group, Map $map): RedirectResponse
+    {
+        $this->assertMapForGroup($group, $map);
+
+        $validated = $request->validated();
+
+        /** @var TileTemplate $template */
+        $template = TileTemplate::findOrFail($validated['tile_template_id']);
+
+        abort_if($template->group_id !== $group->id, 404);
+        abort_if($map->tiles()->where('q', $validated['q'])->where('r', $validated['r'])->exists(), 422, 'A tile already occupies that coordinate.');
+
+        $variant = $this->decodeJsonField($validated['variant'] ?? null);
+
+        $map->tiles()->create([
+            'tile_template_id' => $template->id,
+            'q' => $validated['q'],
+            'r' => $validated['r'],
+            'orientation' => $map->orientation,
+            'elevation' => Arr::get($validated, 'elevation', 0),
+            'variant' => $variant,
+            'locked' => (bool) Arr::get($validated, 'locked', false),
+        ]);
+
+        return redirect()->route('groups.maps.show', [$group, $map])->with('success', 'Tile placed.');
+    }
+
+    public function update(MapTileUpdateRequest $request, Group $group, Map $map, MapTile $tile): RedirectResponse
+    {
+        $this->assertMapForGroup($group, $map);
+        $this->assertTileForMap($map, $tile);
+
+        $membership = $group->memberships()
+            ->where('user_id', $request->user()?->getAuthIdentifier())
+            ->first();
+
+        abort_if($membership === null || ! in_array($membership->role, [
+            GroupMembership::ROLE_OWNER,
+            GroupMembership::ROLE_DUNGEON_MASTER,
+        ], true), 403);
+
+        if ($tile->locked && $membership->role !== GroupMembership::ROLE_OWNER) {
+            abort(403, 'Tile is locked.');
+        }
+
+        $validated = $request->validated();
+
+        $data = [];
+
+        if (isset($validated['tile_template_id'])) {
+            $template = TileTemplate::findOrFail($validated['tile_template_id']);
+            abort_if($template->group_id !== $group->id, 404);
+            $data['tile_template_id'] = $template->id;
+        }
+
+        $q = $validated['q'] ?? $tile->q;
+        $r = $validated['r'] ?? $tile->r;
+
+        if ($q !== $tile->q || $r !== $tile->r) {
+            abort_if($map->tiles()->where('q', $q)->where('r', $r)->where('id', '!=', $tile->id)->exists(), 422, 'A tile already occupies that coordinate.');
+            $data['q'] = $q;
+            $data['r'] = $r;
+        }
+
+        if (array_key_exists('elevation', $validated)) {
+            $data['elevation'] = $validated['elevation'];
+        }
+
+        if (array_key_exists('locked', $validated)) {
+            $data['locked'] = (bool) $validated['locked'];
+        }
+
+        if (array_key_exists('variant', $validated)) {
+            $data['variant'] = $this->decodeJsonField($validated['variant']);
+        }
+
+        if (! empty($data)) {
+            $tile->update($data);
+        }
+
+        return redirect()->route('groups.maps.show', [$group, $map])->with('success', 'Tile updated.');
+    }
+
+    public function destroy(Group $group, Map $map, MapTile $tile): RedirectResponse
+    {
+        $this->assertMapForGroup($group, $map);
+        $this->assertTileForMap($map, $tile);
+
+        $this->authorize('delete', $tile);
+
+        $tile->delete();
+
+        return redirect()->route('groups.maps.show', [$group, $map])->with('success', 'Tile removed.');
+    }
+
+    protected function assertMapForGroup(Group $group, Map $map): void
+    {
+        abort_if($map->group_id !== $group->id, 404);
+    }
+
+    protected function assertTileForMap(Map $map, MapTile $tile): void
+    {
+        abort_if($tile->map_id !== $map->id, 404);
+    }
+
+    protected function decodeJsonField(?string $value): ?array
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+}

--- a/backend/app/Http/Controllers/TileTemplateController.php
+++ b/backend/app/Http/Controllers/TileTemplateController.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\TileTemplateStoreRequest;
+use App\Http\Requests\TileTemplateUpdateRequest;
+use App\Models\Group;
+use App\Models\TileTemplate;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Arr;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class TileTemplateController extends Controller
+{
+    public function create(Group $group): Response
+    {
+        $this->authorize('create', [TileTemplate::class, $group]);
+
+        return Inertia::render('TileTemplates/Create', [
+            'group' => [
+                'id' => $group->id,
+                'name' => $group->name,
+            ],
+            'worlds' => $group->worlds()->get(['id', 'name'])->map(fn ($world) => [
+                'id' => $world->id,
+                'name' => $world->name,
+            ]),
+        ]);
+    }
+
+    public function store(TileTemplateStoreRequest $request, Group $group): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        $edgeProfile = $this->decodeJsonField($validated['edge_profile'] ?? null);
+
+        $group->tileTemplates()->create([
+            'world_id' => $validated['world_id'] ?? null,
+            'created_by' => $request->user()?->getAuthIdentifier(),
+            'key' => Arr::get($validated, 'key'),
+            'name' => $validated['name'],
+            'terrain_type' => $validated['terrain_type'],
+            'movement_cost' => $validated['movement_cost'],
+            'defense_bonus' => $validated['defense_bonus'],
+            'image_path' => Arr::get($validated, 'image_path'),
+            'edge_profile' => $edgeProfile,
+        ]);
+
+        return redirect()->route('groups.show', $group)->with('success', 'Tile template created.');
+    }
+
+    public function edit(Group $group, TileTemplate $tileTemplate): Response
+    {
+        $this->assertTemplateForGroup($group, $tileTemplate);
+        $this->authorize('update', $tileTemplate);
+
+        return Inertia::render('TileTemplates/Edit', [
+            'group' => [
+                'id' => $group->id,
+                'name' => $group->name,
+            ],
+            'worlds' => $group->worlds()->get(['id', 'name'])->map(fn ($world) => [
+                'id' => $world->id,
+                'name' => $world->name,
+            ]),
+            'template' => [
+                'id' => $tileTemplate->id,
+                'name' => $tileTemplate->name,
+                'key' => $tileTemplate->key,
+                'terrain_type' => $tileTemplate->terrain_type,
+                'movement_cost' => $tileTemplate->movement_cost,
+                'defense_bonus' => $tileTemplate->defense_bonus,
+                'image_path' => $tileTemplate->image_path,
+                'edge_profile' => $tileTemplate->edge_profile,
+                'world_id' => $tileTemplate->world_id,
+            ],
+        ]);
+    }
+
+    public function update(TileTemplateUpdateRequest $request, Group $group, TileTemplate $tileTemplate): RedirectResponse
+    {
+        $this->assertTemplateForGroup($group, $tileTemplate);
+
+        $validated = $request->validated();
+
+        $edgeProfile = $this->decodeJsonField($validated['edge_profile'] ?? null);
+
+        $tileTemplate->update([
+            'world_id' => $validated['world_id'] ?? null,
+            'key' => Arr::get($validated, 'key'),
+            'name' => $validated['name'],
+            'terrain_type' => $validated['terrain_type'],
+            'movement_cost' => $validated['movement_cost'],
+            'defense_bonus' => $validated['defense_bonus'],
+            'image_path' => Arr::get($validated, 'image_path'),
+            'edge_profile' => $edgeProfile,
+        ]);
+
+        return redirect()->route('groups.show', $group)->with('success', 'Tile template updated.');
+    }
+
+    public function destroy(Group $group, TileTemplate $tileTemplate): RedirectResponse
+    {
+        $this->assertTemplateForGroup($group, $tileTemplate);
+        $this->authorize('delete', $tileTemplate);
+
+        abort_if($tileTemplate->mapTiles()->exists(), 422, 'Remove tiles that use this template before deleting it.');
+
+        $tileTemplate->delete();
+
+        return redirect()->route('groups.show', $group)->with('success', 'Tile template removed.');
+    }
+
+    protected function assertTemplateForGroup(Group $group, TileTemplate $template): void
+    {
+        abort_if($template->group_id !== $group->id, 404);
+    }
+
+    protected function decodeJsonField(?string $value): ?array
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+}

--- a/backend/app/Http/Controllers/WorldController.php
+++ b/backend/app/Http/Controllers/WorldController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\WorldStoreRequest;
+use App\Http\Requests\WorldUpdateRequest;
+use App\Models\Group;
+use App\Models\World;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class WorldController extends Controller
+{
+    public function create(Group $group): Response
+    {
+        $this->authorize('create', [World::class, $group]);
+
+        return Inertia::render('Worlds/Create', [
+            'group' => [
+                'id' => $group->id,
+                'name' => $group->name,
+            ],
+            'defaults' => [
+                'default_turn_duration_hours' => 24,
+            ],
+        ]);
+    }
+
+    public function store(WorldStoreRequest $request, Group $group): RedirectResponse
+    {
+        $this->authorize('create', [World::class, $group]);
+
+        $validated = $request->validated();
+
+        $group->worlds()->create([
+            'name' => $validated['name'],
+            'summary' => $validated['summary'] ?? null,
+            'description' => $validated['description'] ?? null,
+            'default_turn_duration_hours' => $validated['default_turn_duration_hours'],
+        ]);
+
+        return redirect()->route('groups.show', $group)->with('success', 'World created.');
+    }
+
+    public function edit(Group $group, World $world): Response
+    {
+        $this->assertWorldForGroup($group, $world);
+        $this->authorize('update', $world);
+
+        return Inertia::render('Worlds/Edit', [
+            'group' => [
+                'id' => $group->id,
+                'name' => $group->name,
+            ],
+            'world' => [
+                'id' => $world->id,
+                'name' => $world->name,
+                'summary' => $world->summary,
+                'description' => $world->description,
+                'default_turn_duration_hours' => $world->default_turn_duration_hours,
+            ],
+        ]);
+    }
+
+    public function update(WorldUpdateRequest $request, Group $group, World $world): RedirectResponse
+    {
+        $this->assertWorldForGroup($group, $world);
+        $this->authorize('update', $world);
+
+        $world->update($request->validated());
+
+        return redirect()->route('groups.show', $group)->with('success', 'World updated.');
+    }
+
+    public function destroy(Group $group, World $world): RedirectResponse
+    {
+        $this->assertWorldForGroup($group, $world);
+        $this->authorize('delete', $world);
+
+        abort_if($world->regions()->exists(), 422, 'Remove or reassign regions before deleting this world.');
+
+        $world->delete();
+
+        return redirect()->route('groups.show', $group)->with('success', 'World removed.');
+    }
+
+    protected function assertWorldForGroup(Group $group, World $world): void
+    {
+        abort_if($world->group_id !== $group->id, 404);
+    }
+}

--- a/backend/app/Http/Requests/GroupJoinRequest.php
+++ b/backend/app/Http/Requests/GroupJoinRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GroupJoinRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'code' => ['required', 'string', 'max:16'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/GroupMembershipStoreRequest.php
+++ b/backend/app/Http/Requests/GroupMembershipStoreRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\GroupMembership;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class GroupMembershipStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'email'],
+            'role' => ['sometimes', 'string', Rule::in(GroupMembership::roles())],
+        ];
+    }
+
+    /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        if (! $this->filled('role')) {
+            $this->merge([
+                'role' => GroupMembership::ROLE_PLAYER,
+            ]);
+        }
+    }
+}

--- a/backend/app/Http/Requests/GroupMembershipUpdateRequest.php
+++ b/backend/app/Http/Requests/GroupMembershipUpdateRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\GroupMembership;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class GroupMembershipUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'role' => ['required', 'string', Rule::in(GroupMembership::roles())],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/MapStoreRequest.php
+++ b/backend/app/Http/Requests/MapStoreRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Group;
+use App\Models\Map;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class MapStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        /** @var Group $group */
+        $group = $this->route('group');
+
+        return $this->user()?->can('create', [Map::class, $group]) ?? false;
+    }
+
+    public function rules(): array
+    {
+        /** @var Group $group */
+        $group = $this->route('group');
+
+        return [
+            'title' => ['required', 'string', 'max:120'],
+            'base_layer' => ['required', Rule::in(['hex', 'square', 'image'])],
+            'orientation' => ['required', Rule::in(['pointy', 'flat'])],
+            'width' => ['nullable', 'integer', 'min:1', 'max:200'],
+            'height' => ['nullable', 'integer', 'min:1', 'max:200'],
+            'gm_only' => ['sometimes', 'boolean'],
+            'fog_data' => ['nullable', 'json'],
+            'region_id' => [
+                'nullable',
+                Rule::exists('regions', 'id')->where(fn ($query) => $query->where('group_id', $group->id)),
+            ],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/MapTileStoreRequest.php
+++ b/backend/app/Http/Requests/MapTileStoreRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Map;
+use App\Models\MapTile;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class MapTileStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        /** @var Map $map */
+        $map = $this->route('map');
+
+        return $this->user()?->can('create', [MapTile::class, $map]) ?? false;
+    }
+
+    public function rules(): array
+    {
+        /** @var Map $map */
+        $map = $this->route('map');
+
+        return [
+            'tile_template_id' => [
+                'required',
+                Rule::exists('tile_templates', 'id')->where(fn ($query) => $query->where('group_id', $map->group_id)),
+            ],
+            'q' => ['required', 'integer', 'between:-200,200'],
+            'r' => ['required', 'integer', 'between:-200,200'],
+            'elevation' => ['nullable', 'integer', 'min:-100', 'max:100'],
+            'variant' => ['nullable', 'json'],
+            'locked' => ['sometimes', 'boolean'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/MapTileUpdateRequest.php
+++ b/backend/app/Http/Requests/MapTileUpdateRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Map;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class MapTileUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $mapParam = $this->route('map');
+
+        $map = $mapParam instanceof Map
+            ? $mapParam
+            : Map::query()->findOrFail($mapParam);
+
+        return [
+            'tile_template_id' => [
+                'nullable',
+                Rule::exists('tile_templates', 'id')->where(fn ($query) => $query->where('group_id', $map->group_id)),
+            ],
+            'q' => ['nullable', 'integer', 'between:-200,200'],
+            'r' => ['nullable', 'integer', 'between:-200,200'],
+            'elevation' => ['nullable', 'integer', 'min:-100', 'max:100'],
+            'variant' => ['nullable', 'json'],
+            'locked' => ['sometimes', 'boolean'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/MapUpdateRequest.php
+++ b/backend/app/Http/Requests/MapUpdateRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Group;
+use App\Models\Map;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class MapUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        /** @var Map $map */
+        $map = $this->route('map');
+
+        return $this->user()?->can('update', $map) ?? false;
+    }
+
+    public function rules(): array
+    {
+        /** @var Map $map */
+        $map = $this->route('map');
+        /** @var Group $group */
+        $group = $this->route('group');
+
+        return [
+            'title' => ['required', 'string', 'max:120'],
+            'base_layer' => ['required', Rule::in(['hex', 'square', 'image'])],
+            'orientation' => ['required', Rule::in(['pointy', 'flat'])],
+            'width' => ['nullable', 'integer', 'min:1', 'max:200'],
+            'height' => ['nullable', 'integer', 'min:1', 'max:200'],
+            'gm_only' => ['sometimes', 'boolean'],
+            'fog_data' => ['nullable', 'json'],
+            'region_id' => [
+                'nullable',
+                Rule::exists('regions', 'id')->where(fn ($query) => $query->where('group_id', $group->id)),
+            ],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/RegionStoreRequest.php
+++ b/backend/app/Http/Requests/RegionStoreRequest.php
@@ -20,8 +20,9 @@ class RegionStoreRequest extends FormRequest
             'name' => ['required', 'string', 'max:255'],
             'summary' => ['nullable', 'string', 'max:512'],
             'description' => ['nullable', 'string'],
+            'world_id' => ['required', 'integer', 'exists:worlds,id'],
             'dungeon_master_id' => ['nullable', 'integer', 'exists:users,id'],
-            'turn_duration_hours' => ['required', 'integer', 'in:6,24'],
+            'turn_duration_hours' => ['required', 'integer', 'between:1,168'],
             'next_turn_at' => ['nullable', 'date'],
         ];
     }

--- a/backend/app/Http/Requests/RegionUpdateRequest.php
+++ b/backend/app/Http/Requests/RegionUpdateRequest.php
@@ -20,8 +20,9 @@ class RegionUpdateRequest extends FormRequest
             'name' => ['required', 'string', 'max:255'],
             'summary' => ['nullable', 'string', 'max:512'],
             'description' => ['nullable', 'string'],
+            'world_id' => ['required', 'integer', 'exists:worlds,id'],
             'dungeon_master_id' => ['nullable', 'integer', 'exists:users,id'],
-            'turn_duration_hours' => ['required', 'integer', 'in:6,24'],
+            'turn_duration_hours' => ['required', 'integer', 'between:1,168'],
             'next_turn_at' => ['nullable', 'date'],
         ];
     }

--- a/backend/app/Http/Requests/TileTemplateStoreRequest.php
+++ b/backend/app/Http/Requests/TileTemplateStoreRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Group;
+use App\Models\TileTemplate;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class TileTemplateStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        /** @var Group $group */
+        $group = $this->route('group');
+
+        return $this->user()?->can('create', [TileTemplate::class, $group]) ?? false;
+    }
+
+    public function rules(): array
+    {
+        /** @var Group $group */
+        $group = $this->route('group');
+
+        return [
+            'name' => ['required', 'string', 'max:120'],
+            'key' => [
+                'nullable',
+                'string',
+                'max:64',
+                Rule::unique('tile_templates', 'key')->where(fn ($query) => $query->where('group_id', $group->id)),
+            ],
+            'terrain_type' => ['required', 'string', 'max:64'],
+            'movement_cost' => ['required', 'integer', 'min:0', 'max:20'],
+            'defense_bonus' => ['required', 'integer', 'min:0', 'max:20'],
+            'image_path' => ['nullable', 'string', 'max:255'],
+            'edge_profile' => ['nullable', 'json'],
+            'world_id' => [
+                'nullable',
+                Rule::exists('worlds', 'id')->where(fn ($query) => $query->where('group_id', $group->id)),
+            ],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/TileTemplateUpdateRequest.php
+++ b/backend/app/Http/Requests/TileTemplateUpdateRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Group;
+use App\Models\TileTemplate;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class TileTemplateUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        /** @var TileTemplate $template */
+        $template = $this->route('tile_template');
+
+        return $this->user()?->can('update', $template) ?? false;
+    }
+
+    public function rules(): array
+    {
+        /** @var TileTemplate $template */
+        $template = $this->route('tile_template');
+        /** @var Group $group */
+        $group = $this->route('group');
+
+        return [
+            'name' => ['required', 'string', 'max:120'],
+            'key' => [
+                'nullable',
+                'string',
+                'max:64',
+                Rule::unique('tile_templates', 'key')
+                    ->where(fn ($query) => $query->where('group_id', $group->id))
+                    ->ignore($template->id),
+            ],
+            'terrain_type' => ['required', 'string', 'max:64'],
+            'movement_cost' => ['required', 'integer', 'min:0', 'max:20'],
+            'defense_bonus' => ['required', 'integer', 'min:0', 'max:20'],
+            'image_path' => ['nullable', 'string', 'max:255'],
+            'edge_profile' => ['nullable', 'json'],
+            'world_id' => [
+                'nullable',
+                Rule::exists('worlds', 'id')->where(fn ($query) => $query->where('group_id', $group->id)),
+            ],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/WorldStoreRequest.php
+++ b/backend/app/Http/Requests/WorldStoreRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class WorldStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'summary' => ['nullable', 'string', 'max:512'],
+            'description' => ['nullable', 'string'],
+            'default_turn_duration_hours' => ['required', 'integer', 'between:1,168'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/WorldUpdateRequest.php
+++ b/backend/app/Http/Requests/WorldUpdateRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class WorldUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'summary' => ['nullable', 'string', 'max:512'],
+            'description' => ['nullable', 'string'],
+            'default_turn_duration_hours' => ['required', 'integer', 'between:1,168'],
+        ];
+    }
+}

--- a/backend/app/Models/Group.php
+++ b/backend/app/Models/Group.php
@@ -18,6 +18,7 @@ class Group extends Model
     protected $fillable = [
         'name',
         'slug',
+        'join_code',
         'description',
         'created_by',
     ];
@@ -49,6 +50,14 @@ class Group extends Model
     }
 
     /**
+     * Worlds curated by the group.
+     */
+    public function worlds(): HasMany
+    {
+        return $this->hasMany(World::class);
+    }
+
+    /**
      * Regions owned by the group.
      */
     public function regions(): HasMany
@@ -62,5 +71,21 @@ class Group extends Model
     public function campaigns(): HasMany
     {
         return $this->hasMany(Campaign::class);
+    }
+
+    /**
+     * Tile templates curated by the group.
+     */
+    public function tileTemplates(): HasMany
+    {
+        return $this->hasMany(TileTemplate::class);
+    }
+
+    /**
+     * Maps owned by the group.
+     */
+    public function maps(): HasMany
+    {
+        return $this->hasMany(Map::class);
     }
 }

--- a/backend/app/Models/Map.php
+++ b/backend/app/Models/Map.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Map extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'group_id',
+        'region_id',
+        'title',
+        'base_layer',
+        'orientation',
+        'width',
+        'height',
+        'gm_only',
+        'fog_data',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'gm_only' => 'boolean',
+        'fog_data' => 'array',
+    ];
+
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(Group::class);
+    }
+
+    public function region(): BelongsTo
+    {
+        return $this->belongsTo(Region::class);
+    }
+
+    public function tiles(): HasMany
+    {
+        return $this->hasMany(MapTile::class);
+    }
+}

--- a/backend/app/Models/MapTile.php
+++ b/backend/app/Models/MapTile.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class MapTile extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'map_id',
+        'tile_template_id',
+        'q',
+        'r',
+        'orientation',
+        'elevation',
+        'variant',
+        'locked',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'variant' => 'array',
+        'locked' => 'boolean',
+    ];
+
+    public function map(): BelongsTo
+    {
+        return $this->belongsTo(Map::class);
+    }
+
+    public function tileTemplate(): BelongsTo
+    {
+        return $this->belongsTo(TileTemplate::class);
+    }
+}

--- a/backend/app/Models/Region.php
+++ b/backend/app/Models/Region.php
@@ -17,11 +17,20 @@ class Region extends Model
      */
     protected $fillable = [
         'group_id',
+        'world_id',
         'dungeon_master_id',
         'name',
         'summary',
         'description',
     ];
+
+    /**
+     * Parent world for this region.
+     */
+    public function world(): BelongsTo
+    {
+        return $this->belongsTo(World::class);
+    }
 
     /**
      * Owning group.
@@ -50,5 +59,10 @@ class Region extends Model
     public function turns(): HasMany
     {
         return $this->hasMany(Turn::class);
+    }
+
+    public function maps(): HasMany
+    {
+        return $this->hasMany(Map::class);
     }
 }

--- a/backend/app/Models/TileTemplate.php
+++ b/backend/app/Models/TileTemplate.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class TileTemplate extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'group_id',
+        'world_id',
+        'created_by',
+        'key',
+        'name',
+        'terrain_type',
+        'movement_cost',
+        'defense_bonus',
+        'image_path',
+        'edge_profile',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'edge_profile' => 'array',
+    ];
+
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(Group::class);
+    }
+
+    public function world(): BelongsTo
+    {
+        return $this->belongsTo(World::class);
+    }
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function mapTiles(): HasMany
+    {
+        return $this->hasMany(MapTile::class);
+    }
+}

--- a/backend/app/Models/World.php
+++ b/backend/app/Models/World.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class World extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'group_id',
+        'name',
+        'summary',
+        'description',
+        'default_turn_duration_hours',
+    ];
+
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(Group::class);
+    }
+
+    /**
+     * Regions that belong to this world.
+     */
+    public function regions(): HasMany
+    {
+        return $this->hasMany(Region::class);
+    }
+
+    public function tileTemplates(): HasMany
+    {
+        return $this->hasMany(TileTemplate::class);
+    }
+}

--- a/backend/app/Policies/GroupMembershipPolicy.php
+++ b/backend/app/Policies/GroupMembershipPolicy.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Group;
+use App\Models\GroupMembership;
+use App\Models\User;
+
+class GroupMembershipPolicy
+{
+    public function create(User $user, Group $group): bool
+    {
+        $membership = $this->membershipFor($user, $group);
+
+        if ($membership === null) {
+            return false;
+        }
+
+        return in_array($membership->role, [
+            GroupMembership::ROLE_OWNER,
+            GroupMembership::ROLE_DUNGEON_MASTER,
+        ], true);
+    }
+
+    public function update(User $user, GroupMembership $membership): bool
+    {
+        $actorMembership = $this->membershipFor($user, $membership->group);
+
+        if ($actorMembership === null) {
+            return false;
+        }
+
+        return in_array($actorMembership->role, [
+            GroupMembership::ROLE_OWNER,
+            GroupMembership::ROLE_DUNGEON_MASTER,
+        ], true);
+    }
+
+    public function delete(User $user, GroupMembership $membership): bool
+    {
+        if ($membership->user_id === $user->getAuthIdentifier()) {
+            return true;
+        }
+
+        $actorMembership = $this->membershipFor($user, $membership->group);
+
+        if ($actorMembership === null) {
+            return false;
+        }
+
+        return in_array($actorMembership->role, [
+            GroupMembership::ROLE_OWNER,
+            GroupMembership::ROLE_DUNGEON_MASTER,
+        ], true);
+    }
+
+    protected function membershipFor(User $user, Group $group): ?GroupMembership
+    {
+        return $group->memberships()
+            ->where('user_id', $user->getKey())
+            ->first();
+    }
+}

--- a/backend/app/Policies/MapPolicy.php
+++ b/backend/app/Policies/MapPolicy.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Group;
+use App\Models\GroupMembership;
+use App\Models\Map;
+use App\Models\User;
+
+class MapPolicy
+{
+    public function view(User $user, Map $map): bool
+    {
+        return $this->hasBuilderRole($user, $map->group);
+    }
+
+    public function create(User $user, Group $group): bool
+    {
+        return $this->hasBuilderRole($user, $group);
+    }
+
+    public function update(User $user, Map $map): bool
+    {
+        return $this->hasBuilderRole($user, $map->group);
+    }
+
+    public function delete(User $user, Map $map): bool
+    {
+        return $this->hasGroupRole($user, $map->group, [GroupMembership::ROLE_OWNER]);
+    }
+
+    protected function hasBuilderRole(User $user, Group $group): bool
+    {
+        return $this->hasGroupRole($user, $group);
+    }
+
+    /**
+     * @param  array<int, string>|null  $roles
+     */
+    protected function hasGroupRole(User $user, Group $group, ?array $roles = null): bool
+    {
+        $query = $group->memberships()->where('user_id', $user->getAuthIdentifier());
+
+        if ($roles !== null) {
+            $query->whereIn('role', $roles);
+        } else {
+            $query->whereIn('role', [
+                GroupMembership::ROLE_OWNER,
+                GroupMembership::ROLE_DUNGEON_MASTER,
+            ]);
+        }
+
+        return $query->exists();
+    }
+}

--- a/backend/app/Policies/MapTilePolicy.php
+++ b/backend/app/Policies/MapTilePolicy.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Group;
+use App\Models\GroupMembership;
+use App\Models\Map;
+use App\Models\MapTile;
+use App\Models\User;
+
+class MapTilePolicy
+{
+    public function create(User $user, Map $map): bool
+    {
+        return $this->hasBuilderRole($user, $map->group);
+    }
+
+    public function update(User $user, MapTile $tile): bool
+    {
+        if ($tile->locked) {
+            return $this->hasGroupRole($user, $tile->map->group, [GroupMembership::ROLE_OWNER]);
+        }
+
+        return $this->hasBuilderRole($user, $tile->map->group);
+    }
+
+    public function delete(User $user, MapTile $tile): bool
+    {
+        if ($tile->locked) {
+            return $this->hasGroupRole($user, $tile->map->group, [GroupMembership::ROLE_OWNER]);
+        }
+
+        return $this->hasBuilderRole($user, $tile->map->group);
+    }
+
+    protected function hasBuilderRole(User $user, Group $group): bool
+    {
+        return $this->hasGroupRole($user, $group);
+    }
+
+    /**
+     * @param  array<int, string>|null  $roles
+     */
+    protected function hasGroupRole(User $user, Group $group, ?array $roles = null): bool
+    {
+        $query = $group->memberships()->where('user_id', $user->getAuthIdentifier());
+
+        if ($roles !== null) {
+            $query->whereIn('role', $roles);
+        } else {
+            $query->whereIn('role', [
+                GroupMembership::ROLE_OWNER,
+                GroupMembership::ROLE_DUNGEON_MASTER,
+            ]);
+        }
+
+        return $query->exists();
+    }
+}

--- a/backend/app/Policies/TileTemplatePolicy.php
+++ b/backend/app/Policies/TileTemplatePolicy.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Group;
+use App\Models\GroupMembership;
+use App\Models\TileTemplate;
+use App\Models\User;
+
+class TileTemplatePolicy
+{
+    public function view(User $user, TileTemplate $template): bool
+    {
+        return $this->hasBuilderRole($user, $template->group);
+    }
+
+    public function create(User $user, Group $group): bool
+    {
+        return $this->hasBuilderRole($user, $group);
+    }
+
+    public function update(User $user, TileTemplate $template): bool
+    {
+        return $this->hasBuilderRole($user, $template->group);
+    }
+
+    public function delete(User $user, TileTemplate $template): bool
+    {
+        return $this->hasGroupRole($user, $template->group, [GroupMembership::ROLE_OWNER]);
+    }
+
+    protected function hasBuilderRole(User $user, Group $group): bool
+    {
+        return $this->hasGroupRole($user, $group);
+    }
+
+    /**
+     * @param  array<int, string>|null  $roles
+     */
+    protected function hasGroupRole(User $user, Group $group, ?array $roles = null): bool
+    {
+        $query = $group->memberships()->where('user_id', $user->getAuthIdentifier());
+
+        if ($roles !== null) {
+            $query->whereIn('role', $roles);
+        } else {
+            $query->whereIn('role', [
+                GroupMembership::ROLE_OWNER,
+                GroupMembership::ROLE_DUNGEON_MASTER,
+            ]);
+        }
+
+        return $query->exists();
+    }
+}

--- a/backend/app/Policies/WorldPolicy.php
+++ b/backend/app/Policies/WorldPolicy.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Group;
+use App\Models\GroupMembership;
+use App\Models\User;
+use App\Models\World;
+
+class WorldPolicy
+{
+    public function view(User $user, World $world): bool
+    {
+        return $this->hasGroupRole($user, $world->group);
+    }
+
+    public function create(User $user, Group $group): bool
+    {
+        return $this->hasGroupRole($user, $group);
+    }
+
+    public function update(User $user, World $world): bool
+    {
+        return $this->hasGroupRole($user, $world->group);
+    }
+
+    public function delete(User $user, World $world): bool
+    {
+        return $this->hasGroupRole($user, $world->group, [GroupMembership::ROLE_OWNER]);
+    }
+
+    /**
+     * Determine whether the user has the required group role.
+     *
+     * @param  array<int, string>|null  $roles
+     */
+    protected function hasGroupRole(User $user, Group $group, ?array $roles = null): bool
+    {
+        $query = $group->memberships()->where('user_id', $user->getKey());
+
+        if ($roles === null) {
+            $query->whereIn('role', [
+                GroupMembership::ROLE_OWNER,
+                GroupMembership::ROLE_DUNGEON_MASTER,
+            ]);
+        } else {
+            $query->whereIn('role', $roles);
+        }
+
+        return $query->exists();
+    }
+}

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -4,20 +4,30 @@ namespace App\Providers;
 
 use App\Models\Campaign;
 use App\Models\Group;
+use App\Models\GroupMembership;
 use App\Models\Region;
 use App\Models\DiceRoll;
 use App\Models\InitiativeEntry;
 use App\Models\CampaignSession;
 use App\Models\SessionNote;
 use App\Models\TurnConfiguration;
+use App\Models\World;
+use App\Models\Map;
+use App\Models\MapTile;
+use App\Models\TileTemplate;
 use App\Policies\CampaignPolicy;
 use App\Policies\DiceRollPolicy;
 use App\Policies\GroupPolicy;
+use App\Policies\GroupMembershipPolicy;
 use App\Policies\InitiativeEntryPolicy;
 use App\Policies\RegionPolicy;
 use App\Policies\SessionNotePolicy;
 use App\Policies\SessionPolicy;
 use App\Policies\TurnConfigurationPolicy;
+use App\Policies\WorldPolicy;
+use App\Policies\MapPolicy;
+use App\Policies\MapTilePolicy;
+use App\Policies\TileTemplatePolicy;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 
@@ -37,12 +47,17 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Gate::policy(Group::class, GroupPolicy::class);
+        Gate::policy(GroupMembership::class, GroupMembershipPolicy::class);
         Gate::policy(Campaign::class, CampaignPolicy::class);
         Gate::policy(Region::class, RegionPolicy::class);
         Gate::policy(TurnConfiguration::class, TurnConfigurationPolicy::class);
+        Gate::policy(World::class, WorldPolicy::class);
         Gate::policy(CampaignSession::class, SessionPolicy::class);
         Gate::policy(SessionNote::class, SessionNotePolicy::class);
         Gate::policy(DiceRoll::class, DiceRollPolicy::class);
         Gate::policy(InitiativeEntry::class, InitiativeEntryPolicy::class);
+        Gate::policy(Map::class, MapPolicy::class);
+        Gate::policy(MapTile::class, MapTilePolicy::class);
+        Gate::policy(TileTemplate::class, TileTemplatePolicy::class);
     }
 }

--- a/backend/database/factories/GroupFactory.php
+++ b/backend/database/factories/GroupFactory.php
@@ -22,6 +22,7 @@ class GroupFactory extends Factory
         return [
             'name' => Str::title($name),
             'slug' => $slugBase.'-'.$this->faker->unique()->lexify('???'),
+            'join_code' => Str::upper($this->faker->unique()->lexify('??????')),
             'description' => $this->faker->optional()->sentence(),
             'created_by' => User::factory(),
         ];

--- a/backend/database/factories/MapFactory.php
+++ b/backend/database/factories/MapFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Group;
+use App\Models\Map;
+use App\Models\Region;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Map>
+ */
+class MapFactory extends Factory
+{
+    protected $model = Map::class;
+
+    public function definition(): array
+    {
+        return [
+            'group_id' => Group::factory(),
+            'region_id' => Region::factory(),
+            'title' => $this->faker->words(3, true),
+            'base_layer' => 'hex',
+            'orientation' => 'pointy',
+            'width' => 20,
+            'height' => 20,
+            'gm_only' => false,
+            'fog_data' => null,
+        ];
+    }
+}

--- a/backend/database/factories/MapTileFactory.php
+++ b/backend/database/factories/MapTileFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Map;
+use App\Models\MapTile;
+use App\Models\TileTemplate;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<MapTile>
+ */
+class MapTileFactory extends Factory
+{
+    protected $model = MapTile::class;
+
+    public function definition(): array
+    {
+        return [
+            'map_id' => Map::factory(),
+            'tile_template_id' => TileTemplate::factory(),
+            'q' => $this->faker->numberBetween(-5, 5),
+            'r' => $this->faker->numberBetween(-5, 5),
+            'orientation' => 'pointy',
+            'elevation' => $this->faker->numberBetween(-2, 4),
+            'variant' => null,
+            'locked' => false,
+        ];
+    }
+}

--- a/backend/database/factories/RegionFactory.php
+++ b/backend/database/factories/RegionFactory.php
@@ -2,8 +2,8 @@
 
 namespace Database\Factories;
 
-use App\Models\Group;
 use App\Models\Region;
+use App\Models\World;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -16,10 +16,41 @@ class RegionFactory extends Factory
     public function definition(): array
     {
         return [
-            'group_id' => Group::factory(),
+            'world_id' => World::factory(),
             'name' => $this->faker->unique()->words(2, true),
             'summary' => $this->faker->sentence(),
             'description' => $this->faker->paragraph(),
         ];
+    }
+
+    public function configure(): static
+    {
+        return $this
+            ->afterMaking(function (Region $region): void {
+                if ($region->group_id === null) {
+                    $this->syncGroupFromWorld($region);
+                }
+            })
+            ->afterCreating(function (Region $region): void {
+                if ($region->group_id === null) {
+                    $this->syncGroupFromWorld($region, persist: true);
+                }
+            });
+    }
+
+    protected function syncGroupFromWorld(Region $region, bool $persist = false): void
+    {
+        if ($region->relationLoaded('world') && $region->world !== null) {
+            $region->group()->associate($region->world->group);
+        } elseif ($region->world_id !== null) {
+            $world = World::query()->find($region->world_id);
+            if ($world !== null) {
+                $region->group()->associate($world->group);
+            }
+        }
+
+        if ($persist && $region->isDirty('group_id')) {
+            $region->save();
+        }
     }
 }

--- a/backend/database/factories/TileTemplateFactory.php
+++ b/backend/database/factories/TileTemplateFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Group;
+use App\Models\TileTemplate;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<TileTemplate>
+ */
+class TileTemplateFactory extends Factory
+{
+    protected $model = TileTemplate::class;
+
+    public function definition(): array
+    {
+        return [
+            'group_id' => Group::factory(),
+            'world_id' => null,
+            'created_by' => User::factory(),
+            'key' => $this->faker->unique()->lexify('tile-????'),
+            'name' => $this->faker->words(2, true),
+            'terrain_type' => $this->faker->randomElement(['grassland', 'forest', 'mountain', 'water']),
+            'movement_cost' => $this->faker->numberBetween(1, 6),
+            'defense_bonus' => $this->faker->numberBetween(0, 4),
+            'image_path' => null,
+            'edge_profile' => ['north' => 'open', 'south' => 'open'],
+        ];
+    }
+}

--- a/backend/database/factories/WorldFactory.php
+++ b/backend/database/factories/WorldFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Group;
+use App\Models\World;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<World>
+ */
+class WorldFactory extends Factory
+{
+    protected $model = World::class;
+
+    public function definition(): array
+    {
+        return [
+            'group_id' => Group::factory(),
+            'name' => $this->faker->unique()->words(3, true),
+            'summary' => $this->faker->sentence(),
+            'description' => $this->faker->paragraph(),
+            'default_turn_duration_hours' => $this->faker->numberBetween(6, 72),
+        ];
+    }
+}

--- a/backend/database/migrations/2025_10_15_170000_add_join_code_to_groups_table.php
+++ b/backend/database/migrations/2025_10_15_170000_add_join_code_to_groups_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('groups', function (Blueprint $table): void {
+            $table->string('join_code', 16)->after('slug')->unique();
+        });
+
+        DB::table('groups')->select('id')->orderBy('id')->chunkById(100, function ($groups): void {
+            foreach ($groups as $group) {
+                DB::table('groups')
+                    ->where('id', $group->id)
+                    ->update(['join_code' => Str::upper(Str::random(10))]);
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('groups', function (Blueprint $table): void {
+            $table->dropColumn('join_code');
+        });
+    }
+};

--- a/backend/database/migrations/2025_10_15_180000_create_worlds_table.php
+++ b/backend/database/migrations/2025_10_15_180000_create_worlds_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\Group;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('worlds', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignIdFor(Group::class)->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('summary', 512)->nullable();
+            $table->text('description')->nullable();
+            $table->unsignedSmallInteger('default_turn_duration_hours')->default(24);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('worlds');
+    }
+};

--- a/backend/database/migrations/2025_10_15_181000_add_world_id_to_regions_table.php
+++ b/backend/database/migrations/2025_10_15_181000_add_world_id_to_regions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\World;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('regions', function (Blueprint $table): void {
+            $table->foreignIdFor(World::class)
+                ->after('group_id')
+                ->constrained()
+                ->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('regions', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('world_id');
+        });
+    }
+};

--- a/backend/database/migrations/2025_10_16_090000_create_tile_templates_table.php
+++ b/backend/database/migrations/2025_10_16_090000_create_tile_templates_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Models\Group;
+use App\Models\User;
+use App\Models\World;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tile_templates', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignIdFor(Group::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(World::class)->nullable()->constrained()->nullOnDelete();
+            $table->foreignIdFor(User::class, 'created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('key', 64)->nullable();
+            $table->string('name', 120);
+            $table->string('terrain_type', 64);
+            $table->unsignedTinyInteger('movement_cost')->default(1);
+            $table->unsignedTinyInteger('defense_bonus')->default(0);
+            $table->string('image_path')->nullable();
+            $table->json('edge_profile')->nullable();
+            $table->timestamps();
+
+            $table->unique(['group_id', 'key']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tile_templates');
+    }
+};

--- a/backend/database/migrations/2025_10_16_090100_create_maps_table.php
+++ b/backend/database/migrations/2025_10_16_090100_create_maps_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\Group;
+use App\Models\Region;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('maps', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignIdFor(Group::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(Region::class)->nullable()->constrained()->nullOnDelete();
+            $table->string('title');
+            $table->enum('base_layer', ['hex', 'square', 'image'])->default('hex');
+            $table->enum('orientation', ['pointy', 'flat'])->default('pointy');
+            $table->unsignedInteger('width')->nullable();
+            $table->unsignedInteger('height')->nullable();
+            $table->boolean('gm_only')->default(false);
+            $table->json('fog_data')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('maps');
+    }
+};

--- a/backend/database/migrations/2025_10_16_090200_create_map_tiles_table.php
+++ b/backend/database/migrations/2025_10_16_090200_create_map_tiles_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Models\Map;
+use App\Models\TileTemplate;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('map_tiles', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignIdFor(Map::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(TileTemplate::class)->constrained()->cascadeOnDelete();
+            $table->integer('q');
+            $table->integer('r');
+            $table->enum('orientation', ['pointy', 'flat']);
+            $table->smallInteger('elevation')->default(0);
+            $table->json('variant')->nullable();
+            $table->boolean('locked')->default(false);
+            $table->timestamps();
+
+            $table->unique(['map_id', 'q', 'r']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('map_tiles');
+    }
+};

--- a/backend/resources/js/Pages/Groups/Index.tsx
+++ b/backend/resources/js/Pages/Groups/Index.tsx
@@ -27,9 +27,14 @@ export default function GroupsIndex({ groups }: GroupsIndexProps) {
                     </p>
                 </div>
 
-                <Button asChild>
-                    <Link href={route('groups.create')}>Create group</Link>
-                </Button>
+                <div className="flex items-center gap-3">
+                    <Button asChild variant="outline" className="border-zinc-700">
+                        <Link href={route('groups.join')}>Join group</Link>
+                    </Button>
+                    <Button asChild>
+                        <Link href={route('groups.create')}>Create group</Link>
+                    </Button>
+                </div>
             </div>
 
             <div className="mt-8 grid gap-4 sm:grid-cols-2">

--- a/backend/resources/js/Pages/Groups/Join.tsx
+++ b/backend/resources/js/Pages/Groups/Join.tsx
@@ -1,0 +1,61 @@
+import { FormEvent } from 'react';
+import { Head, Link, useForm } from '@inertiajs/react';
+
+import AppLayout from '@/Layouts/AppLayout';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export default function GroupsJoin() {
+    const form = useForm({
+        code: '',
+    });
+
+    function submit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        form.post(route('groups.join.store'), {
+            preserveScroll: true,
+        });
+    }
+
+    return (
+        <AppLayout>
+            <Head title="Join a party" />
+
+            <div className="mx-auto max-w-xl rounded-xl border border-zinc-800 bg-zinc-950/70 p-8 shadow-lg shadow-black/40">
+                <h1 className="text-3xl font-semibold text-zinc-100">Join an adventuring party</h1>
+                <p className="mt-2 text-sm text-zinc-400">
+                    Enter the join code shared by a Game Master or dungeon master to step into their realm. You will be added as an
+                    adventurer, and they can promote you once you have proven your worth.
+                </p>
+
+                <form onSubmit={submit} className="mt-6 space-y-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="code" className="text-zinc-300">
+                            Join code
+                        </Label>
+                        <Input
+                            id="code"
+                            name="code"
+                            value={form.data.code}
+                            onChange={(event) => form.setData('code', event.target.value.toUpperCase())}
+                            placeholder="DRAGON12"
+                            className="uppercase tracking-[0.3em]"
+                            autoFocus
+                        />
+                        {form.errors.code && <p className="text-sm text-rose-400">{form.errors.code}</p>}
+                    </div>
+
+                    <div className="flex items-center gap-3">
+                        <Button type="submit" disabled={form.processing}>
+                            Join party
+                        </Button>
+                        <Button asChild variant="outline" className="border-zinc-700" disabled={form.processing}>
+                            <Link href={route('groups.index')}>Back to parties</Link>
+                        </Button>
+                    </div>
+                </form>
+            </div>
+        </AppLayout>
+    );
+}

--- a/backend/resources/js/Pages/Groups/Show.tsx
+++ b/backend/resources/js/Pages/Groups/Show.tsx
@@ -1,17 +1,23 @@
-import { Head, Link } from '@inertiajs/react';
+import { FormEvent, useCallback, useState } from 'react';
+import { Head, Link, router, useForm } from '@inertiajs/react';
 
 import AppLayout from '@/Layouts/AppLayout';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 
 type GroupMember = {
     id: number;
+    user_id: number;
     name: string;
     email: string;
     role: string;
+    is_viewer: boolean;
 };
 
 type RegionSummary = {
     id: number;
+    world_id: number | null;
     name: string;
     summary: string | null;
     dungeon_master: { id: number; name: string } | null;
@@ -32,17 +38,63 @@ type RegionSummary = {
     can_process_turn: boolean;
 };
 
+type WorldSummary = {
+    id: number;
+    name: string;
+    summary: string | null;
+    description: string | null;
+    default_turn_duration_hours: number;
+    regions: RegionSummary[];
+};
+
+type TileTemplateSummary = {
+    id: number;
+    name: string;
+    key: string | null;
+    terrain_type: string;
+    movement_cost: number;
+    defense_bonus: number;
+    world: { id: number; name: string } | null;
+    creator: { id: number; name: string } | null;
+};
+
+type MapSummary = {
+    id: number;
+    title: string;
+    base_layer: string;
+    orientation: string;
+    tile_count: number;
+    region: { id: number; name: string } | null;
+};
+
 type GroupPayload = {
     id: number;
     name: string;
     description: string | null;
     members: GroupMember[];
+    worlds: WorldSummary[];
     regions: RegionSummary[];
     campaigns: { id: number; title: string; status: string }[];
+    tile_templates: TileTemplateSummary[];
+    maps: MapSummary[];
+};
+
+type ViewerMembership = {
+    id: number;
+    role: string;
+} | null;
+
+type GroupPermissions = {
+    manage_members: boolean;
+    promote_to_owner: boolean;
 };
 
 type GroupShowProps = {
     group: GroupPayload;
+    viewer_membership: ViewerMembership;
+    permissions: GroupPermissions;
+    join_code: string | null;
+    role_options: string[];
 };
 
 const roleLabels: Record<string, string> = {
@@ -51,7 +103,85 @@ const roleLabels: Record<string, string> = {
     player: 'Adventurer',
 };
 
-export default function GroupShow({ group }: GroupShowProps) {
+export default function GroupShow({ group, viewer_membership, permissions, join_code, role_options }: GroupShowProps) {
+    const defaultRole = role_options.includes('player') ? 'player' : role_options[0] ?? 'player';
+    const inviteForm = useForm({
+        email: '',
+        role: defaultRole,
+    });
+    const [copied, setCopied] = useState(false);
+    const [roleUpdating, setRoleUpdating] = useState<number | null>(null);
+    const [removing, setRemoving] = useState<number | null>(null);
+    const [removingTemplate, setRemovingTemplate] = useState<number | null>(null);
+    const [removingMap, setRemovingMap] = useState<number | null>(null);
+
+    const manageMembers = permissions.manage_members;
+    const promoteToOwner = permissions.promote_to_owner;
+    const totalRegions = group.regions.length;
+
+    const handleInvite = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        inviteForm.post(route('groups.memberships.store', group.id), {
+            preserveScroll: true,
+            onSuccess: () => {
+                inviteForm.reset();
+                setTimeout(() => inviteForm.clearErrors(), 0);
+            },
+        });
+    };
+
+    const handleRoleChange = (member: GroupMember, role: string) => {
+        if (role === member.role) {
+            return;
+        }
+
+        setRoleUpdating(member.id);
+        router.patch(route('groups.memberships.update', [group.id, member.id]), { role }, {
+            preserveScroll: true,
+            onFinish: () => setRoleUpdating(null),
+        });
+    };
+
+    const handleRemove = (member: GroupMember) => {
+        setRemoving(member.id);
+        router.delete(route('groups.memberships.destroy', [group.id, member.id]), {
+            preserveScroll: true,
+            onFinish: () => setRemoving(null),
+        });
+    };
+
+    const handleTemplateRemove = (template: TileTemplateSummary) => {
+        setRemovingTemplate(template.id);
+        router.delete(route('groups.tile-templates.destroy', [group.id, template.id]), {
+            preserveScroll: true,
+            onFinish: () => setRemovingTemplate(null),
+        });
+    };
+
+    const handleMapRemove = (map: MapSummary) => {
+        setRemovingMap(map.id);
+        router.delete(route('groups.maps.destroy', [group.id, map.id]), {
+            preserveScroll: true,
+            onFinish: () => setRemovingMap(null),
+        });
+    };
+
+    const copyJoinCode = useCallback(async () => {
+        if (!join_code) {
+            return;
+        }
+
+        try {
+            if (typeof navigator !== 'undefined' && navigator.clipboard) {
+                await navigator.clipboard.writeText(join_code);
+                setCopied(true);
+                setTimeout(() => setCopied(false), 2000);
+            }
+        } catch (error) {
+            setCopied(false);
+        }
+    }, [join_code]);
+
     return (
         <AppLayout>
             <Head title={group.name} />
@@ -64,14 +194,19 @@ export default function GroupShow({ group }: GroupShowProps) {
                     ) : (
                         <p className="mt-2 text-sm text-zinc-500">No primer yet. Share the party&apos;s legend soon.</p>
                     )}
+                    {viewer_membership && (
+                        <p className="mt-3 text-xs uppercase tracking-wide text-indigo-300">
+                            Your role: {roleLabels[viewer_membership.role] ?? viewer_membership.role}
+                        </p>
+                    )}
                 </div>
 
                 <div className="flex items-center gap-3">
+                    <Button asChild>
+                        <Link href={route('groups.worlds.create', group.id)}>Create world</Link>
+                    </Button>
                     <Button asChild variant="outline" className="border-zinc-700 text-sm">
                         <Link href={route('groups.edit', group.id)}>Edit group</Link>
-                    </Button>
-                    <Button asChild>
-                        <Link href={route('groups.regions.create', group.id)}>Assign region</Link>
                     </Button>
                 </div>
             </div>
@@ -83,146 +218,307 @@ export default function GroupShow({ group }: GroupShowProps) {
                         <span className="text-xs uppercase tracking-wide text-zinc-500">{group.members.length} members</span>
                     </header>
 
-                    <ul className="mt-4 space-y-3">
-                        {group.members.map((member) => (
-                            <li
-                                key={member.id}
-                                className="flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-900/60 px-4 py-3"
-                            >
+                    <div className="mt-4 space-y-4">
+                        {manageMembers && join_code && (
+                            <div className="flex flex-col gap-3 rounded-lg border border-indigo-500/40 bg-indigo-500/10 p-4 sm:flex-row sm:items-center sm:justify-between">
                                 <div>
-                                    <p className="font-medium text-zinc-100">{member.name}</p>
-                                    <p className="text-xs text-zinc-500">{member.email}</p>
+                                    <p className="text-xs uppercase tracking-wide text-indigo-200/80">Join code</p>
+                                    <p className="font-mono text-lg tracking-[0.4em] text-indigo-100">{join_code}</p>
                                 </div>
-                                <span className="text-xs font-semibold uppercase tracking-wide text-indigo-300">
-                                    {roleLabels[member.role] ?? member.role}
-                                </span>
-                            </li>
-                        ))}
-                    </ul>
+                                <div className="flex items-center gap-3">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        className="border-indigo-400/60 text-indigo-100"
+                                        onClick={copyJoinCode}
+                                    >
+                                        Copy
+                                    </Button>
+                                    {copied && <span className="text-xs text-indigo-200">Copied!</span>}
+                                </div>
+                            </div>
+                        )}
+
+                        {manageMembers && (
+                            <div className="rounded-lg border border-zinc-800 bg-zinc-900/60 p-4">
+                                <h3 className="text-sm font-semibold text-zinc-200">Invite new adventurer</h3>
+                                <p className="mt-1 text-xs text-zinc-500">
+                                    Send an existing account into the roster by email. They will arrive as an adventurer unless you grant a higher mantle.
+                                </p>
+                                <form onSubmit={handleInvite} className="mt-4 space-y-4">
+                                    <div className="grid gap-4 sm:grid-cols-[2fr,1fr]">
+                                        <div className="space-y-2">
+                                            <Label htmlFor="invite-email" className="text-xs uppercase tracking-wide text-zinc-400">
+                                                Email
+                                            </Label>
+                                            <Input
+                                                id="invite-email"
+                                                type="email"
+                                                value={inviteForm.data.email}
+                                                onChange={(event) => inviteForm.setData('email', event.target.value)}
+                                                placeholder="hero@realm.test"
+                                                className="text-sm"
+                                            />
+                                            {inviteForm.errors.email && <p className="text-sm text-rose-400">{inviteForm.errors.email}</p>}
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label htmlFor="invite-role" className="text-xs uppercase tracking-wide text-zinc-400">
+                                                Role
+                                            </Label>
+                                            <select
+                                                id="invite-role"
+                                                value={inviteForm.data.role}
+                                                onChange={(event) => inviteForm.setData('role', event.target.value)}
+                                                className="w-full rounded-md border border-zinc-700 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                                            >
+                                                {role_options.map((role) => (
+                                                    <option key={role} value={role} disabled={role === 'owner' && !promoteToOwner}>
+                                                        {roleLabels[role] ?? role}
+                                                    </option>
+                                                ))}
+                                            </select>
+                                            {inviteForm.errors.role && <p className="text-sm text-rose-400">{inviteForm.errors.role}</p>}
+                                        </div>
+                                    </div>
+                                    <div className="flex items-center gap-3">
+                                        <Button type="submit" size="sm" disabled={inviteForm.processing}>
+                                            Send invite
+                                        </Button>
+                                        <Button
+                                            type="button"
+                                            size="sm"
+                                            variant="ghost"
+                                            disabled={inviteForm.processing}
+                                            onClick={() => inviteForm.reset()}
+                                        >
+                                            Clear
+                                        </Button>
+                                    </div>
+                                </form>
+                            </div>
+                        )}
+
+                        <div className="space-y-3">
+                            {group.members.map((member) => {
+                                const isOwner = member.role === 'owner';
+                                const canChangeRole = manageMembers && (!isOwner || promoteToOwner);
+                                const canRemove = member.is_viewer || (manageMembers && (!isOwner || promoteToOwner));
+                                const isChanging = roleUpdating === member.id;
+                                const isRemoving = removing === member.id;
+
+                                return (
+                                    <div
+                                        key={member.id}
+                                        className="rounded-lg border border-zinc-800 bg-zinc-900/60 p-4"
+                                    >
+                                        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                            <div>
+                                                <div className="flex items-center gap-2">
+                                                    <p className="font-medium text-zinc-100">{member.name}</p>
+                                                    {member.is_viewer && (
+                                                        <span className="rounded-full bg-indigo-500/10 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-indigo-200">
+                                                            You
+                                                        </span>
+                                                    )}
+                                                </div>
+                                                <p className="text-xs text-zinc-500">{member.email}</p>
+                                            </div>
+                                            <div className="flex flex-col gap-2 sm:items-end">
+                                                {manageMembers ? (
+                                                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                                                        <select
+                                                            value={member.role}
+                                                            onChange={(event) => handleRoleChange(member, event.target.value)}
+                                                            disabled={!canChangeRole || isChanging}
+                                                            className="rounded-md border border-zinc-700 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                                                        >
+                                                            {role_options.map((role) => (
+                                                                <option key={role} value={role} disabled={role === 'owner' && !promoteToOwner}>
+                                                                    {roleLabels[role] ?? role}
+                                                                </option>
+                                                            ))}
+                                                        </select>
+                                                        <Button
+                                                            type="button"
+                                                            variant={member.is_viewer ? 'outline' : 'ghost'}
+                                                            size="sm"
+                                                            disabled={!canRemove || isRemoving}
+                                                            onClick={() => handleRemove(member)}
+                                                        >
+                                                            {member.is_viewer ? 'Leave party' : 'Remove'}
+                                                        </Button>
+                                                    </div>
+                                                ) : (
+                                                    <div className="flex flex-col gap-2 sm:items-end">
+                                                        <span className="rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-200">
+                                                            {roleLabels[member.role] ?? member.role}
+                                                        </span>
+                                                        {member.is_viewer && (
+                                                            <Button
+                                                                type="button"
+                                                                variant="outline"
+                                                                size="sm"
+                                                                disabled={isRemoving}
+                                                                onClick={() => handleRemove(member)}
+                                                            >
+                                                                Leave party
+                                                            </Button>
+                                                        )}
+                                                    </div>
+                                                )}
+                                                {(isChanging || isRemoving) && (
+                                                    <span className="text-xs text-zinc-500">Working...</span>
+                                                )}
+                                            </div>
+                                        </div>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    </div>
                 </section>
 
                 <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/40">
                     <header className="flex items-center justify-between">
                         <h2 className="text-lg font-semibold text-zinc-100">World regions</h2>
-                        <span className="text-xs uppercase tracking-wide text-zinc-500">{group.regions.length} tracked</span>
+                        <span className="text-xs uppercase tracking-wide text-zinc-500">{totalRegions} tracked</span>
                     </header>
 
-                    <div className="mt-4 space-y-4">
-                        {group.regions.length === 0 ? (
-                            <p className="rounded-lg border border-dashed border-zinc-800 bg-zinc-900/40 p-4 text-sm text-zinc-400">
-                                No regions assigned yet. Deploy a DM to begin mapping encounters and turn cadence.
-                            </p>
-                        ) : (
-                            group.regions.map((region) => (
-                                <article key={region.id} id={`region-${region.id}`} className="rounded-lg border border-zinc-800 bg-zinc-900/60 p-4">
-                                        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
-                                            <div>
-                                                <h3 className="text-base font-semibold text-zinc-100">{region.name}</h3>
-                                                {region.summary && <p className="mt-1 text-sm text-zinc-400">{region.summary}</p>}
-                                            </div>
-                                            <div className="flex items-center gap-2">
-                                                <Button asChild variant="outline" size="sm" className="border-zinc-700 text-xs">
-                                                    <Link href={route('groups.regions.edit', [group.id, region.id])}>Configure</Link>
-                                                </Button>
-                                                {region.can_process_turn && (
-                                                    <Button asChild size="sm" className="text-xs">
-                                                        <Link href={route('groups.regions.turns.create', [group.id, region.id])}>
-                                                            Process turn
-                                                        </Link>
-                                                    </Button>
-                                                )}
-                                            </div>
+                    {group.worlds.length === 0 ? (
+                        <p className="mt-4 rounded-lg border border-dashed border-zinc-800 bg-zinc-900/40 p-4 text-sm text-zinc-400">
+                            No worlds yet. Forge one to begin mapping realms and assigning dungeon masters.
+                        </p>
+                    ) : (
+                        <div className="mt-4 space-y-6">
+                            {group.worlds.map((world) => (
+                                <article key={world.id} className="space-y-4 rounded-lg border border-zinc-800 bg-zinc-900/60 p-5">
+                                    <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                                        <div>
+                                            <h3 className="text-base font-semibold text-zinc-100">{world.name}</h3>
+                                            <p className="text-sm text-zinc-500">
+                                                {world.summary ?? 'No summary yet. Chronicle this world for your party.'}
+                                            </p>
                                         </div>
+                                        <div className="flex items-center gap-2">
+                                            <Button asChild variant="secondary" size="sm">
+                                                <Link href={route('groups.worlds.edit', [group.id, world.id])}>Tend world</Link>
+                                            </Button>
+                                            <Button asChild size="sm">
+                                                <Link
+                                                    href={route('groups.regions.create', {
+                                                        group: group.id,
+                                                        world_id: world.id,
+                                                    })}
+                                                >
+                                                    Add region
+                                                </Link>
+                                            </Button>
+                                        </div>
+                                    </div>
 
-                                        <dl className="mt-3 grid gap-2 text-sm text-zinc-400 sm:grid-cols-2">
-                                            <div>
-                                                <dt className="text-xs uppercase tracking-wide text-zinc-500">Dungeon master</dt>
-                                                <dd>{region.dungeon_master ? region.dungeon_master.name : 'Unassigned'}</dd>
-                                            </div>
-                                            <div>
-                                                <dt className="text-xs uppercase tracking-wide text-zinc-500">Turn cadence</dt>
-                                                <dd>
-                                                    {region.turn_configuration
-                                                        ? `${region.turn_configuration.turn_duration_hours}h`
-                                                        : 'Not configured'}
-                                                </dd>
-                                            </div>
-                                            <div className="sm:col-span-2">
-                                                <dt className="text-xs uppercase tracking-wide text-zinc-500">Next scheduled turn</dt>
-                                                <dd>
-                                                    {region.turn_configuration?.next_turn_at
-                                                        ? new Date(region.turn_configuration.next_turn_at).toLocaleString()
-                                                        : 'Awaiting schedule'}
-                                                </dd>
-                                            </div>
-                                            <div className="sm:col-span-2">
-                                                <dt className="text-xs uppercase tracking-wide text-zinc-500">Status</dt>
-                                                <dd>
-                                                    {region.turn_configuration
-                                                        ? region.turn_configuration.is_due
-                                                            ? 'Turn ready for processing'
-                                                            : `Advances ${region.turn_configuration.next_turn_at ? new Date(region.turn_configuration.next_turn_at).toLocaleString() : ''}`
-                                                        : 'Configure cadence to begin scheduling'}
-                                                </dd>
-                                            </div>
-                                            <div className="sm:col-span-2">
-                                                <dt className="text-xs uppercase tracking-wide text-zinc-500">Last processed</dt>
-                                                <dd>
-                                                    {region.turn_configuration?.last_processed_at
-                                                        ? new Date(region.turn_configuration.last_processed_at).toLocaleString()
-                                                        : 'No turns processed yet'}
-                                                </dd>
-                                            </div>
-                                        </dl>
-
-                                        {region.recent_turns.length > 0 && (
-                                            <div className="mt-4 space-y-2">
-                                                <h4 className="text-xs font-semibold uppercase tracking-wide text-zinc-500">
-                                                    Recent turns
-                                                </h4>
-                                                <ul className="space-y-2 text-sm text-zinc-300">
-                                                    {region.recent_turns.map((turn) => (
-                                                        <li
-                                                            key={turn.id}
-                                                            className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-3"
-                                                        >
-                                                            <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-zinc-400">
-                                                                <span className="font-semibold text-zinc-200">Turn #{turn.number}</span>
-                                                                {turn.processed_at && (
-                                                                    <span>{new Date(turn.processed_at).toLocaleString()}</span>
-                                                                )}
-                                                            </div>
-                                                            {turn.summary ? (
-                                                                <p className="mt-2 text-sm text-zinc-300">{turn.summary}</p>
+                                    {world.regions.length === 0 ? (
+                                        <p className="rounded border border-dashed border-zinc-700/70 bg-zinc-950/40 p-4 text-sm text-zinc-500">
+                                            No regions assigned. Bring a DM on board to steward the first frontier.
+                                        </p>
+                                    ) : (
+                                        <div className="space-y-5">
+                                            {world.regions.map((region) => (
+                                                <article key={region.id} id={`region-${region.id}`} className="rounded-lg border border-zinc-800 bg-zinc-950/50 p-4">
+                                                    <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                                                        <div>
+                                                            <h4 className="text-sm font-semibold text-zinc-100">{region.name}</h4>
+                                                            <p className="text-xs text-zinc-500">
+                                                                {region.summary ?? 'No summary yet. Add a quick legend hook.'}
+                                                            </p>
+                                                            {region.dungeon_master ? (
+                                                                <p className="mt-2 text-[11px] uppercase tracking-wide text-indigo-300">
+                                                                    DM: {region.dungeon_master.name}
+                                                                </p>
                                                             ) : (
-                                                                <p className="mt-2 text-sm text-zinc-500">
-                                                                    Awaiting summary details.
+                                                                <p className="mt-2 text-[11px] uppercase tracking-wide text-zinc-500">
+                                                                    DM unassigned
                                                                 </p>
                                                             )}
-                                                            <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-zinc-500">
-                                                                <span>
-                                                                    Processed by{' '}
-                                                                    {turn.processed_by
-                                                                        ? turn.processed_by.name
-                                                                        : turn.used_ai_fallback
-                                                                        ? 'AI delegate'
-                                                                        : 'Unknown'}
+                                                        </div>
+                                                        <div className="flex items-center gap-2">
+                                                            <Button asChild variant="outline" size="sm" className="border-indigo-400/40 text-indigo-200">
+                                                                <Link href={route('groups.regions.edit', [group.id, region.id])}>Adjust</Link>
+                                                            </Button>
+                                                            {region.can_process_turn ? (
+                                                                <Button asChild size="sm">
+                                                                    <Link href={route('groups.regions.turns.create', [group.id, region.id])}>
+                                                                        Process turn
+                                                                    </Link>
+                                                                </Button>
+                                                            ) : (
+                                                                <span className="rounded border border-zinc-800/70 px-3 py-1 text-[11px] uppercase tracking-wide text-zinc-500">
+                                                                    Awaiting cadence
                                                                 </span>
-                                                                {turn.used_ai_fallback && (
-                                                                    <span className="rounded bg-indigo-500/10 px-2 py-0.5 text-indigo-300">
-                                                                        AI fallback
-                                                                    </span>
-                                                                )}
-                                                            </div>
-                                                        </li>
-                                                    ))}
-                                                </ul>
-                                            </div>
-                                        )}
-                                    </article>
-                                ))
-                            )}
+                                                            )}
+                                                        </div>
+                                                    </div>
+
+                                                    <dl className="mt-4 grid gap-3 text-xs text-zinc-400 sm:grid-cols-3">
+                                                        <div>
+                                                            <dt className="uppercase tracking-wide text-zinc-500">Cadence</dt>
+                                                            <dd>
+                                                                {region.turn_configuration
+                                                                    ? `${region.turn_configuration.turn_duration_hours}h`
+                                                                    : `${world.default_turn_duration_hours}h default`}
+                                                            </dd>
+                                                        </div>
+                                                        <div>
+                                                            <dt className="uppercase tracking-wide text-zinc-500">Next turn</dt>
+                                                            <dd>
+                                                                {region.turn_configuration?.next_turn_at
+                                                                    ? new Date(region.turn_configuration.next_turn_at).toLocaleString()
+                                                                    : 'Awaiting schedule'}
+                                                            </dd>
+                                                        </div>
+                                                        <div>
+                                                            <dt className="uppercase tracking-wide text-zinc-500">Status</dt>
+                                                            <dd className={region.turn_configuration?.is_due ? 'text-amber-300' : 'text-emerald-300'}>
+                                                                {region.turn_configuration?.is_due ? 'Turn ready' : 'On schedule'}
+                                                            </dd>
+                                                        </div>
+                                                    </dl>
+
+                                                    {region.recent_turns.length > 0 && (
+                                                        <div className="mt-4 border-t border-zinc-800 pt-4">
+                                                            <h5 className="text-[11px] uppercase tracking-wide text-zinc-500">Recent turns</h5>
+                                                            <ul className="mt-3 space-y-3 text-sm text-zinc-400">
+                                                                {region.recent_turns.map((turn) => (
+                                                                    <li key={turn.id} className="rounded border border-zinc-800/60 bg-zinc-950/50 p-3">
+                                                                        <div className="flex items-center justify-between text-[11px] uppercase tracking-wide text-zinc-500">
+                                                                            <span>Turn #{turn.number}</span>
+                                                                            <span>
+                                                                                {turn.processed_at
+                                                                                    ? new Date(turn.processed_at).toLocaleString()
+                                                                                    : 'Pending'}
+                                                                            </span>
+                                                                        </div>
+                                                                        <p className="mt-2 text-sm text-zinc-300">{turn.summary ?? 'Awaiting scribe.'}</p>
+                                                                        <p className="mt-2 text-xs text-zinc-500">
+                                                                            {turn.processed_by
+                                                                                ? `Processed by ${turn.processed_by.name}`
+                                                                                : turn.used_ai_fallback
+                                                                                ? 'AI assisted'
+                                                                                : 'Manual processing'}
+                                                                        </p>
+                                                                    </li>
+                                                                ))}
+                                                            </ul>
+                                                        </div>
+                                                    )}
+                                                </article>
+                                            ))}
+                                        </div>
+                                    )}
+                                </article>
+                            ))}
                         </div>
+                    )}
                 </section>
 
                 <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/40 lg:col-span-2">
@@ -252,6 +548,118 @@ export default function GroupShow({ group }: GroupShowProps) {
                             ))
                         )}
                     </div>
+                </section>
+
+                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/40 lg:col-span-2">
+                    <header className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                        <div>
+                            <h2 className="text-lg font-semibold text-zinc-100">Tile template library</h2>
+                            <p className="text-sm text-zinc-500">
+                                Reusable terrain tiles guide consistent maps and movement rules across your worlds.
+                            </p>
+                        </div>
+                        <Button asChild size="sm">
+                            <Link href={route('groups.tile-templates.create', group.id)}>Add template</Link>
+                        </Button>
+                    </header>
+
+                    {group.tile_templates.length === 0 ? (
+                        <p className="mt-4 rounded-lg border border-dashed border-zinc-800 bg-zinc-900/40 p-4 text-sm text-zinc-400">
+                            No templates yet. Draft a few core terrains so dungeon masters can assemble boards quickly.
+                        </p>
+                    ) : (
+                        <div className="mt-6 space-y-4">
+                            {group.tile_templates.map((template) => (
+                                <article key={template.id} className="flex flex-col gap-3 rounded-lg border border-zinc-800 bg-zinc-950/50 p-4 md:flex-row md:items-center md:justify-between">
+                                    <div>
+                                        <div className="flex items-center gap-2">
+                                            <h3 className="text-base font-semibold text-zinc-100">{template.name}</h3>
+                                            {template.key && (
+                                                <span className="rounded-full bg-zinc-800 px-2 py-0.5 text-[11px] uppercase tracking-wide text-zinc-400">{template.key}</span>
+                                            )}
+                                        </div>
+                                        <p className="mt-1 text-sm text-zinc-400">
+                                            Terrain: {template.terrain_type} · Movement cost {template.movement_cost} · Defense +{template.defense_bonus}
+                                        </p>
+                                        <div className="mt-2 flex flex-wrap gap-3 text-xs text-zinc-500">
+                                            {template.world ? <span>World: {template.world.name}</span> : <span>Shared across worlds</span>}
+                                            {template.creator && <span>Crafted by {template.creator.name}</span>}
+                                        </div>
+                                    </div>
+                                    <div className="flex items-center gap-2 self-end md:self-auto">
+                                        <Button asChild variant="secondary" size="sm">
+                                            <Link href={route('groups.tile-templates.edit', [group.id, template.id])}>Edit</Link>
+                                        </Button>
+                                        <Button
+                                            type="button"
+                                            variant="ghost"
+                                            size="sm"
+                                            className="text-rose-300 hover:text-rose-200"
+                                            disabled={removingTemplate === template.id}
+                                            onClick={() => handleTemplateRemove(template)}
+                                        >
+                                            {removingTemplate === template.id ? 'Removing...' : 'Remove'}
+                                        </Button>
+                                    </div>
+                                </article>
+                            ))}
+                        </div>
+                    )}
+                </section>
+
+                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/40 lg:col-span-2">
+                    <header className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                        <div>
+                            <h2 className="text-lg font-semibold text-zinc-100">Region maps</h2>
+                            <p className="text-sm text-zinc-500">
+                                Track the boards that anchor your adventures and drop tiles with axial precision.
+                            </p>
+                        </div>
+                        <Button asChild size="sm">
+                            <Link href={route('groups.maps.create', group.id)}>Create map</Link>
+                        </Button>
+                    </header>
+
+                    {group.maps.length === 0 ? (
+                        <p className="mt-4 rounded-lg border border-dashed border-zinc-800 bg-zinc-900/40 p-4 text-sm text-zinc-400">
+                            No maps charted yet. Craft one to start placing templates on the hex grid.
+                        </p>
+                    ) : (
+                        <div className="mt-6 space-y-4">
+                            {group.maps.map((map) => (
+                                <article key={map.id} className="flex flex-col gap-3 rounded-lg border border-zinc-800 bg-zinc-950/50 p-4 md:flex-row md:items-center md:justify-between">
+                                    <div>
+                                        <h3 className="text-base font-semibold text-zinc-100">{map.title}</h3>
+                                        <p className="mt-1 text-sm text-zinc-400">
+                                            {map.base_layer === 'hex' ? 'Hex grid' : map.base_layer === 'square' ? 'Square grid' : 'Image backdrop'} · {map.orientation === 'pointy' ? 'Pointy-top' : 'Flat-top'}
+                                        </p>
+                                        <div className="mt-2 flex flex-wrap gap-3 text-xs text-zinc-500">
+                                            <span>{map.tile_count} tiles</span>
+                                            {map.region ? <span>Region: {map.region.name}</span> : <span>Unassigned region</span>}
+                                        </div>
+                                    </div>
+                                    <div className="flex items-center gap-2 self-end md:self-auto">
+                                        <Button asChild variant="secondary" size="sm">
+                                            <Link href={route('groups.maps.show', [group.id, map.id])}>Open</Link>
+                                        </Button>
+                                        <Button asChild variant="outline" size="sm" className="border-zinc-700 text-xs">
+                                            <Link href={route('groups.maps.edit', [group.id, map.id])}>Settings</Link>
+                                        </Button>
+                                        <Button
+                                            type="button"
+                                            variant="ghost"
+                                            size="sm"
+                                            className="text-rose-300 hover:text-rose-200"
+                                            disabled={removingMap === map.id}
+                                            onClick={() => handleMapRemove(map)}
+                                        >
+                                            {removingMap === map.id ? 'Removing...' : 'Remove'}
+                                        </Button>
+                                    </div>
+                                </article>
+                            ))}
+                        </div>
+                    )}
                 </section>
             </div>
         </AppLayout>

--- a/backend/resources/js/Pages/Maps/Create.tsx
+++ b/backend/resources/js/Pages/Maps/Create.tsx
@@ -1,0 +1,189 @@
+import { Head, Link, useForm } from '@inertiajs/react';
+
+import AppLayout from '@/Layouts/AppLayout';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+
+type MapCreateProps = {
+    group: { id: number; name: string };
+    regions: { id: number; name: string }[];
+    defaults: {
+        base_layer: string;
+        orientation: string;
+    };
+};
+
+type MapForm = {
+    title: string;
+    base_layer: string;
+    orientation: string;
+    width: number | '';
+    height: number | '';
+    region_id: number | '';
+    gm_only: boolean;
+    fog_data: string;
+};
+
+export default function MapCreate({ group, regions, defaults }: MapCreateProps) {
+    const form = useForm<MapForm>({
+        title: '',
+        base_layer: defaults.base_layer,
+        orientation: defaults.orientation,
+        width: '',
+        height: '',
+        region_id: '',
+        gm_only: false,
+        fog_data: '',
+    });
+
+    const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        form.post(route('groups.maps.store', group.id));
+    };
+
+    return (
+        <AppLayout>
+            <Head title={`Create map · ${group.name}`} />
+
+            <div className="mx-auto max-w-3xl">
+                <div className="mb-6 flex items-center justify-between">
+                    <div>
+                        <h1 className="text-2xl font-semibold text-zinc-100">Create map</h1>
+                        <p className="text-sm text-zinc-400">Launch a board for one of {group.name}&apos;s regions.</p>
+                    </div>
+                    <Button asChild variant="outline" className="border-zinc-700 text-sm">
+                        <Link href={route('groups.show', group.id)}>Back to group</Link>
+                    </Button>
+                </div>
+
+                <form onSubmit={handleSubmit} className="space-y-6">
+                    <div className="space-y-2">
+                        <Label htmlFor="title">Title</Label>
+                        <Input
+                            id="title"
+                            value={form.data.title}
+                            onChange={(event) => form.setData('title', event.target.value)}
+                            placeholder="Shimmering Expanse"
+                        />
+                        {form.errors.title && <p className="text-sm text-rose-400">{form.errors.title}</p>}
+                    </div>
+
+                    <div className="grid gap-4 sm:grid-cols-2">
+                        <div className="space-y-2">
+                            <Label htmlFor="base_layer">Base layer</Label>
+                            <select
+                                id="base_layer"
+                                value={form.data.base_layer}
+                                onChange={(event) => form.setData('base_layer', event.target.value)}
+                                className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                            >
+                                <option value="hex">Hex grid</option>
+                                <option value="square">Square grid</option>
+                                <option value="image">Image backdrop</option>
+                            </select>
+                            {form.errors.base_layer && <p className="text-sm text-rose-400">{form.errors.base_layer}</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="orientation">Orientation</Label>
+                            <select
+                                id="orientation"
+                                value={form.data.orientation}
+                                onChange={(event) => form.setData('orientation', event.target.value)}
+                                className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                            >
+                                <option value="pointy">Pointy-top hex</option>
+                                <option value="flat">Flat-top hex</option>
+                            </select>
+                            {form.errors.orientation && <p className="text-sm text-rose-400">{form.errors.orientation}</p>}
+                        </div>
+                    </div>
+
+                    <div className="grid gap-4 sm:grid-cols-3">
+                        <div className="space-y-2">
+                            <Label htmlFor="width">Width (optional)</Label>
+                            <Input
+                                id="width"
+                                type="number"
+                                min={1}
+                                max={200}
+                                value={form.data.width}
+                                onChange={(event) => form.setData('width', event.target.value === '' ? '' : Number(event.target.value))}
+                            />
+                            {form.errors.width && <p className="text-sm text-rose-400">{form.errors.width}</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="height">Height (optional)</Label>
+                            <Input
+                                id="height"
+                                type="number"
+                                min={1}
+                                max={200}
+                                value={form.data.height}
+                                onChange={(event) => form.setData('height', event.target.value === '' ? '' : Number(event.target.value))}
+                            />
+                            {form.errors.height && <p className="text-sm text-rose-400">{form.errors.height}</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="region_id">Region (optional)</Label>
+                            <select
+                                id="region_id"
+                                value={form.data.region_id}
+                                onChange={(event) =>
+                                    form.setData('region_id', event.target.value === '' ? '' : Number(event.target.value))
+                                }
+                                className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                            >
+                                <option value="">Unassigned</option>
+                                {regions.map((region) => (
+                                    <option key={region.id} value={region.id}>
+                                        {region.name}
+                                    </option>
+                                ))}
+                            </select>
+                            {form.errors.region_id && <p className="text-sm text-rose-400">{form.errors.region_id}</p>}
+                        </div>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                        <Checkbox
+                            id="gm_only"
+                            checked={form.data.gm_only}
+                            onChange={(event) => form.setData('gm_only', event.target.checked)}
+                        />
+                        <Label htmlFor="gm_only" className="text-sm text-zinc-300">
+                            GM-only map (players need invites)
+                        </Label>
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="fog_data">Fog configuration JSON (optional)</Label>
+                        <Textarea
+                            id="fog_data"
+                            value={form.data.fog_data}
+                            onChange={(event) => form.setData('fog_data', event.target.value)}
+                            placeholder='{"revealed": [[0,0]]}'
+                        />
+                        {form.errors.fog_data && <p className="text-sm text-rose-400">{form.errors.fog_data}</p>}
+                    </div>
+
+                    <div className="flex items-center gap-3">
+                        <Button type="submit" disabled={form.processing}>
+                            Save map
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            disabled={form.processing}
+                            onClick={() => form.reset()}
+                        >
+                            Reset
+                        </Button>
+                    </div>
+                </form>
+            </div>
+        </AppLayout>
+    );
+}

--- a/backend/resources/js/Pages/Maps/Edit.tsx
+++ b/backend/resources/js/Pages/Maps/Edit.tsx
@@ -1,0 +1,194 @@
+import { Head, Link, useForm } from '@inertiajs/react';
+
+import AppLayout from '@/Layouts/AppLayout';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+
+type MapEditProps = {
+    group: { id: number; name: string };
+    regions: { id: number; name: string }[];
+    map: {
+        id: number;
+        title: string;
+        base_layer: string;
+        orientation: string;
+        width: number | null;
+        height: number | null;
+        gm_only: boolean;
+        region_id: number | null;
+        fog_data: Record<string, unknown> | null;
+    };
+};
+
+type MapForm = {
+    title: string;
+    base_layer: string;
+    orientation: string;
+    width: number | '';
+    height: number | '';
+    region_id: number | '';
+    gm_only: boolean;
+    fog_data: string;
+};
+
+export default function MapEdit({ group, regions, map }: MapEditProps) {
+    const form = useForm<MapForm>({
+        title: map.title,
+        base_layer: map.base_layer,
+        orientation: map.orientation,
+        width: map.width ?? '',
+        height: map.height ?? '',
+        region_id: map.region_id ?? '',
+        gm_only: map.gm_only,
+        fog_data: map.fog_data ? JSON.stringify(map.fog_data, null, 2) : '',
+    });
+
+    const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        form.put(route('groups.maps.update', [group.id, map.id]));
+    };
+
+    return (
+        <AppLayout>
+            <Head title={`Edit ${map.title} · ${group.name}`} />
+
+            <div className="mx-auto max-w-3xl">
+                <div className="mb-6 flex items-center justify-between">
+                    <div>
+                        <h1 className="text-2xl font-semibold text-zinc-100">Edit map</h1>
+                        <p className="text-sm text-zinc-400">Adjust map metadata and visibility settings.</p>
+                    </div>
+                    <Button asChild variant="outline" className="border-zinc-700 text-sm">
+                        <Link href={route('groups.maps.show', [group.id, map.id])}>Back to map</Link>
+                    </Button>
+                </div>
+
+                <form onSubmit={handleSubmit} className="space-y-6">
+                    <div className="space-y-2">
+                        <Label htmlFor="title">Title</Label>
+                        <Input
+                            id="title"
+                            value={form.data.title}
+                            onChange={(event) => form.setData('title', event.target.value)}
+                        />
+                        {form.errors.title && <p className="text-sm text-rose-400">{form.errors.title}</p>}
+                    </div>
+
+                    <div className="grid gap-4 sm:grid-cols-2">
+                        <div className="space-y-2">
+                            <Label htmlFor="base_layer">Base layer</Label>
+                            <select
+                                id="base_layer"
+                                value={form.data.base_layer}
+                                onChange={(event) => form.setData('base_layer', event.target.value)}
+                                className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                            >
+                                <option value="hex">Hex grid</option>
+                                <option value="square">Square grid</option>
+                                <option value="image">Image backdrop</option>
+                            </select>
+                            {form.errors.base_layer && <p className="text-sm text-rose-400">{form.errors.base_layer}</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="orientation">Orientation</Label>
+                            <select
+                                id="orientation"
+                                value={form.data.orientation}
+                                onChange={(event) => form.setData('orientation', event.target.value)}
+                                className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                            >
+                                <option value="pointy">Pointy-top hex</option>
+                                <option value="flat">Flat-top hex</option>
+                            </select>
+                            {form.errors.orientation && <p className="text-sm text-rose-400">{form.errors.orientation}</p>}
+                        </div>
+                    </div>
+
+                    <div className="grid gap-4 sm:grid-cols-3">
+                        <div className="space-y-2">
+                            <Label htmlFor="width">Width (optional)</Label>
+                            <Input
+                                id="width"
+                                type="number"
+                                min={1}
+                                max={200}
+                                value={form.data.width}
+                                onChange={(event) => form.setData('width', event.target.value === '' ? '' : Number(event.target.value))}
+                            />
+                            {form.errors.width && <p className="text-sm text-rose-400">{form.errors.width}</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="height">Height (optional)</Label>
+                            <Input
+                                id="height"
+                                type="number"
+                                min={1}
+                                max={200}
+                                value={form.data.height}
+                                onChange={(event) => form.setData('height', event.target.value === '' ? '' : Number(event.target.value))}
+                            />
+                            {form.errors.height && <p className="text-sm text-rose-400">{form.errors.height}</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="region_id">Region (optional)</Label>
+                            <select
+                                id="region_id"
+                                value={form.data.region_id}
+                                onChange={(event) =>
+                                    form.setData('region_id', event.target.value === '' ? '' : Number(event.target.value))
+                                }
+                                className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                            >
+                                <option value="">Unassigned</option>
+                                {regions.map((region) => (
+                                    <option key={region.id} value={region.id}>
+                                        {region.name}
+                                    </option>
+                                ))}
+                            </select>
+                            {form.errors.region_id && <p className="text-sm text-rose-400">{form.errors.region_id}</p>}
+                        </div>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                        <Checkbox
+                            id="gm_only"
+                            checked={form.data.gm_only}
+                            onChange={(event) => form.setData('gm_only', event.target.checked)}
+                        />
+                        <Label htmlFor="gm_only" className="text-sm text-zinc-300">
+                            GM-only map (players need invites)
+                        </Label>
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="fog_data">Fog configuration JSON (optional)</Label>
+                        <Textarea
+                            id="fog_data"
+                            value={form.data.fog_data}
+                            onChange={(event) => form.setData('fog_data', event.target.value)}
+                        />
+                        {form.errors.fog_data && <p className="text-sm text-rose-400">{form.errors.fog_data}</p>}
+                    </div>
+
+                    <div className="flex items-center gap-3">
+                        <Button type="submit" disabled={form.processing}>
+                            Update map
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            disabled={form.processing}
+                            onClick={() => form.reset()}
+                        >
+                            Reset changes
+                        </Button>
+                    </div>
+                </form>
+            </div>
+        </AppLayout>
+    );
+}

--- a/backend/resources/js/Pages/Maps/Show.tsx
+++ b/backend/resources/js/Pages/Maps/Show.tsx
@@ -1,0 +1,428 @@
+import { useEffect, useState } from 'react';
+import { Head, Link, router, useForm } from '@inertiajs/react';
+
+import AppLayout from '@/Layouts/AppLayout';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+
+type TileTemplateOption = {
+    id: number;
+    name: string;
+    terrain_type: string;
+    movement_cost: number;
+    defense_bonus: number;
+};
+
+type MapTileSummary = {
+    id: number;
+    q: number;
+    r: number;
+    elevation: number;
+    locked: boolean;
+    variant: Record<string, unknown> | null;
+    template: TileTemplateOption;
+};
+
+type MapShowProps = {
+    group: { id: number; name: string };
+    map: {
+        id: number;
+        title: string;
+        base_layer: string;
+        orientation: string;
+        width: number | null;
+        height: number | null;
+        gm_only: boolean;
+        region: { id: number; name: string } | null;
+    };
+    tiles: MapTileSummary[];
+    tile_templates: TileTemplateOption[];
+};
+
+type CreateTileForm = {
+    tile_template_id: number | '';
+    q: number;
+    r: number;
+    elevation: number;
+    variant: string;
+    locked: boolean;
+};
+
+type TileDraft = {
+    tile_template_id: number;
+    elevation: number | '';
+    variant: string;
+};
+
+export default function MapShow({ group, map, tiles, tile_templates }: MapShowProps) {
+    const createForm = useForm<CreateTileForm>({
+        tile_template_id: tile_templates[0]?.id ?? '',
+        q: 0,
+        r: 0,
+        elevation: 0,
+        variant: '',
+        locked: false,
+    });
+
+    const [tileEdits, setTileEdits] = useState<Record<number, TileDraft>>({});
+    const [updatingTile, setUpdatingTile] = useState<number | null>(null);
+    const [removingTile, setRemovingTile] = useState<number | null>(null);
+
+    useEffect(() => {
+        if (tile_templates.length > 0 && createForm.data.tile_template_id === '') {
+            createForm.setData('tile_template_id', tile_templates[0].id);
+        }
+    }, [tile_templates]);
+
+    useEffect(() => {
+        const drafts: Record<number, TileDraft> = {};
+        tiles.forEach((tile) => {
+            drafts[tile.id] = {
+                tile_template_id: tile.template.id,
+                elevation: tile.elevation,
+                variant: tile.variant ? JSON.stringify(tile.variant, null, 2) : '',
+            };
+        });
+        setTileEdits(drafts);
+    }, [tiles]);
+
+    const handleCreate = (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        createForm.post(route('groups.maps.tiles.store', [group.id, map.id]), {
+            preserveScroll: true,
+            onSuccess: () => {
+                createForm.setData({
+                    tile_template_id: tile_templates[0]?.id ?? '',
+                    q: 0,
+                    r: 0,
+                    elevation: 0,
+                    variant: '',
+                    locked: false,
+                });
+            },
+        });
+    };
+
+    const handleTileDraftChange = (tileId: number, field: keyof TileDraft, value: string | number) => {
+        setTileEdits((drafts) => ({
+            ...drafts,
+            [tileId]: {
+                ...drafts[tileId],
+                [field]: value,
+            },
+        }));
+    };
+
+    const handleTileUpdate = (tileId: number) => {
+        const draft = tileEdits[tileId];
+        if (!draft) {
+            return;
+        }
+
+        setUpdatingTile(tileId);
+        router.patch(
+            route('groups.maps.tiles.update', [group.id, map.id, tileId]),
+            {
+                tile_template_id: draft.tile_template_id,
+                elevation: draft.elevation === '' ? null : Number(draft.elevation),
+                variant: draft.variant.trim() === '' ? null : draft.variant,
+            },
+            {
+                preserveScroll: true,
+                onFinish: () => setUpdatingTile(null),
+            }
+        );
+    };
+
+    const handleToggleLock = (tile: MapTileSummary) => {
+        setUpdatingTile(tile.id);
+        router.patch(
+            route('groups.maps.tiles.update', [group.id, map.id, tile.id]),
+            {
+                locked: !tile.locked,
+            },
+            {
+                preserveScroll: true,
+                onFinish: () => setUpdatingTile(null),
+            }
+        );
+    };
+
+    const handleRemoveTile = (tile: MapTileSummary) => {
+        setRemovingTile(tile.id);
+        router.delete(route('groups.maps.tiles.destroy', [group.id, map.id, tile.id]), {
+            preserveScroll: true,
+            onFinish: () => setRemovingTile(null),
+        });
+    };
+
+    const templateOptions = tile_templates.map((template) => ({
+        value: template.id,
+        label: `${template.name} · ${template.terrain_type}`,
+    }));
+
+    return (
+        <AppLayout>
+            <Head title={`${map.title} · ${group.name}`} />
+
+            <div className="space-y-8">
+                <div className="border-b border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/40">
+                    <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                        <div>
+                            <p className="text-sm uppercase tracking-wide text-indigo-300">{group.name}</p>
+                            <h1 className="text-3xl font-semibold text-zinc-100">{map.title}</h1>
+                            <p className="mt-2 text-sm text-zinc-400">
+                                {map.base_layer === 'hex' ? 'Hex grid' : map.base_layer === 'square' ? 'Square grid' : 'Image backdrop'} ·{' '}
+                                {map.orientation === 'pointy' ? 'Pointy-top' : 'Flat-top'} ·{' '}
+                                {map.region ? `Region: ${map.region.name}` : 'Unassigned region'}
+                            </p>
+                            <p className="mt-1 text-xs uppercase tracking-wide text-zinc-500">
+                                {tiles.length} tiles · {map.gm_only ? 'GM only' : 'Visible to party'}
+                            </p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <Button asChild variant="outline" className="border-zinc-700 text-sm">
+                                <Link href={route('groups.maps.edit', [group.id, map.id])}>Map settings</Link>
+                            </Button>
+                            <Button asChild variant="ghost" className="text-sm text-zinc-400 hover:text-zinc-200">
+                                <Link href={route('groups.show', group.id)}>Back to group</Link>
+                            </Button>
+                        </div>
+                    </div>
+                </div>
+
+                <section className="mx-auto max-w-4xl rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
+                    <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                            <h2 className="text-lg font-semibold text-zinc-100">Place tile</h2>
+                            <p className="text-sm text-zinc-400">Drop a template onto the axial grid. Coordinates use q,r.</p>
+                        </div>
+                    </header>
+
+                    <form onSubmit={handleCreate} className="mt-4 grid gap-4 md:grid-cols-2">
+                        <div className="space-y-2">
+                            <Label htmlFor="tile_template_id">Tile template</Label>
+                            <select
+                                id="tile_template_id"
+                                value={createForm.data.tile_template_id}
+                                onChange={(event) =>
+                                    createForm.setData('tile_template_id', event.target.value === '' ? '' : Number(event.target.value))
+                                }
+                                className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                                disabled={tile_templates.length === 0 || createForm.processing}
+                            >
+                                {tile_templates.length === 0 ? (
+                                    <option value="">No templates available</option>
+                                ) : (
+                                    templateOptions.map((option) => (
+                                        <option key={option.value} value={option.value}>
+                                            {option.label}
+                                        </option>
+                                    ))
+                                )}
+                            </select>
+                            {createForm.errors.tile_template_id && (
+                                <p className="text-sm text-rose-400">{createForm.errors.tile_template_id}</p>
+                            )}
+                        </div>
+                        <div className="grid gap-4 sm:grid-cols-3">
+                            <div className="space-y-2">
+                                <Label htmlFor="q">Q</Label>
+                                <Input
+                                    id="q"
+                                    type="number"
+                                    value={createForm.data.q}
+                                    onChange={(event) => createForm.setData('q', Number(event.target.value))}
+                                />
+                                {createForm.errors.q && <p className="text-sm text-rose-400">{createForm.errors.q}</p>}
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="r">R</Label>
+                                <Input
+                                    id="r"
+                                    type="number"
+                                    value={createForm.data.r}
+                                    onChange={(event) => createForm.setData('r', Number(event.target.value))}
+                                />
+                                {createForm.errors.r && <p className="text-sm text-rose-400">{createForm.errors.r}</p>}
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="elevation">Elevation</Label>
+                                <Input
+                                    id="elevation"
+                                    type="number"
+                                    value={createForm.data.elevation}
+                                    onChange={(event) => createForm.setData('elevation', Number(event.target.value))}
+                                />
+                                {createForm.errors.elevation && (
+                                    <p className="text-sm text-rose-400">{createForm.errors.elevation}</p>
+                                )}
+                            </div>
+                        </div>
+                        <div className="space-y-2 md:col-span-2">
+                            <Label htmlFor="variant">Variant JSON (optional)</Label>
+                            <Textarea
+                                id="variant"
+                                value={createForm.data.variant}
+                                onChange={(event) => createForm.setData('variant', event.target.value)}
+                                placeholder='{"resource":"gold"}'
+                            />
+                            {createForm.errors.variant && <p className="text-sm text-rose-400">{createForm.errors.variant}</p>}
+                        </div>
+                        <div className="flex items-center gap-2 md:col-span-2">
+                            <Checkbox
+                                id="locked"
+                                checked={createForm.data.locked}
+                                onChange={(event) => createForm.setData('locked', event.target.checked)}
+                            />
+                            <Label htmlFor="locked" className="text-sm text-zinc-300">
+                                Lock tile after placement
+                            </Label>
+                        </div>
+                        <div className="md:col-span-2 flex items-center gap-3">
+                            <Button type="submit" disabled={createForm.processing || tile_templates.length === 0}>
+                                Place tile
+                            </Button>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                disabled={createForm.processing}
+                                onClick={() => createForm.reset()}
+                            >
+                                Reset
+                            </Button>
+                        </div>
+                    </form>
+                </section>
+
+                <section className="mx-auto max-w-4xl space-y-4">
+                    <header className="flex items-center justify-between">
+                        <h2 className="text-lg font-semibold text-zinc-100">Placed tiles</h2>
+                        <span className="text-xs uppercase tracking-wide text-zinc-500">{tiles.length} total</span>
+                    </header>
+
+                    {tiles.length === 0 ? (
+                        <p className="rounded-lg border border-dashed border-zinc-800 bg-zinc-950/40 p-4 text-sm text-zinc-400">
+                            No tiles placed yet. Drop a template above to start charting the region.
+                        </p>
+                    ) : (
+                        <div className="space-y-4">
+                            {tiles.map((tile) => {
+                                const draft = tileEdits[tile.id];
+
+                                return (
+                                    <article
+                                        key={tile.id}
+                                        className="flex flex-col gap-4 rounded-lg border border-zinc-800 bg-zinc-950/50 p-4 md:flex-row md:items-start md:justify-between"
+                                    >
+                                        <div className="space-y-2">
+                                            <div className="flex flex-wrap items-center gap-2">
+                                                <h3 className="text-base font-semibold text-zinc-100">
+                                                    {tile.template.name}
+                                                </h3>
+                                                <span className="rounded-full bg-zinc-800 px-2 py-0.5 text-[11px] uppercase tracking-wide text-zinc-400">
+                                                    q {tile.q}, r {tile.r}
+                                                </span>
+                                                {tile.locked && (
+                                                    <span className="rounded-full bg-amber-500/20 px-2 py-0.5 text-[11px] uppercase tracking-wide text-amber-200">
+                                                        Locked
+                                                    </span>
+                                                )}
+                                            </div>
+                                            <p className="text-sm text-zinc-400">
+                                                Terrain: {tile.template.terrain_type} · Movement {tile.template.movement_cost} · Defense +{tile.template.defense_bonus}
+                                            </p>
+                                            <div className="grid gap-3 sm:grid-cols-2">
+                                                <div className="space-y-1">
+                                                    <Label htmlFor={`tile-template-${tile.id}`} className="text-xs uppercase tracking-wide text-zinc-500">
+                                                        Template
+                                                    </Label>
+                                                    <select
+                                                        id={`tile-template-${tile.id}`}
+                                                        value={draft?.tile_template_id ?? tile.template.id}
+                                                        onChange={(event) =>
+                                                            handleTileDraftChange(tile.id, 'tile_template_id', Number(event.target.value))
+                                                        }
+                                                        className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                                                        disabled={updatingTile === tile.id}
+                                                    >
+                                                        {templateOptions.map((option) => (
+                                                            <option key={option.value} value={option.value}>
+                                                                {option.label}
+                                                            </option>
+                                                        ))}
+                                                    </select>
+                                                </div>
+                                                <div className="space-y-1">
+                                                    <Label htmlFor={`tile-elevation-${tile.id}`} className="text-xs uppercase tracking-wide text-zinc-500">
+                                                        Elevation
+                                                    </Label>
+                                                    <Input
+                                                        id={`tile-elevation-${tile.id}`}
+                                                        type="number"
+                                                        value={draft?.elevation ?? tile.elevation}
+                                                        onChange={(event) =>
+                                                            handleTileDraftChange(tile.id, 'elevation',
+                                                                event.target.value === '' ? '' : Number(event.target.value)
+                                                            )
+                                                        }
+                                                        disabled={updatingTile === tile.id}
+                                                    />
+                                                </div>
+                                                <div className="space-y-1 sm:col-span-2">
+                                                    <Label htmlFor={`tile-variant-${tile.id}`} className="text-xs uppercase tracking-wide text-zinc-500">
+                                                        Variant JSON (optional)
+                                                    </Label>
+                                                    <Textarea
+                                                        id={`tile-variant-${tile.id}`}
+                                                        value={draft?.variant ?? ''}
+                                                        onChange={(event) => handleTileDraftChange(tile.id, 'variant', event.target.value)}
+                                                        disabled={updatingTile === tile.id}
+                                                    />
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div className="flex flex-col gap-2 md:items-end">
+                                            <Button
+                                                type="button"
+                                                size="sm"
+                                                disabled={updatingTile === tile.id}
+                                                onClick={() => handleTileUpdate(tile.id)}
+                                            >
+                                                {updatingTile === tile.id ? 'Saving…' : 'Save changes'}
+                                            </Button>
+                                            <Button
+                                                type="button"
+                                                size="sm"
+                                                variant="outline"
+                                                className="border-amber-400/40 text-amber-200"
+                                                disabled={updatingTile === tile.id}
+                                                onClick={() => handleToggleLock(tile)}
+                                            >
+                                                {tile.locked ? 'Unlock' : 'Lock'}
+                                            </Button>
+                                            <Button
+                                                type="button"
+                                                size="sm"
+                                                variant="ghost"
+                                                className="text-rose-300 hover:text-rose-200"
+                                                disabled={removingTile === tile.id}
+                                                onClick={() => handleRemoveTile(tile)}
+                                            >
+                                                {removingTile === tile.id ? 'Removing…' : 'Remove'}
+                                            </Button>
+                                        </div>
+                                    </article>
+                                );
+                            })}
+                        </div>
+                    )}
+                </section>
+            </div>
+        </AppLayout>
+    );
+}

--- a/backend/resources/js/Pages/TileTemplates/Create.tsx
+++ b/backend/resources/js/Pages/TileTemplates/Create.tsx
@@ -1,0 +1,177 @@
+import { Head, Link, useForm } from '@inertiajs/react';
+
+import AppLayout from '@/Layouts/AppLayout';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+
+type TileTemplateCreateProps = {
+    group: { id: number; name: string };
+    worlds: { id: number; name: string }[];
+};
+
+type TileTemplateForm = {
+    name: string;
+    key: string;
+    terrain_type: string;
+    movement_cost: number | string;
+    defense_bonus: number | string;
+    world_id: number | '';
+    image_path: string;
+    edge_profile: string;
+};
+
+export default function TileTemplateCreate({ group, worlds }: TileTemplateCreateProps) {
+    const form = useForm<TileTemplateForm>({
+        name: '',
+        key: '',
+        terrain_type: '',
+        movement_cost: 1,
+        defense_bonus: 0,
+        world_id: '',
+        image_path: '',
+        edge_profile: '',
+    });
+
+    const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        form.post(route('groups.tile-templates.store', group.id));
+    };
+
+    return (
+        <AppLayout>
+            <Head title={`New tile template · ${group.name}`} />
+
+            <div className="mx-auto max-w-3xl">
+                <div className="mb-6 flex items-center justify-between">
+                    <div>
+                        <h1 className="text-2xl font-semibold text-zinc-100">New tile template</h1>
+                        <p className="text-sm text-zinc-400">Define reusable terrain pieces for {group.name}&apos;s maps.</p>
+                    </div>
+                    <Button asChild variant="outline" className="border-zinc-700 text-sm">
+                        <Link href={route('groups.show', group.id)}>Back to group</Link>
+                    </Button>
+                </div>
+
+                <form onSubmit={handleSubmit} className="space-y-6">
+                    <div className="space-y-2">
+                        <Label htmlFor="name">Name</Label>
+                        <Input
+                            id="name"
+                            value={form.data.name}
+                            onChange={(event) => form.setData('name', event.target.value)}
+                            placeholder="Luminous grassland"
+                        />
+                        {form.errors.name && <p className="text-sm text-rose-400">{form.errors.name}</p>}
+                    </div>
+
+                    <div className="grid gap-4 sm:grid-cols-2">
+                        <div className="space-y-2">
+                            <Label htmlFor="key">Key (optional)</Label>
+                            <Input
+                                id="key"
+                                value={form.data.key}
+                                onChange={(event) => form.setData('key', event.target.value)}
+                                placeholder="grass-basic"
+                            />
+                            {form.errors.key && <p className="text-sm text-rose-400">{form.errors.key}</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="terrain_type">Terrain type</Label>
+                            <Input
+                                id="terrain_type"
+                                value={form.data.terrain_type}
+                                onChange={(event) => form.setData('terrain_type', event.target.value)}
+                                placeholder="grassland"
+                            />
+                            {form.errors.terrain_type && <p className="text-sm text-rose-400">{form.errors.terrain_type}</p>}
+                        </div>
+                    </div>
+
+                    <div className="grid gap-4 sm:grid-cols-3">
+                        <div className="space-y-2">
+                            <Label htmlFor="movement_cost">Movement cost</Label>
+                            <Input
+                                id="movement_cost"
+                                type="number"
+                                min={0}
+                                max={20}
+                                value={form.data.movement_cost}
+                                onChange={(event) => form.setData('movement_cost', Number(event.target.value))}
+                            />
+                            {form.errors.movement_cost && <p className="text-sm text-rose-400">{form.errors.movement_cost}</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="defense_bonus">Defense bonus</Label>
+                            <Input
+                                id="defense_bonus"
+                                type="number"
+                                min={0}
+                                max={20}
+                                value={form.data.defense_bonus}
+                                onChange={(event) => form.setData('defense_bonus', Number(event.target.value))}
+                            />
+                            {form.errors.defense_bonus && <p className="text-sm text-rose-400">{form.errors.defense_bonus}</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="world_id">World scope</Label>
+                            <select
+                                id="world_id"
+                                value={form.data.world_id}
+                                onChange={(event) =>
+                                    form.setData('world_id', event.target.value === '' ? '' : Number(event.target.value))
+                                }
+                                className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                            >
+                                <option value="">Shared across worlds</option>
+                                {worlds.map((world) => (
+                                    <option key={world.id} value={world.id}>
+                                        {world.name}
+                                    </option>
+                                ))}
+                            </select>
+                            {form.errors.world_id && <p className="text-sm text-rose-400">{form.errors.world_id}</p>}
+                        </div>
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="image_path">Image path (optional)</Label>
+                        <Input
+                            id="image_path"
+                            value={form.data.image_path}
+                            onChange={(event) => form.setData('image_path', event.target.value)}
+                            placeholder="tiles/grassland.png"
+                        />
+                        {form.errors.image_path && <p className="text-sm text-rose-400">{form.errors.image_path}</p>}
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="edge_profile">Edge profile JSON (optional)</Label>
+                        <Textarea
+                            id="edge_profile"
+                            value={form.data.edge_profile}
+                            onChange={(event) => form.setData('edge_profile', event.target.value)}
+                            placeholder='{"north":"road","south":"road"}'
+                        />
+                        {form.errors.edge_profile && <p className="text-sm text-rose-400">{form.errors.edge_profile}</p>}
+                    </div>
+
+                    <div className="flex items-center gap-3">
+                        <Button type="submit" disabled={form.processing}>
+                            Save template
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            disabled={form.processing}
+                            onClick={() => form.reset()}
+                        >
+                            Reset
+                        </Button>
+                    </div>
+                </form>
+            </div>
+        </AppLayout>
+    );
+}

--- a/backend/resources/js/Pages/TileTemplates/Edit.tsx
+++ b/backend/resources/js/Pages/TileTemplates/Edit.tsx
@@ -1,0 +1,183 @@
+import { Head, Link, useForm } from '@inertiajs/react';
+
+import AppLayout from '@/Layouts/AppLayout';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+
+type TileTemplateEditProps = {
+    group: { id: number; name: string };
+    worlds: { id: number; name: string }[];
+    template: {
+        id: number;
+        name: string;
+        key: string | null;
+        terrain_type: string;
+        movement_cost: number;
+        defense_bonus: number;
+        image_path: string | null;
+        edge_profile: Record<string, unknown> | null;
+        world_id: number | null;
+    };
+};
+
+type TileTemplateForm = {
+    name: string;
+    key: string | null;
+    terrain_type: string;
+    movement_cost: number | string;
+    defense_bonus: number | string;
+    world_id: number | '';
+    image_path: string;
+    edge_profile: string;
+};
+
+export default function TileTemplateEdit({ group, worlds, template }: TileTemplateEditProps) {
+    const form = useForm<TileTemplateForm>({
+        name: template.name,
+        key: template.key ?? '',
+        terrain_type: template.terrain_type,
+        movement_cost: template.movement_cost,
+        defense_bonus: template.defense_bonus,
+        world_id: template.world_id ?? '',
+        image_path: template.image_path ?? '',
+        edge_profile: template.edge_profile ? JSON.stringify(template.edge_profile, null, 2) : '',
+    });
+
+    const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        form.put(route('groups.tile-templates.update', [group.id, template.id]));
+    };
+
+    return (
+        <AppLayout>
+            <Head title={`Edit ${template.name} · ${group.name}`} />
+
+            <div className="mx-auto max-w-3xl">
+                <div className="mb-6 flex items-center justify-between">
+                    <div>
+                        <h1 className="text-2xl font-semibold text-zinc-100">Edit tile template</h1>
+                        <p className="text-sm text-zinc-400">Tune how this tile behaves across {group.name}&apos;s boards.</p>
+                    </div>
+                    <Button asChild variant="outline" className="border-zinc-700 text-sm">
+                        <Link href={route('groups.show', group.id)}>Back to group</Link>
+                    </Button>
+                </div>
+
+                <form onSubmit={handleSubmit} className="space-y-6">
+                    <div className="space-y-2">
+                        <Label htmlFor="name">Name</Label>
+                        <Input
+                            id="name"
+                            value={form.data.name}
+                            onChange={(event) => form.setData('name', event.target.value)}
+                        />
+                        {form.errors.name && <p className="text-sm text-rose-400">{form.errors.name}</p>}
+                    </div>
+
+                    <div className="grid gap-4 sm:grid-cols-2">
+                        <div className="space-y-2">
+                            <Label htmlFor="key">Key (optional)</Label>
+                            <Input
+                                id="key"
+                                value={form.data.key ?? ''}
+                                onChange={(event) => form.setData('key', event.target.value)}
+                            />
+                            {form.errors.key && <p className="text-sm text-rose-400">{form.errors.key}</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="terrain_type">Terrain type</Label>
+                            <Input
+                                id="terrain_type"
+                                value={form.data.terrain_type}
+                                onChange={(event) => form.setData('terrain_type', event.target.value)}
+                            />
+                            {form.errors.terrain_type && <p className="text-sm text-rose-400">{form.errors.terrain_type}</p>}
+                        </div>
+                    </div>
+
+                    <div className="grid gap-4 sm:grid-cols-3">
+                        <div className="space-y-2">
+                            <Label htmlFor="movement_cost">Movement cost</Label>
+                            <Input
+                                id="movement_cost"
+                                type="number"
+                                min={0}
+                                max={20}
+                                value={form.data.movement_cost}
+                                onChange={(event) => form.setData('movement_cost', Number(event.target.value))}
+                            />
+                            {form.errors.movement_cost && <p className="text-sm text-rose-400">{form.errors.movement_cost}</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="defense_bonus">Defense bonus</Label>
+                            <Input
+                                id="defense_bonus"
+                                type="number"
+                                min={0}
+                                max={20}
+                                value={form.data.defense_bonus}
+                                onChange={(event) => form.setData('defense_bonus', Number(event.target.value))}
+                            />
+                            {form.errors.defense_bonus && <p className="text-sm text-rose-400">{form.errors.defense_bonus}</p>}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="world_id">World scope</Label>
+                            <select
+                                id="world_id"
+                                value={form.data.world_id}
+                                onChange={(event) =>
+                                    form.setData('world_id', event.target.value === '' ? '' : Number(event.target.value))
+                                }
+                                className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                            >
+                                <option value="">Shared across worlds</option>
+                                {worlds.map((world) => (
+                                    <option key={world.id} value={world.id}>
+                                        {world.name}
+                                    </option>
+                                ))}
+                            </select>
+                            {form.errors.world_id && <p className="text-sm text-rose-400">{form.errors.world_id}</p>}
+                        </div>
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="image_path">Image path (optional)</Label>
+                        <Input
+                            id="image_path"
+                            value={form.data.image_path}
+                            onChange={(event) => form.setData('image_path', event.target.value)}
+                        />
+                        {form.errors.image_path && <p className="text-sm text-rose-400">{form.errors.image_path}</p>}
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="edge_profile">Edge profile JSON (optional)</Label>
+                        <Textarea
+                            id="edge_profile"
+                            value={form.data.edge_profile}
+                            onChange={(event) => form.setData('edge_profile', event.target.value)}
+                        />
+                        {form.errors.edge_profile && <p className="text-sm text-rose-400">{form.errors.edge_profile}</p>}
+                    </div>
+
+                    <div className="flex items-center gap-3">
+                        <Button type="submit" disabled={form.processing}>
+                            Update template
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            disabled={form.processing}
+                            onClick={() => form.reset()}
+                        >
+                            Reset changes
+                        </Button>
+                    </div>
+                </form>
+            </div>
+        </AppLayout>
+    );
+}

--- a/backend/resources/js/Pages/Worlds/Create.tsx
+++ b/backend/resources/js/Pages/Worlds/Create.tsx
@@ -1,0 +1,113 @@
+import { FormEventHandler } from 'react';
+
+import { Head, Link, useForm } from '@inertiajs/react';
+
+import AppLayout from '@/Layouts/AppLayout';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { InputError } from '@/components/InputError';
+
+type WorldCreateProps = {
+    group: {
+        id: number;
+        name: string;
+    };
+    defaults: {
+        default_turn_duration_hours: number;
+    };
+};
+
+type FormData = {
+    name: string;
+    summary: string;
+    description: string;
+    default_turn_duration_hours: number;
+};
+
+export default function WorldCreate({ group, defaults }: WorldCreateProps) {
+    const { data, setData, post, processing, errors } = useForm<FormData>({
+        name: '',
+        summary: '',
+        description: '',
+        default_turn_duration_hours: defaults.default_turn_duration_hours,
+    });
+
+    const submit: FormEventHandler = (event) => {
+        event.preventDefault();
+        post(route('groups.worlds.store', group.id));
+    };
+
+    return (
+        <AppLayout>
+            <Head title={`Found a world · ${group.name}`} />
+
+            <div className="mb-6">
+                <h1 className="text-3xl font-semibold text-zinc-100">Found a new world</h1>
+                <p className="mt-2 text-sm text-zinc-400">
+                    Sketch the broad strokes of a shared realm and define how quickly its regions tick through turns.
+                </p>
+            </div>
+
+            <form onSubmit={submit} className="space-y-6">
+                <div className="space-y-2">
+                    <Label htmlFor="name">World name</Label>
+                    <Input
+                        id="name"
+                        value={data.name}
+                        onChange={(event) => setData('name', event.target.value)}
+                        required
+                        autoFocus
+                    />
+                    <InputError message={errors.name} />
+                </div>
+
+                <div className="space-y-2">
+                    <Label htmlFor="summary">Summary</Label>
+                    <Input
+                        id="summary"
+                        value={data.summary}
+                        onChange={(event) => setData('summary', event.target.value)}
+                        placeholder="Shared dreamscape of the Sapphire Archive"
+                    />
+                    <InputError message={errors.summary} />
+                </div>
+
+                <div className="space-y-2">
+                    <Label htmlFor="description">Lore notes</Label>
+                    <textarea
+                        id="description"
+                        value={data.description}
+                        onChange={(event) => setData('description', event.target.value)}
+                        className="min-h-[140px] w-full rounded-md border border-zinc-800 bg-zinc-950/70 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                    />
+                    <InputError message={errors.description} />
+                </div>
+
+                <div className="space-y-2">
+                    <Label htmlFor="default_turn_duration_hours">Default turn cadence (hours)</Label>
+                    <Input
+                        id="default_turn_duration_hours"
+                        type="number"
+                        min={1}
+                        max={168}
+                        value={data.default_turn_duration_hours}
+                        onChange={(event) => setData('default_turn_duration_hours', Number(event.target.value))}
+                        required
+                    />
+                    <InputError message={errors.default_turn_duration_hours} />
+                </div>
+
+                <div className="flex items-center justify-between">
+                    <Button type="submit" disabled={processing}>
+                        Create world
+                    </Button>
+
+                    <Link href={route('groups.show', group.id)} className="text-sm text-zinc-400 hover:text-zinc-200">
+                        Cancel
+                    </Link>
+                </div>
+            </form>
+        </AppLayout>
+    );
+}

--- a/backend/resources/js/Pages/Worlds/Edit.tsx
+++ b/backend/resources/js/Pages/Worlds/Edit.tsx
@@ -1,0 +1,117 @@
+import { FormEventHandler } from 'react';
+
+import { Head, Link, useForm } from '@inertiajs/react';
+
+import AppLayout from '@/Layouts/AppLayout';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { InputError } from '@/components/InputError';
+
+type WorldPayload = {
+    id: number;
+    name: string;
+    summary: string | null;
+    description: string | null;
+    default_turn_duration_hours: number;
+};
+
+type WorldEditProps = {
+    group: {
+        id: number;
+        name: string;
+    };
+    world: WorldPayload;
+};
+
+type FormData = {
+    name: string;
+    summary: string;
+    description: string;
+    default_turn_duration_hours: number;
+};
+
+export default function WorldEdit({ group, world }: WorldEditProps) {
+    const { data, setData, put, processing, errors } = useForm<FormData>({
+        name: world.name,
+        summary: world.summary ?? '',
+        description: world.description ?? '',
+        default_turn_duration_hours: world.default_turn_duration_hours,
+    });
+
+    const submit: FormEventHandler = (event) => {
+        event.preventDefault();
+        put(route('groups.worlds.update', [group.id, world.id]));
+    };
+
+    return (
+        <AppLayout>
+            <Head title={`Tend world · ${world.name}`} />
+
+            <div className="mb-6">
+                <h1 className="text-3xl font-semibold text-zinc-100">Tend world</h1>
+                <p className="mt-2 text-sm text-zinc-400">
+                    Refresh lore, adjust pacing defaults, or refine summaries before sharing with your dungeon masters.
+                </p>
+            </div>
+
+            <form onSubmit={submit} className="space-y-6">
+                <div className="space-y-2">
+                    <Label htmlFor="name">World name</Label>
+                    <Input
+                        id="name"
+                        value={data.name}
+                        onChange={(event) => setData('name', event.target.value)}
+                        required
+                    />
+                    <InputError message={errors.name} />
+                </div>
+
+                <div className="space-y-2">
+                    <Label htmlFor="summary">Summary</Label>
+                    <Input
+                        id="summary"
+                        value={data.summary}
+                        onChange={(event) => setData('summary', event.target.value)}
+                    />
+                    <InputError message={errors.summary} />
+                </div>
+
+                <div className="space-y-2">
+                    <Label htmlFor="description">Lore notes</Label>
+                    <textarea
+                        id="description"
+                        value={data.description}
+                        onChange={(event) => setData('description', event.target.value)}
+                        className="min-h-[140px] w-full rounded-md border border-zinc-800 bg-zinc-950/70 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                    />
+                    <InputError message={errors.description} />
+                </div>
+
+                <div className="space-y-2">
+                    <Label htmlFor="default_turn_duration_hours">Default turn cadence (hours)</Label>
+                    <Input
+                        id="default_turn_duration_hours"
+                        type="number"
+                        min={1}
+                        max={168}
+                        value={data.default_turn_duration_hours}
+                        onChange={(event) => setData('default_turn_duration_hours', Number(event.target.value))}
+                        required
+                    />
+                    <InputError message={errors.default_turn_duration_hours} />
+                </div>
+
+                <div className="flex items-center justify-between">
+                    <Button type="submit" disabled={processing}>
+                        Save world
+                    </Button>
+
+                    <Link href={route('groups.show', group.id)} className="text-sm text-zinc-400 hover:text-zinc-200">
+                        Back to group
+                    </Link>
+                </div>
+            </form>
+        </AppLayout>
+    );
+}

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -7,11 +7,17 @@ use App\Http\Controllers\CampaignInvitationController;
 use App\Http\Controllers\CampaignRoleAssignmentController;
 use App\Http\Controllers\DiceRollController;
 use App\Http\Controllers\GroupController;
+use App\Http\Controllers\GroupJoinController;
+use App\Http\Controllers\GroupMembershipController;
 use App\Http\Controllers\InitiativeEntryController;
 use App\Http\Controllers\RegionController;
 use App\Http\Controllers\RegionTurnController;
+use App\Http\Controllers\MapController;
+use App\Http\Controllers\MapTileController;
+use App\Http\Controllers\TileTemplateController;
 use App\Http\Controllers\SessionController;
 use App\Http\Controllers\SessionNoteController;
+use App\Http\Controllers\WorldController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -29,8 +35,25 @@ Route::middleware('guest')->group(function (): void {
 
 Route::middleware('auth')->group(function (): void {
     Route::get('/dashboard', fn () => Inertia::render('Dashboard'))->name('dashboard');
+    Route::get('groups/join', [GroupJoinController::class, 'create'])->name('groups.join');
+    Route::post('groups/join', [GroupJoinController::class, 'store'])->name('groups.join.store');
     Route::resource('groups', GroupController::class);
+    Route::resource('groups.memberships', GroupMembershipController::class)
+        ->only(['store', 'update', 'destroy'])
+        ->scoped();
+    Route::resource('groups.worlds', WorldController::class)
+        ->except(['index', 'show'])
+        ->scoped();
     Route::resource('groups.regions', RegionController::class)->except(['index'])->scoped();
+    Route::resource('groups.tile-templates', TileTemplateController::class)
+        ->except(['index', 'show'])
+        ->scoped();
+    Route::resource('groups.maps', MapController::class)
+        ->except(['index'])
+        ->scoped();
+    Route::resource('groups.maps.tiles', MapTileController::class)
+        ->only(['store', 'update', 'destroy'])
+        ->scoped();
     Route::get('groups/{group}/regions/{region}/turns/create', [RegionTurnController::class, 'create'])->name('groups.regions.turns.create');
     Route::post('groups/{group}/regions/{region}/turns', [RegionTurnController::class, 'store'])->name('groups.regions.turns.store');
     Route::resource('campaigns', CampaignController::class);

--- a/backend/tests/Browser/RegionTurnProcessingTest.php
+++ b/backend/tests/Browser/RegionTurnProcessingTest.php
@@ -5,6 +5,7 @@ namespace Tests\Browser;
 use App\Models\Group;
 use App\Models\GroupMembership;
 use App\Models\Region;
+use App\Models\World;
 use App\Models\User;
 use App\Services\TurnScheduler;
 use Carbon\CarbonImmutable;
@@ -29,7 +30,8 @@ class RegionTurnProcessingTest extends DuskTestCase
             'role' => GroupMembership::ROLE_OWNER,
         ]);
 
-        $region = Region::factory()->for($group)->create(['name' => 'Eldertide Vale']);
+        $world = World::factory()->for($group)->create();
+        $region = Region::factory()->for($group)->for($world)->create(['name' => 'Eldertide Vale']);
 
         app(TurnScheduler::class)->configure($region, 24, CarbonImmutable::now('UTC'));
 

--- a/backend/tests/Feature/CampaignTest.php
+++ b/backend/tests/Feature/CampaignTest.php
@@ -5,6 +5,7 @@ use App\Models\CampaignRoleAssignment;
 use App\Models\Group;
 use App\Models\GroupMembership;
 use App\Models\Region;
+use App\Models\World;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -19,7 +20,8 @@ it('allows group managers to create campaigns', function () {
         'role' => GroupMembership::ROLE_OWNER,
     ]);
 
-    $region = Region::factory()->for($group)->create();
+    $world = World::factory()->for($group)->create();
+    $region = Region::factory()->for($group)->for($world)->create();
 
     $response = $this->actingAs($user)->post(route('campaigns.store'), [
         'group_id' => $group->id,

--- a/backend/tests/Feature/GroupManagementTest.php
+++ b/backend/tests/Feature/GroupManagementTest.php
@@ -1,0 +1,181 @@
+<?php
+
+use App\Models\Group;
+use App\Models\GroupMembership;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('allows owners to invite existing users into the group', function () {
+    $owner = User::factory()->create();
+    $target = User::factory()->create();
+    $group = Group::factory()->for($owner, 'creator')->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $owner->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    $response = $this->actingAs($owner)->post(route('groups.memberships.store', $group), [
+        'email' => $target->email,
+        'role' => GroupMembership::ROLE_DUNGEON_MASTER,
+    ]);
+
+    $response->assertRedirect(route('groups.show', $group));
+
+    $this->assertDatabaseHas('group_memberships', [
+        'group_id' => $group->id,
+        'user_id' => $target->id,
+        'role' => GroupMembership::ROLE_DUNGEON_MASTER,
+    ]);
+});
+
+it('prevents dungeon masters from promoting a member to owner', function () {
+    $owner = User::factory()->create();
+    $dm = User::factory()->create();
+    $target = User::factory()->create();
+
+    $group = Group::factory()->for($owner, 'creator')->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $owner->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    $dmMembership = GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $dm->id,
+        'role' => GroupMembership::ROLE_DUNGEON_MASTER,
+    ]);
+
+    $targetMembership = GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $target->id,
+        'role' => GroupMembership::ROLE_PLAYER,
+    ]);
+
+    $response = $this->actingAs($dm)->patch(route('groups.memberships.update', [$group, $targetMembership]), [
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    $response->assertForbidden();
+
+    $this->assertDatabaseHas('group_memberships', [
+        'id' => $targetMembership->id,
+        'role' => GroupMembership::ROLE_PLAYER,
+    ]);
+    $this->assertDatabaseHas('group_memberships', [
+        'id' => $dmMembership->id,
+        'role' => GroupMembership::ROLE_DUNGEON_MASTER,
+    ]);
+});
+
+it('blocks removing the final owner from the roster', function () {
+    $owner = User::factory()->create();
+    $group = Group::factory()->for($owner, 'creator')->create();
+
+    $ownerMembership = GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $owner->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    $response = $this->actingAs($owner)->delete(route('groups.memberships.destroy', [$group, $ownerMembership]));
+
+    $response->assertSessionHasErrors('membership');
+    $this->assertDatabaseHas('group_memberships', [
+        'id' => $ownerMembership->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+});
+
+it('allows members to leave when another owner remains', function () {
+    $owner = User::factory()->create();
+    $secondOwner = User::factory()->create();
+
+    $group = Group::factory()->for($owner, 'creator')->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $owner->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    $secondMembership = GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $secondOwner->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    $response = $this->actingAs($secondOwner)->delete(route('groups.memberships.destroy', [$group, $secondMembership]));
+
+    $response->assertRedirect(route('groups.index'));
+    $this->assertDatabaseMissing('group_memberships', [
+        'id' => $secondMembership->id,
+    ]);
+});
+
+it('lets adventurers join by code and avoids duplicates', function () {
+    $owner = User::factory()->create();
+    $joiner = User::factory()->create();
+
+    $group = Group::factory()->for($owner, 'creator')->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $owner->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    $joinResponse = $this->actingAs($joiner)->post(route('groups.join.store'), [
+        'code' => strtolower($group->join_code),
+    ]);
+
+    $joinResponse->assertRedirect(route('groups.show', $group));
+
+    $this->assertDatabaseHas('group_memberships', [
+        'group_id' => $group->id,
+        'user_id' => $joiner->id,
+        'role' => GroupMembership::ROLE_PLAYER,
+    ]);
+
+    $repeatResponse = $this->actingAs($joiner)->post(route('groups.join.store'), [
+        'code' => $group->join_code,
+    ]);
+
+    $repeatResponse->assertRedirect(route('groups.show', $group));
+    $this->assertDatabaseCount('group_memberships', 2);
+});
+
+it('prevents players from inviting other members', function () {
+    $owner = User::factory()->create();
+    $player = User::factory()->create();
+    $target = User::factory()->create();
+
+    $group = Group::factory()->for($owner, 'creator')->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $owner->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $player->id,
+        'role' => GroupMembership::ROLE_PLAYER,
+    ]);
+
+    $response = $this->actingAs($player)->post(route('groups.memberships.store', $group), [
+        'email' => $target->email,
+    ]);
+
+    $response->assertForbidden();
+    $this->assertDatabaseMissing('group_memberships', [
+        'group_id' => $group->id,
+        'user_id' => $target->id,
+    ]);
+});

--- a/backend/tests/Feature/MapTileTest.php
+++ b/backend/tests/Feature/MapTileTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use App\Models\Group;
+use App\Models\GroupMembership;
+use App\Models\Map;
+use App\Models\MapTile;
+use App\Models\TileTemplate;
+use App\Models\User;
+use App\Models\World;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function createGroupWithOwner(): array
+{
+    $owner = User::factory()->create();
+    $group = Group::factory()->for($owner, 'creator')->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $owner->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    return [$group, $owner];
+}
+
+it('enforces unique coordinates per map', function () {
+    [$group, $owner] = createGroupWithOwner();
+    $world = World::factory()->for($group)->create();
+    $region = \App\Models\Region::factory()->for($world)->create();
+    $map = Map::factory()->for($group)->for($region)->create();
+    $template = TileTemplate::factory()->for($group)->create();
+
+    $first = $this->actingAs($owner)->post(route('groups.maps.tiles.store', [$group, $map]), [
+        'tile_template_id' => $template->id,
+        'q' => 1,
+        'r' => 2,
+        'elevation' => 0,
+    ]);
+
+    $first->assertRedirect(route('groups.maps.show', [$group, $map]));
+
+    $second = $this->actingAs($owner)->post(route('groups.maps.tiles.store', [$group, $map]), [
+        'tile_template_id' => $template->id,
+        'q' => 1,
+        'r' => 2,
+        'elevation' => 1,
+    ]);
+
+    $second->assertStatus(422);
+    $this->assertDatabaseCount('map_tiles', 1);
+});
+
+it('rejects tile placements using templates from another group', function () {
+    [$group, $owner] = createGroupWithOwner();
+    $world = World::factory()->for($group)->create();
+    $region = \App\Models\Region::factory()->for($world)->create();
+    $map = Map::factory()->for($group)->for($region)->create();
+
+    $foreignTemplate = TileTemplate::factory()->create();
+
+    $response = $this->actingAs($owner)->post(route('groups.maps.tiles.store', [$group, $map]), [
+        'tile_template_id' => $foreignTemplate->id,
+        'q' => 0,
+        'r' => 0,
+    ]);
+
+    $response->assertSessionHasErrors('tile_template_id');
+});
+
+it('allows owners to toggle lock state on tiles', function () {
+    [$group, $owner] = createGroupWithOwner();
+    $world = World::factory()->for($group)->create();
+    $region = \App\Models\Region::factory()->for($world)->create();
+    $map = Map::factory()->for($group)->for($region)->create();
+    $template = TileTemplate::factory()->for($group)->create();
+
+    $tile = MapTile::factory()->for($map)->for($template, 'tileTemplate')->create([
+        'locked' => false,
+    ]);
+
+    expect($tile->map_id)->toBe($map->id);
+    expect($owner->can('update', $tile))->toBeTrue();
+
+    $response = $this->actingAs($owner)->patch(route('groups.maps.tiles.update', [$group->id, $map->id, $tile->id]), [
+        'locked' => true,
+    ]);
+
+    $response->assertRedirect(route('groups.maps.show', [$group, $map]));
+    $this->assertDatabaseHas('map_tiles', [
+        'id' => $tile->id,
+        'locked' => true,
+    ]);
+});
+
+it('allows dungeon masters to update tile metadata', function () {
+    [$group, $owner] = createGroupWithOwner();
+    $dm = User::factory()->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $dm->id,
+        'role' => GroupMembership::ROLE_DUNGEON_MASTER,
+    ]);
+
+    $world = World::factory()->for($group)->create();
+    $region = \App\Models\Region::factory()->for($world)->create();
+    $map = Map::factory()->for($group)->for($region)->create();
+
+    $templateA = TileTemplate::factory()->for($group)->create();
+    $templateB = TileTemplate::factory()->for($group)->create();
+
+    $tile = MapTile::factory()->for($map)->for($templateA, 'tileTemplate')->create([
+        'q' => -1,
+        'r' => 0,
+        'elevation' => 0,
+        'locked' => false,
+    ]);
+
+    expect($tile->map_id)->toBe($map->id);
+    expect($dm->can('update', $tile))->toBeTrue();
+
+    $response = $this->actingAs($dm)->patch(route('groups.maps.tiles.update', [$group->id, $map->id, $tile->id]), [
+        'tile_template_id' => $templateB->id,
+        'elevation' => 3,
+        'variant' => json_encode(['hazard' => 'acid fog']),
+    ]);
+
+    $response->assertRedirect(route('groups.maps.show', [$group, $map]));
+
+    $this->assertDatabaseHas('map_tiles', [
+        'id' => $tile->id,
+        'tile_template_id' => $templateB->id,
+        'elevation' => 3,
+    ]);
+});

--- a/backend/tests/Feature/TileTemplateTest.php
+++ b/backend/tests/Feature/TileTemplateTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use App\Models\Group;
+use App\Models\GroupMembership;
+use App\Models\Map;
+use App\Models\MapTile;
+use App\Models\TileTemplate;
+use App\Models\User;
+use App\Models\World;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('allows dungeon masters to create tile templates for their group', function () {
+    $owner = User::factory()->create();
+    $dm = User::factory()->create();
+    $group = Group::factory()->for($owner, 'creator')->create();
+    $world = World::factory()->for($group)->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $owner->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $dm->id,
+        'role' => GroupMembership::ROLE_DUNGEON_MASTER,
+    ]);
+
+    $response = $this->actingAs($dm)->post(route('groups.tile-templates.store', $group), [
+        'name' => 'Crystal Plains',
+        'key' => 'crystal-plains',
+        'terrain_type' => 'crystal',
+        'movement_cost' => 2,
+        'defense_bonus' => 1,
+        'world_id' => $world->id,
+        'edge_profile' => json_encode(['north' => 'road']),
+    ]);
+
+    $response->assertRedirect(route('groups.show', $group));
+
+    $this->assertDatabaseHas('tile_templates', [
+        'group_id' => $group->id,
+        'name' => 'Crystal Plains',
+        'world_id' => $world->id,
+    ]);
+});
+
+it('prevents deleting tile templates that are still referenced by tiles', function () {
+    $owner = User::factory()->create();
+    $group = Group::factory()->for($owner, 'creator')->create();
+    $region = \App\Models\Region::factory()->for($group)->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $owner->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    $template = TileTemplate::factory()->for($group)->create([
+        'world_id' => null,
+    ]);
+
+    $map = Map::factory()->for($group)->for($region)->create();
+    MapTile::factory()->for($map)->for($template, 'tileTemplate')->create([
+        'q' => 0,
+        'r' => 0,
+    ]);
+
+    $response = $this->actingAs($owner)->delete(route('groups.tile-templates.destroy', [$group, $template]));
+
+    $response->assertStatus(422);
+    $this->assertDatabaseHas('tile_templates', ['id' => $template->id]);
+});
+
+it('allows owners to delete unused tile templates', function () {
+    $owner = User::factory()->create();
+    $group = Group::factory()->for($owner, 'creator')->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $owner->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    $template = TileTemplate::factory()->for($group)->create();
+
+    $response = $this->actingAs($owner)->delete(route('groups.tile-templates.destroy', [$group, $template]));
+
+    $response->assertRedirect(route('groups.show', $group));
+    $this->assertDatabaseMissing('tile_templates', ['id' => $template->id]);
+});
+
+it('blocks dungeon masters from deleting templates directly', function () {
+    $owner = User::factory()->create();
+    $dm = User::factory()->create();
+    $group = Group::factory()->for($owner, 'creator')->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $owner->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $dm->id,
+        'role' => GroupMembership::ROLE_DUNGEON_MASTER,
+    ]);
+
+    $template = TileTemplate::factory()->for($group)->create();
+
+    $response = $this->actingAs($dm)->delete(route('groups.tile-templates.destroy', [$group, $template]));
+
+    $response->assertForbidden();
+    $this->assertDatabaseHas('tile_templates', ['id' => $template->id]);
+});

--- a/backend/tests/Feature/TurnProcessingTest.php
+++ b/backend/tests/Feature/TurnProcessingTest.php
@@ -5,6 +5,7 @@ use App\Models\GroupMembership;
 use App\Models\Region;
 use App\Models\Turn;
 use App\Models\User;
+use App\Models\World;
 use App\Services\TurnScheduler;
 use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -21,7 +22,8 @@ it('allows authorized managers to process region turns', function () {
         'role' => GroupMembership::ROLE_OWNER,
     ]);
 
-    $region = Region::factory()->for($group)->create();
+    $world = World::factory()->for($group)->create();
+    $region = Region::factory()->for($group)->for($world)->create();
 
     app(TurnScheduler::class)->configure($region, 24, CarbonImmutable::now('UTC'));
 
@@ -52,7 +54,8 @@ it('supports ai fallback when no summary is provided', function () {
         'role' => GroupMembership::ROLE_OWNER,
     ]);
 
-    $region = Region::factory()->for($group)->create();
+    $world = World::factory()->for($group)->create();
+    $region = Region::factory()->for($group)->for($world)->create();
 
     app(TurnScheduler::class)->configure($region, 6, CarbonImmutable::now('UTC'));
 
@@ -84,7 +87,8 @@ it('prevents players from processing region turns', function () {
         'role' => GroupMembership::ROLE_PLAYER,
     ]);
 
-    $region = Region::factory()->for($group)->create();
+    $world = World::factory()->for($group)->create();
+    $region = Region::factory()->for($group)->for($world)->create();
 
     app(TurnScheduler::class)->configure($region, 24, CarbonImmutable::now('UTC'));
 

--- a/backend/tests/Feature/WorldManagementTest.php
+++ b/backend/tests/Feature/WorldManagementTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use App\Models\Group;
+use App\Models\GroupMembership;
+use App\Models\Region;
+use App\Models\User;
+use App\Models\World;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('allows owners to create worlds for their group', function () {
+    $owner = User::factory()->create();
+    $group = Group::factory()->for($owner, 'creator')->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $owner->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    $response = $this->actingAs($owner)->post(route('groups.worlds.store', $group), [
+        'name' => 'Eclipsed Horizons',
+        'summary' => 'Fragments of moonlight stitched into a sea of stars.',
+        'description' => 'An interwoven realm curated by the Dawnstriders.',
+        'default_turn_duration_hours' => 24,
+    ]);
+
+    $response->assertRedirect(route('groups.show', $group));
+
+    $this->assertDatabaseHas('worlds', [
+        'group_id' => $group->id,
+        'name' => 'Eclipsed Horizons',
+        'default_turn_duration_hours' => 24,
+    ]);
+});
+
+it('allows dungeon masters to update world metadata', function () {
+    $owner = User::factory()->create();
+    $dm = User::factory()->create();
+    $group = Group::factory()->for($owner, 'creator')->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $owner->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $dm->id,
+        'role' => GroupMembership::ROLE_DUNGEON_MASTER,
+    ]);
+
+    $world = World::factory()->for($group)->create([
+        'name' => 'Crimson Meridian',
+        'default_turn_duration_hours' => 12,
+    ]);
+
+    $response = $this->actingAs($dm)->put(route('groups.worlds.update', [$group, $world]), [
+        'name' => 'Crimson Meridian',
+        'summary' => 'Sunswept ley-lines spanning the frontier.',
+        'description' => 'New lore etched by the DM council.',
+        'default_turn_duration_hours' => 18,
+    ]);
+
+    $response->assertRedirect(route('groups.show', $group));
+
+    $this->assertDatabaseHas('worlds', [
+        'id' => $world->id,
+        'default_turn_duration_hours' => 18,
+        'summary' => 'Sunswept ley-lines spanning the frontier.',
+    ]);
+});
+
+it('blocks deleting worlds that still have regions', function () {
+    $owner = User::factory()->create();
+    $group = Group::factory()->for($owner, 'creator')->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $owner->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    $world = World::factory()->for($group)->create();
+    Region::factory()->for($group)->for($world)->create();
+
+    $response = $this->actingAs($owner)->delete(route('groups.worlds.destroy', [$group, $world]));
+
+    $response->assertStatus(422);
+    $this->assertDatabaseHas('worlds', ['id' => $world->id]);
+});
+
+it('allows owners to delete empty worlds', function () {
+    $owner = User::factory()->create();
+    $group = Group::factory()->for($owner, 'creator')->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $owner->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    $world = World::factory()->for($group)->create();
+
+    $response = $this->actingAs($owner)->delete(route('groups.worlds.destroy', [$group, $world]));
+
+    $response->assertRedirect(route('groups.show', $group));
+    $this->assertDatabaseMissing('worlds', ['id' => $world->id]);
+});
+
+it('requires regions to target a world that belongs to the group', function () {
+    $owner = User::factory()->create();
+    $group = Group::factory()->for($owner, 'creator')->create();
+    $otherGroup = Group::factory()->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $owner->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    $foreignWorld = World::factory()->for($otherGroup)->create();
+
+    $response = $this->actingAs($owner)->post(route('groups.regions.store', $group), [
+        'name' => 'Borrowed Vale',
+        'summary' => 'Illicit region attempt.',
+        'description' => 'Should not be created.',
+        'world_id' => $foreignWorld->id,
+        'turn_duration_hours' => 24,
+    ]);
+
+    $response->assertNotFound();
+    $this->assertDatabaseMissing('regions', ['name' => 'Borrowed Vale']);
+});


### PR DESCRIPTION
## Summary
- introduce map, tile template, and map tile models with migrations, policies, requests, and controllers for group-scoped hex map management
- extend group dashboards and add dedicated Inertia views so parties can curate tile templates, create maps, and manage tiles with locking and template swaps
- add Pest feature coverage plus task documentation updates to capture modular tile map workflows and edge cases

## Testing
- ./vendor/bin/pest

------
https://chatgpt.com/codex/tasks/task_e_68ee92eedd348332aa6e5c91008425a3