### PR TITLE
Add campaign lore codex with tagging filters

### DIFF
--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -20,5 +20,9 @@
 | 2025-10-18 09:45 | Realtime Collaboration | Integrated Laravel Reverb websockets, broadcasting session workspace updates and live map tile edits with Echo-powered UI syncing. |
 | 2025-10-18 13:10 | Task Board Workflow | Delivered campaign Kanban board with turn-based due dates, assignment controls, and priority reordering backed by authorization and tests. |
 | 2025-10-19 10:20 | AI Services | Connected Ollama Gemma3 for turn summaries, AI DM delegation, and the session NPC guide with logged requests and coverage. |
+| 2025-10-20 09:15 | Search Infrastructure | Implemented scoped global search across campaigns, sessions, notes, and tasks with authorization-aware filtering and coverage. |
+| 2025-10-20 17:40 | Session Exports & Vault | Added Markdown/PDF session exports, Inertia UI download controls, and managed recording uploads with authorization-aware storage. |
+| 2025-10-21 11:10 | Accessibility & Localization | Delivered user preference persistence, localized navigation, adjustable theming, and accessibility enhancements with coverage. |
+| 2025-10-22 10:20 | Lore Codex & Tags | Shipped campaign lore entities with tagging, filters, stat blocks, dashboard highlights, and Pest coverage for the new codex workflows. |
 
 > Update this log as features move from backlog to completion. Keep entries in UTC and 24-hour time.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,19 @@ Build a collaborative, browser-based Dungeon & Dragons campaign platform for dis
 - Collaborative notes support GM/player/public visibility with pinning controls, while dice rolls are logged through a deterministic `DiceRoller` service that evaluates `NdM±X` expressions.
 - Initiative entries track combat order with auto-rolling support and “current turn” toggles so parties can manage encounters without leaving the workspace.
 - Inertia pages provide a session index, scheduling form, and rich workspace view with note editor, dice log, and initiative board styled for the project’s D&D aesthetic.
+- Session workspace exports campaigns to Markdown/PDF and lets managers upload or remove stored recordings alongside external links.
 - Pest feature coverage exercises session CRUD, note permissions, dice logging, and initiative management; a Dusk scenario walks through scheduling a session and collaborating in the workspace UI.
+
+## Lore Codex
+- Campaign managers can chronicle characters, NPCs, monsters, relics, and locations in a dedicated lore codex with stat blocks, pronouncing guides, and visibility controls (GM, party, public).
+- Tags provide quick filtering by arc, faction, or motif. The codex index supports search, type filters, and tag chips so facilitators can focus on exactly the lore they need.
+- The campaign dashboard now surfaces total codex entries and the three most recent lore updates for rapid prep navigation.
+- Lore entries support Markdown descriptions, initiative defaults, and AI-controlled flags so automation hooks stay aware of the story world.
+
+## Accessibility & Localization
+- Player and GM experiences support English and Romanian translations. Navigation strings, preference forms, and layout chrome resolve through the shared `resources/lang/{locale}` dictionaries.
+- Authenticated users can visit **Preferences** to adjust language, timezone, theme (system, midnight dark, dawn light), font scale, and high-contrast focus outlines. Settings persist to the `users` table and cascade through middleware so PHP, Inertia, and Tailwind share the same configuration.
+- The global layout now includes skip links, adaptive theming, and high-contrast focus rings that meet WCAG contrast recommendations. Font scaling modifies the root size to assist low-vision players without breaking layout density.
 
 ## Architectural Choice
 **Laravel + Inertia React Monolith**: Recommended after weighing feedback from Laravel and React experts.
@@ -283,6 +295,7 @@ Shared components: `TurnCountdown`, `RegionSelector`, `GroupInviteForm`, `AIStat
 - Additional tests for `2d20kh1+5`, `3d10!`, `1d100rr1`.
 
 ## Search & Filters
+- `/search` provides a scoped global lookup across campaigns, sessions, notes, and tasks the user can access, with toggleable scopes and contextual metadata for quick navigation.
 - Full-text indexes on `campaign_entities`, `notes`, `tasks`.
 - Add composite indexes for `turns (campaign_id, processed_at)`, `sessions (campaign_id, session_date)`, `regions (world_id, status)`.
 - Add unique index `map_tiles (map_id, q, r)` to enforce snap grid and accelerate tile lookups.

--- a/TASK_PLAN.md
+++ b/TASK_PLAN.md
@@ -8,9 +8,9 @@
 - [x] Integrate Laravel Reverb for realtime initiative, chat, map tokens.
 - [x] Build task board with turn-based due dates and Kanban UI.
 - [x] Implement AI services (Ollama Gemma3) for NPC and DM takeover workflows.
-- [ ] Add search/filter infrastructure across entities, tasks, notes.
-- [ ] Implement exports (Markdown/PDF) and session recording storage.
-- [ ] Finalize localization, accessibility, theming, and docs.
+- [x] Add search/filter infrastructure across entities, tasks, notes.
+- [x] Implement exports (Markdown/PDF) and session recording storage.
+- [x] Finalize localization, accessibility, theming, and docs.
 
 ## In Progress
 - _None_
@@ -30,3 +30,8 @@
 - Task 11 – Realtime Collaboration (Laravel Reverb broadcasting with Echo-powered session and map syncing)
 - Task 12 – Task Board Workflow (campaign Kanban lanes, turn due dates, assignments, and ordering controls)
 - Task 13 – AI Services (Ollama Gemma3 region delegation, NPC guide, and turn narration)
+- Task 14 – Global Search (campaign/session/task/note discovery with scoped filters)
+- Task 15 – Session Exports & Recording Vault (Markdown/PDF exports, recording storage UX)
+- Task 16 – Accessibility, Localization & Theming Polish (user preference middleware, localized UI shell, accessibility pass)
+- Task 17 – Lore Codex (campaign entity CRUD, codex pages, dashboard integration)
+- Task 18 – Lore Tags & Quick Reference (tagging, filters, codex summary highlights)

--- a/Tasks/Week 1/Task 14 - Global Search.md
+++ b/Tasks/Week 1/Task 14 - Global Search.md
@@ -1,0 +1,28 @@
+# Task 14 – Global Search & Filters
+
+**Status:** Completed
+**Owner:** Engineering
+**Dependencies:** Task 4, Task 6, Task 12
+**Related Backlog Items:** Add search/filter infrastructure across entities, tasks, notes.
+
+## Intent
+Deliver a unified search experience so storytellers can quickly find campaigns, sessions, tasks, and notes they have access to.
+Search must respect campaign membership and role assignments, expose scoped filters, and surface enough context for users to
+decide where to jump next.
+
+## Subtasks
+- [x] Draft authorization-aware queries spanning campaigns, sessions, notes, and tasks.
+- [x] Build a dedicated `GlobalSearchService` with scope normalization and GM-note protections.
+- [x] Expose a new Inertia search page with scope filters, contextual metadata, and navigation links.
+- [x] Wire up form request validation and routing within the authenticated shell.
+- [x] Cover service behavior for accessible resources and GM-only visibility via Pest tests.
+- [x] Update progress artifacts to reflect delivery.
+
+## Notes
+- Scopes default to all record types but persist selections through Inertia state to encourage iterative filtering.
+- GM-only notes only display to campaign managers (owners/DMs/assigned GMs) so secrets stay hidden from players.
+- Result cards include direct navigation buttons to preserve pacing when moving between sessions and task boards mid-play.
+
+## Log
+- 2025-10-19 18:45 UTC – Planned global search aggregation strategy, identified visibility constraints, and outlined service API.
+- 2025-10-20 09:15 UTC – Implemented search service, controller, Inertia UI, and Pest coverage; refreshed docs and logs.

--- a/Tasks/Week 1/Task 15 - Session Exports.md
+++ b/Tasks/Week 1/Task 15 - Session Exports.md
@@ -1,0 +1,26 @@
+# Task 15 – Session Exports & Recording Vault
+
+**Status:** Completed
+**Owner:** Engineering
+**Dependencies:** Task 6 (Session Workspace), Task 10 (Milestone Demo Flow)
+**Related Backlog Items:** Implement exports (Markdown/PDF) and session recording storage.
+
+## Intent
+Deliver archival tooling for campaign sessions so facilitators can preserve complete recaps, share transcripts, and stash audiovisual recordings. Ship Markdown/PDF exports that respect visibility rules, and add first-party storage for uploaded recordings alongside existing external links.
+
+## Subtasks
+- [x] Outline export data contract, visibility behavior, and storage UX updates.
+- [x] Implement backend service + routes that generate Markdown and PDF exports for authorized viewers.
+- [x] Extend Inertia session workspace UI with export actions and recording management controls.
+- [x] Add recording upload/removal endpoints with durable storage and validation.
+- [x] Cover exports and recording flows with Pest feature tests.
+- [x] Update progress artifacts after delivery.
+
+## Notes
+- Exports must stay in UTC and include agenda, summary, notes (filtered), dice rolls, initiative order, and AI dialogue highlights.
+- GM-only notes only appear for managers; player exports omit them automatically.
+- Store recordings on the `public` disk under `session-recordings/` using generated filenames; purge prior uploads on replacement.
+
+## Log
+- 2025-10-20 16:55 UTC – Finalized export payload contract and recording UX, aligning Inertia controls with authorization rules.
+- 2025-10-20 17:35 UTC – Implemented Markdown/PDF exports, recording vault endpoints, UI hooks, and automated coverage.

--- a/Tasks/Week 1/Task 16 - Accessibility & Localization.md
+++ b/Tasks/Week 1/Task 16 - Accessibility & Localization.md
@@ -1,0 +1,25 @@
+# Task 16 – Accessibility, Localization & Theming Polish
+
+**Status:** Completed
+**Owner:** Engineering
+**Dependencies:** Task 6 (Session Workspace), Task 14 (Global Search)
+**Related Backlog Items:** Finalize localization, accessibility, theming, and docs.
+
+## Intent
+Complete the first sprint accessibility and localization objectives so the platform supports multiple languages, adjustable appearance, and inclusive focus handling. Ship persistent user preferences for language, timezone, theme, font scale, and high-contrast outlines while updating the shared UI shell and documentation to reflect the enhancements.
+
+## Subtasks
+- [x] Draft accessibility/localization plan and capture acceptance criteria in this task file.
+- [x] Add persistent user preference fields, middleware, and validation for locale, timezone, theme, contrast, and font scale.
+- [x] Update the Inertia layout with translation support, skip links, theme toggles, and high-contrast focus states.
+- [x] Build a dedicated accessibility & appearance settings page with localized copy and Pest coverage.
+- [x] Refresh documentation and progress trackers to note the new capabilities.
+
+## Notes
+- Localization launches with English and Romanian; translation keys live under `resources/lang/{locale}/app.php`.
+- User preferences default to system theme, dark/light options respect OS settings when applicable, and timezone changes propagate to PHP runtime configuration for consistent scheduling.
+- High-contrast mode reinforces focus visibility with amber outlines that meet WCAG contrast ratios.
+
+## Log
+- 2025-10-21 08:40 UTC – Outlined preference schema, middleware hooks, translation needs, and accessibility targets.
+- 2025-10-21 11:10 UTC – Implemented preference persistence, layout theming, localization utilities, settings UI, tests, and documentation updates.

--- a/Tasks/Week 1/Task 17 - Lore Codex.md
+++ b/Tasks/Week 1/Task 17 - Lore Codex.md
@@ -1,0 +1,25 @@
+# Task 17 – Lore Codex
+
+**Status:** Completed
+**Owner:** Engineering
+**Dependencies:** Task 4 (Campaign Management), Task 6 (Session Workspace)
+**Related Backlog Items:** Campaign entity codex & lore surfacing
+
+## Intent
+Introduce a campaign-level lore codex that lets facilitators chronicle characters, NPCs, monsters, relics, and locations tied to a campaign. Provide CRUD workflows, authorization, and Inertia pages so managers can curate lore while players can browse entries that match their permissions.
+
+## Subtasks
+- [x] Design the campaign entity schema, model, policy, and migrations.
+- [x] Implement controller actions, routes, and validation requests for managing codex entries.
+- [x] Build Inertia pages for listing, viewing, creating, and editing lore entries with stat block editors.
+- [x] Wire codex access into the campaign dashboard with recent-entry highlights.
+- [x] Cover entity lifecycle behaviours with Pest feature tests.
+
+## Notes
+- Campaign entities support five archetypes (character, npc, monster, item, location) with configurable visibility levels (GM, party, public).
+- Stat blocks store structured label/value pairs for quick initiative or encounter reference.
+- The policy leans on campaign authorization so only managers can create/update while members can browse per visibility rules.
+
+## Log
+- 2025-10-22 07:40 UTC – Finalized schema/UX plan for the lore codex, drafted migration and UI checklist.
+- 2025-10-22 10:20 UTC – Delivered migrations, controller, Inertia pages, dashboard integration, and tests.

--- a/Tasks/Week 1/Task 18 - Lore Tags & Quick Reference.md
+++ b/Tasks/Week 1/Task 18 - Lore Tags & Quick Reference.md
@@ -1,0 +1,25 @@
+# Task 18 – Lore Tags & Quick Reference
+
+**Status:** Completed
+**Owner:** Engineering
+**Dependencies:** Task 17 (Lore Codex)
+**Related Backlog Items:** Lore discovery aids & dashboard summaries
+
+## Intent
+Enhance the lore codex with thematic tagging, filtering, and quick-reference surfacing. Allow managers to curate reusable tags, filter entities by type or tag, and surface recent lore on the campaign dashboard so facilitators can jump into the right context during prep and play.
+
+## Subtasks
+- [x] Add tag and pivot migrations plus Tag model relationships for campaign entities.
+- [x] Extend codex controllers and requests to normalize tags, auto-create colors, and sync assignments on create/update.
+- [x] Upgrade index page with search, type and tag filters, chips, and tag editing widgets in create/edit flows.
+- [x] Surface a lore codex summary and recent entries on the campaign overview with quick navigation.
+- [x] Expand Pest coverage for tag syncing, authorization, and filtering behaviours.
+
+## Notes
+- Tag colors derive deterministically from the label hash so palettes stay consistent without manual styling.
+- Lore filters use GET params to support shareable codex views and keep Inertia state in sync with search inputs.
+- The campaign dashboard now shows counts and recent lore entries to highlight prep hotspots.
+
+## Log
+- 2025-10-22 08:30 UTC – Planned tagging UX, dashboard summary, and test coverage requirements.
+- 2025-10-22 10:20 UTC – Implemented tag models, filters, UI enhancements, dashboard summaries, and tests.

--- a/backend/app/Http/Controllers/CampaignController.php
+++ b/backend/app/Http/Controllers/CampaignController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\CampaignStoreRequest;
 use App\Http\Requests\CampaignUpdateRequest;
 use App\Models\Campaign;
 use App\Models\CampaignRoleAssignment;
+use App\Models\CampaignEntity;
 use App\Models\Group;
 use App\Models\GroupMembership;
 use App\Models\Region;
@@ -169,6 +170,18 @@ class CampaignController extends Controller
             'roleAssignments.assignee',
         ]);
 
+        $entityCount = $campaign->entities()->count();
+        $recentEntities = $campaign->entities()
+            ->latest()
+            ->take(3)
+            ->get(['id', 'name', 'entity_type'])
+            ->map(fn (CampaignEntity $entity) => [
+                'id' => $entity->id,
+                'name' => $entity->name,
+                'entity_type' => $entity->entity_type,
+            ])
+            ->values();
+
         $members = $campaign->group->memberships->map(fn (GroupMembership $membership) => [
             'id' => $membership->user->id,
             'name' => $membership->user->name,
@@ -232,6 +245,8 @@ class CampaignController extends Controller
                 'members' => $members,
                 'assignments' => $assignments,
                 'invitations' => $invitations,
+                'entities_count' => $entityCount,
+                'recent_entities' => $recentEntities,
             ],
             'available_roles' => CampaignRoleAssignment::roles(),
             'available_statuses' => Campaign::statuses(),

--- a/backend/app/Http/Controllers/CampaignEntityController.php
+++ b/backend/app/Http/Controllers/CampaignEntityController.php
@@ -1,0 +1,431 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\CampaignEntityStoreRequest;
+use App\Http\Requests\CampaignEntityUpdateRequest;
+use App\Models\Campaign;
+use App\Models\CampaignEntity;
+use App\Models\GroupMembership;
+use App\Models\Tag;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class CampaignEntityController extends Controller
+{
+    public function index(Request $request, Campaign $campaign): Response
+    {
+        $campaign->load('group');
+        $this->authorize('viewAny', [CampaignEntity::class, $campaign]);
+
+        $entities = CampaignEntity::query()
+            ->forCampaign($campaign)
+            ->with(['group:id,name', 'owner:id,name', 'tags:id,label,slug,color'])
+            ->when($request->string('search')->isNotEmpty(), function (Builder $builder) use ($request): void {
+                $term = $request->string('search')->toString();
+                $builder->where(function (Builder $query) use ($term): void {
+                    $query->where('name', 'like', "%{$term}%")
+                        ->orWhere('alias', 'like', "%{$term}%")
+                        ->orWhere('description', 'like', "%{$term}%");
+                });
+            })
+            ->when($request->string('type')->isNotEmpty(), function (Builder $builder) use ($request): void {
+                $builder->where('entity_type', $request->string('type')->toString());
+            })
+            ->when($request->string('tag')->isNotEmpty(), function (Builder $builder) use ($request): void {
+                $builder->whereHas('tags', function (Builder $tagQuery) use ($request): void {
+                    $tagQuery->where('slug', $request->string('tag')->toString());
+                });
+            })
+            ->orderBy('name')
+            ->get()
+            ->map(fn (CampaignEntity $entity) => [
+                'id' => $entity->id,
+                'name' => $entity->name,
+                'entity_type' => $entity->entity_type,
+                'alias' => $entity->alias,
+                'visibility' => $entity->visibility,
+                'ai_controlled' => $entity->ai_controlled,
+                'tags' => $entity->tags->map(fn (Tag $tag) => [
+                    'id' => $tag->id,
+                    'label' => $tag->label,
+                    'slug' => $tag->slug,
+                    'color' => $tag->color,
+                ])->values(),
+                'owner' => $entity->owner?->only(['id', 'name']),
+            ])
+            ->values();
+
+        $filters = [
+            'search' => $request->string('search')->toString(),
+            'type' => $request->string('type')->toString(),
+            'tag' => $request->string('tag')->toString(),
+        ];
+
+        $availableTags = $campaign->tags()
+            ->orderBy('label')
+            ->get()
+            ->map(fn (Tag $tag) => [
+                'id' => $tag->id,
+                'label' => $tag->label,
+                'slug' => $tag->slug,
+                'color' => $tag->color,
+            ]);
+
+        return Inertia::render('CampaignEntities/Index', [
+            'campaign' => [
+                'id' => $campaign->id,
+                'title' => $campaign->title,
+                'group' => [
+                    'id' => $campaign->group->id,
+                    'name' => $campaign->group->name,
+                ],
+            ],
+            'entities' => $entities,
+            'filters' => $filters,
+            'available_types' => CampaignEntity::types(),
+            'available_tags' => $availableTags,
+        ]);
+    }
+
+    public function create(Campaign $campaign): Response
+    {
+        $campaign->load('group.memberships.user');
+        $this->authorize('create', [CampaignEntity::class, $campaign]);
+
+        return Inertia::render('CampaignEntities/Create', [
+            'campaign' => [
+                'id' => $campaign->id,
+                'title' => $campaign->title,
+            ],
+            'available_types' => CampaignEntity::types(),
+            'visibility_options' => CampaignEntity::visibilities(),
+            'available_tags' => $campaign->tags()
+                ->orderBy('label')
+                ->get()
+                ->map(fn (Tag $tag) => [
+                    'id' => $tag->id,
+                    'label' => $tag->label,
+                    'slug' => $tag->slug,
+                ]),
+            'group' => [
+                'id' => $campaign->group->id,
+                'name' => $campaign->group->name,
+            ],
+            'members' => $campaign->group->memberships
+                ->map(fn (GroupMembership $membership) => [
+                    'id' => $membership->user->id,
+                    'name' => $membership->user->name,
+                ])
+                ->values(),
+        ]);
+    }
+
+    public function store(CampaignEntityStoreRequest $request, Campaign $campaign): RedirectResponse
+    {
+        $campaign->load('group.memberships');
+        $this->authorize('create', [CampaignEntity::class, $campaign]);
+
+        $data = $request->validatedEntityData();
+        $data['campaign_id'] = $campaign->id;
+        $data['group_id'] = $this->resolveGroupId($campaign, Arr::get($data, 'group_id'));
+        $data['owner_id'] = $this->resolveOwnerId($campaign, Arr::get($data, 'owner_id'));
+        $data['initiative_default'] = $this->normalizeNullableInteger(Arr::get($data, 'initiative_default'));
+        $data['visibility'] = $data['visibility'] ?? CampaignEntity::VISIBILITY_PLAYERS;
+        $data['slug'] = $this->generateUniqueSlug($campaign, $data['name']);
+        $data['stats'] = $this->filterStats($data['stats'] ?? []);
+
+        $entity = CampaignEntity::create($data);
+
+        $this->syncTags($campaign, $entity, $request->tagNames());
+
+        return redirect()
+            ->route('campaigns.entities.show', [$campaign, $entity])
+            ->with('success', 'Lore entry recorded.');
+    }
+
+    public function show(Campaign $campaign, CampaignEntity $entity): Response
+    {
+        $campaign->load('group');
+        $this->ensureCampaignContext($campaign, $entity);
+        $this->authorize('view', $entity);
+
+        $entity->load(['group:id,name', 'owner:id,name', 'tags:id,label,slug,color']);
+
+        return Inertia::render('CampaignEntities/Show', [
+            'campaign' => [
+                'id' => $campaign->id,
+                'title' => $campaign->title,
+            ],
+            'entity' => [
+                'id' => $entity->id,
+                'name' => $entity->name,
+                'entity_type' => $entity->entity_type,
+                'alias' => $entity->alias,
+                'pronunciation' => $entity->pronunciation,
+                'visibility' => $entity->visibility,
+                'ai_controlled' => $entity->ai_controlled,
+                'initiative_default' => $entity->initiative_default,
+                'description' => $entity->description,
+                'stats' => $entity->stats,
+                'group' => $entity->group?->only(['id', 'name']),
+                'owner' => $entity->owner?->only(['id', 'name']),
+                'tags' => $entity->tags->map(fn (Tag $tag) => [
+                    'id' => $tag->id,
+                    'label' => $tag->label,
+                    'slug' => $tag->slug,
+                    'color' => $tag->color,
+                ])->values(),
+            ],
+        ]);
+    }
+
+    public function edit(Campaign $campaign, CampaignEntity $entity): Response
+    {
+        $campaign->load('group.memberships.user');
+        $this->ensureCampaignContext($campaign, $entity);
+        $this->authorize('update', $entity);
+
+        $entity->load(['tags:id,label,slug']);
+
+        return Inertia::render('CampaignEntities/Edit', [
+            'campaign' => [
+                'id' => $campaign->id,
+                'title' => $campaign->title,
+            ],
+            'entity' => [
+                'id' => $entity->id,
+                'entity_type' => $entity->entity_type,
+                'name' => $entity->name,
+                'alias' => $entity->alias,
+                'pronunciation' => $entity->pronunciation,
+                'visibility' => $entity->visibility,
+                'group_id' => $entity->group_id,
+                'owner_id' => $entity->owner_id,
+                'ai_controlled' => $entity->ai_controlled,
+                'initiative_default' => $entity->initiative_default,
+                'description' => $entity->description,
+                'stats' => $entity->stats,
+                'tags' => $entity->tags->pluck('label')->values(),
+            ],
+            'available_types' => CampaignEntity::types(),
+            'visibility_options' => CampaignEntity::visibilities(),
+            'available_tags' => $campaign->tags()
+                ->orderBy('label')
+                ->get()
+                ->map(fn (Tag $tag) => [
+                    'id' => $tag->id,
+                    'label' => $tag->label,
+                    'slug' => $tag->slug,
+                ]),
+            'group' => [
+                'id' => $campaign->group->id,
+                'name' => $campaign->group->name,
+            ],
+            'members' => $campaign->group->memberships
+                ->map(fn (GroupMembership $membership) => [
+                    'id' => $membership->user->id,
+                    'name' => $membership->user->name,
+                ])
+                ->values(),
+        ]);
+    }
+
+    public function update(CampaignEntityUpdateRequest $request, Campaign $campaign, CampaignEntity $entity): RedirectResponse
+    {
+        $campaign->load('group.memberships');
+        $this->ensureCampaignContext($campaign, $entity);
+        $this->authorize('update', $entity);
+
+        $data = $request->validatedEntityData();
+        $data['group_id'] = $this->resolveGroupId($campaign, Arr::get($data, 'group_id'));
+        $data['owner_id'] = $this->resolveOwnerId($campaign, Arr::get($data, 'owner_id'));
+        $data['initiative_default'] = $this->normalizeNullableInteger(Arr::get($data, 'initiative_default'));
+        $data['stats'] = $this->filterStats($data['stats'] ?? []);
+
+        if ($entity->name !== $data['name']) {
+            $entity->slug = $this->generateUniqueSlug($campaign, $data['name'], $entity);
+        }
+
+        $entity->fill($data);
+        $entity->save();
+
+        $this->syncTags($campaign, $entity, $request->tagNames());
+
+        return redirect()
+            ->route('campaigns.entities.show', [$campaign, $entity])
+            ->with('success', 'Lore entry updated.');
+    }
+
+    public function destroy(Campaign $campaign, CampaignEntity $entity): RedirectResponse
+    {
+        $this->ensureCampaignContext($campaign, $entity);
+        $this->authorize('delete', $entity);
+
+        $entity->delete();
+
+        return redirect()
+            ->route('campaigns.entities.index', $campaign)
+            ->with('success', 'Lore entry archived.');
+    }
+
+    /**
+     * @return array<int, array<string, string|null>>
+     */
+    private function filterStats(array $stats): array
+    {
+        return collect($stats)
+            ->filter(fn ($entry) => filled(Arr::get($entry, 'label')) || filled(Arr::get($entry, 'value')))
+            ->map(fn ($entry) => [
+                'label' => (string) Arr::get($entry, 'label'),
+                'value' => Arr::get($entry, 'value') !== null ? (string) Arr::get($entry, 'value') : null,
+            ])
+            ->values()
+            ->toArray();
+    }
+
+    private function generateUniqueSlug(Campaign $campaign, string $name, ?CampaignEntity $entity = null): string
+    {
+        $base = Str::slug($name);
+
+        if ($base === '') {
+            $base = Str::slug(Str::random(8));
+        }
+
+        $slug = $base;
+        $suffix = 2;
+
+        while ($this->slugExists($campaign, $slug, $entity)) {
+            $slug = $base.'-'.$suffix;
+            $suffix++;
+        }
+
+        return $slug;
+    }
+
+    private function slugExists(Campaign $campaign, string $slug, ?CampaignEntity $ignore = null): bool
+    {
+        return CampaignEntity::query()
+            ->where('campaign_id', $campaign->id)
+            ->when($ignore !== null, fn (Builder $builder) => $builder->whereKeyNot($ignore->getKey()))
+            ->where('slug', $slug)
+            ->exists();
+    }
+
+    private function resolveGroupId(Campaign $campaign, $groupId): ?int
+    {
+        if ($groupId === null || $groupId === '') {
+            return null;
+        }
+
+        $groupId = (int) $groupId;
+
+        if ($groupId !== $campaign->group_id) {
+            throw ValidationException::withMessages([
+                'group_id' => 'Lore entries may only reference the owning group.',
+            ]);
+        }
+
+        return $groupId;
+    }
+
+    private function resolveOwnerId(Campaign $campaign, $ownerId): ?int
+    {
+        if ($ownerId === null || $ownerId === '') {
+            return null;
+        }
+
+        $ownerId = (int) $ownerId;
+
+        $isMember = $campaign->group
+            ->memberships()
+            ->where('user_id', $ownerId)
+            ->exists();
+
+        if (! $isMember) {
+            throw ValidationException::withMessages([
+                'owner_id' => 'Owner must belong to the campaign group roster.',
+            ]);
+        }
+
+        return $ownerId;
+    }
+
+    private function syncTags(Campaign $campaign, CampaignEntity $entity, array $tagNames): void
+    {
+        if ($tagNames === []) {
+            $entity->tags()->sync([]);
+
+            return;
+        }
+
+        $tagIds = collect($tagNames)
+            ->map(function (string $label) use ($campaign) {
+                $slug = Tag::slugFor($label);
+
+                $existing = Tag::query()
+                    ->where('campaign_id', $campaign->id)
+                    ->where('slug', $slug)
+                    ->first();
+
+                if ($existing !== null) {
+                    if ($existing->label !== $label) {
+                        $existing->label = $label;
+                        $existing->save();
+                    }
+
+                    return $existing->id;
+                }
+
+                $tag = Tag::create([
+                    'campaign_id' => $campaign->id,
+                    'label' => $label,
+                    'slug' => $slug,
+                    'color' => $this->deriveColor($label),
+                ]);
+
+                return $tag->id;
+            })
+            ->values();
+
+        $entity->tags()->sync($tagIds);
+    }
+
+    private function deriveColor(string $label): ?string
+    {
+        $palette = collect([
+            '#f97316',
+            '#10b981',
+            '#6366f1',
+            '#ec4899',
+            '#facc15',
+            '#38bdf8',
+        ]);
+
+        $hash = crc32(Str::lower($label));
+
+        return $palette[$hash % $palette->count()];
+    }
+
+    private function ensureCampaignContext(Campaign $campaign, CampaignEntity $entity): void
+    {
+        if ($entity->campaign_id !== $campaign->id) {
+            abort(404);
+        }
+    }
+
+    private function normalizeNullableInteger($value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return (int) $value;
+    }
+}

--- a/backend/app/Http/Controllers/SearchController.php
+++ b/backend/app/Http/Controllers/SearchController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\SearchIndexRequest;
+use App\Models\User;
+use App\Services\GlobalSearchService;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class SearchController extends Controller
+{
+    public function index(SearchIndexRequest $request, GlobalSearchService $search): Response
+    {
+        $validated = $request->validated();
+
+        $query = isset($validated['q']) ? trim((string) $validated['q']) : '';
+        $scopes = $search->normalizeScopes($validated['scopes'] ?? []);
+
+        /** @var Authenticatable&User $user */
+        $user = $request->user();
+
+        $results = $search->search($user, $query, $scopes);
+
+        return Inertia::render('Search/Index', [
+            'query' => $query,
+            'results' => $results,
+            'active_scopes' => $scopes,
+            'available_scopes' => $search->availableScopes(),
+        ]);
+    }
+}

--- a/backend/app/Http/Controllers/UserPreferenceController.php
+++ b/backend/app/Http/Controllers/UserPreferenceController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\UserPreferenceUpdateRequest;
+use DateTimeZone;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Lang;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class UserPreferenceController extends Controller
+{
+    /**
+     * Show the preference form.
+     */
+    public function edit(Request $request): Response
+    {
+        $user = $request->user();
+
+        return Inertia::render('Settings/Preferences', [
+            'form' => [
+                'locale' => $user->locale,
+                'timezone' => $user->timezone,
+                'theme' => $user->theme,
+                'high_contrast' => $user->high_contrast,
+                'font_scale' => $user->font_scale,
+            ],
+            'options' => [
+                'locales' => array_keys((array) config('preferences.locales')),
+                'themes' => array_keys((array) config('preferences.themes')),
+                'font_scales' => config('preferences.font_scales'),
+                'timezones' => DateTimeZone::listIdentifiers(),
+            ],
+        ]);
+    }
+
+    /**
+     * Persist the preference changes.
+     */
+    public function update(UserPreferenceUpdateRequest $request): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        $request->user()->forceFill([
+            'locale' => $validated['locale'],
+            'timezone' => $validated['timezone'],
+            'theme' => $validated['theme'],
+            'high_contrast' => (bool) ($validated['high_contrast'] ?? false),
+            'font_scale' => (int) $validated['font_scale'],
+        ])->save();
+
+        return redirect()
+            ->route('settings.preferences.edit')
+            ->with('success', Lang::get('app.preferences.success'));
+    }
+}

--- a/backend/app/Http/Middleware/ApplyUserPreferences.php
+++ b/backend/app/Http/Middleware/ApplyUserPreferences.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use DateTimeZone;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Config;
+use Symfony\Component\HttpFoundation\Response;
+
+class ApplyUserPreferences
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        $locales = array_keys((array) config('preferences.locales'));
+        $locale = $user?->locale;
+
+        if (! $locale || ! in_array($locale, $locales, true)) {
+            $locale = config('app.locale');
+        }
+
+        App::setLocale($locale);
+
+        $timezone = $user?->timezone ?: config('app.timezone');
+        if (! in_array($timezone, DateTimeZone::listIdentifiers(), true)) {
+            $timezone = config('app.timezone');
+        }
+
+        Config::set('app.timezone', $timezone);
+        date_default_timezone_set($timezone);
+
+        return $next($request);
+    }
+}

--- a/backend/app/Http/Middleware/HandleInertiaRequests.php
+++ b/backend/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Middleware;
 
+use DateTimeZone;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Lang;
 use Inertia\Middleware;
 
 class HandleInertiaRequests extends Middleware
@@ -27,16 +29,44 @@ class HandleInertiaRequests extends Middleware
     {
         return array_merge(parent::share($request), [
             'csrf_token' => fn () => csrf_token(),
+            'locale' => fn () => app()->getLocale(),
             'auth' => [
                 'user' => fn () => $request->user()?->only([
                     'id',
                     'name',
                     'email',
+                    'locale',
+                    'timezone',
+                    'theme',
+                    'high_contrast',
+                    'font_scale',
                 ]),
             ],
             'flash' => [
                 'success' => fn () => $request->session()->get('success'),
                 'error' => fn () => $request->session()->get('error'),
+            ],
+            'preferences' => fn () => $request->user()?->only([
+                'locale',
+                'timezone',
+                'theme',
+                'high_contrast',
+                'font_scale',
+            ]) ?? [
+                'locale' => app()->getLocale(),
+                'timezone' => config('app.timezone'),
+                'theme' => 'system',
+                'high_contrast' => false,
+                'font_scale' => 100,
+            ],
+            'preferenceOptions' => [
+                'locales' => array_keys((array) config('preferences.locales')),
+                'themes' => array_keys((array) config('preferences.themes')),
+                'font_scales' => config('preferences.font_scales'),
+                'timezones' => DateTimeZone::listIdentifiers(),
+            ],
+            'translations' => [
+                'app' => fn () => Lang::get('app'),
             ],
         ]);
     }

--- a/backend/app/Http/Requests/CampaignEntityStoreRequest.php
+++ b/backend/app/Http/Requests/CampaignEntityStoreRequest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Campaign;
+use App\Models\CampaignEntity;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Arr;
+
+class CampaignEntityStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $campaign = $this->route('campaign');
+
+        if (! $campaign instanceof Campaign) {
+            return false;
+        }
+
+        return $this->user()?->can('create', [CampaignEntity::class, $campaign]) === true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'entity_type' => ['required', 'string', 'in:'.implode(',', CampaignEntity::types())],
+            'name' => ['required', 'string', 'max:255'],
+            'alias' => ['nullable', 'string', 'max:255'],
+            'pronunciation' => ['nullable', 'string', 'max:255'],
+            'visibility' => ['required', 'string', 'in:'.implode(',', CampaignEntity::visibilities())],
+            'group_id' => ['nullable', 'integer', 'exists:groups,id'],
+            'owner_id' => ['nullable', 'integer', 'exists:users,id'],
+            'ai_controlled' => ['boolean'],
+            'initiative_default' => ['nullable', 'integer', 'between:0,40'],
+            'description' => ['nullable', 'string'],
+            'stats' => ['nullable', 'array'],
+            'stats.*.label' => ['required_with:stats.*.value', 'string', 'max:100'],
+            'stats.*.value' => ['nullable', 'string', 'max:255'],
+            'tags' => ['nullable', 'array'],
+            'tags.*' => ['string', 'max:50'],
+        ];
+    }
+
+    /**
+     * Normalized tag names stripped of whitespace and duplicates.
+     *
+     * @return array<int, string>
+     */
+    public function tagNames(): array
+    {
+        $tags = array_filter(array_map(
+            fn ($value) => trim((string) $value),
+            $this->input('tags', [])
+        ));
+
+        return array_values(array_unique($tags));
+    }
+
+    /**
+     * Build the sanitized payload for creation.
+     *
+     * @return array<string, mixed>
+     */
+    public function validatedEntityData(): array
+    {
+        $data = $this->validated();
+
+        return Arr::except($data, ['tags']);
+    }
+}

--- a/backend/app/Http/Requests/CampaignEntityUpdateRequest.php
+++ b/backend/app/Http/Requests/CampaignEntityUpdateRequest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\CampaignEntity;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Arr;
+
+class CampaignEntityUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $entity = $this->route('entity');
+
+        if (! $entity instanceof CampaignEntity) {
+            return false;
+        }
+
+        return $this->user()?->can('update', $entity) === true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'entity_type' => ['required', 'string', 'in:'.implode(',', CampaignEntity::types())],
+            'name' => ['required', 'string', 'max:255'],
+            'alias' => ['nullable', 'string', 'max:255'],
+            'pronunciation' => ['nullable', 'string', 'max:255'],
+            'visibility' => ['required', 'string', 'in:'.implode(',', CampaignEntity::visibilities())],
+            'group_id' => ['nullable', 'integer', 'exists:groups,id'],
+            'owner_id' => ['nullable', 'integer', 'exists:users,id'],
+            'ai_controlled' => ['boolean'],
+            'initiative_default' => ['nullable', 'integer', 'between:0,40'],
+            'description' => ['nullable', 'string'],
+            'stats' => ['nullable', 'array'],
+            'stats.*.label' => ['required_with:stats.*.value', 'string', 'max:100'],
+            'stats.*.value' => ['nullable', 'string', 'max:255'],
+            'tags' => ['nullable', 'array'],
+            'tags.*' => ['string', 'max:50'],
+        ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function tagNames(): array
+    {
+        $tags = array_filter(array_map(
+            fn ($value) => trim((string) $value),
+            $this->input('tags', [])
+        ));
+
+        return array_values(array_unique($tags));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function validatedEntityData(): array
+    {
+        $data = $this->validated();
+
+        return Arr::except($data, ['tags']);
+    }
+}

--- a/backend/app/Http/Requests/SearchIndexRequest.php
+++ b/backend/app/Http/Requests/SearchIndexRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Services\GlobalSearchService;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class SearchIndexRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'q' => ['nullable', 'string', 'max:120'],
+            'scopes' => ['nullable', 'array'],
+            'scopes.*' => ['string', Rule::in(GlobalSearchService::SCOPES)],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/SessionRecordingStoreRequest.php
+++ b/backend/app/Http/Requests/SessionRecordingStoreRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SessionRecordingStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'recording' => [
+                'required',
+                'file',
+                'max:512000',
+                'mimetypes:audio/mpeg,audio/mp3,audio/wav,audio/x-wav,audio/flac,audio/ogg,audio/webm,video/mp4,video/webm,video/ogg',
+            ],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/UserPreferenceUpdateRequest.php
+++ b/backend/app/Http/Requests/UserPreferenceUpdateRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UserPreferenceUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $locales = array_keys((array) config('preferences.locales'));
+        $themes = array_keys((array) config('preferences.themes'));
+        $fontScales = config('preferences.font_scales');
+
+        return [
+            'locale' => ['required', Rule::in($locales)],
+            'timezone' => ['required', 'timezone:all'],
+            'theme' => ['required', Rule::in($themes)],
+            'high_contrast' => ['nullable', 'boolean'],
+            'font_scale' => ['required', 'integer', Rule::in($fontScales)],
+        ];
+    }
+}

--- a/backend/app/Models/Campaign.php
+++ b/backend/app/Models/Campaign.php
@@ -108,4 +108,14 @@ class Campaign extends Model
     {
         return $this->hasMany(CampaignTask::class);
     }
+
+    public function entities(): HasMany
+    {
+        return $this->hasMany(CampaignEntity::class);
+    }
+
+    public function tags(): HasMany
+    {
+        return $this->hasMany(Tag::class);
+    }
 }

--- a/backend/app/Models/CampaignEntity.php
+++ b/backend/app/Models/CampaignEntity.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
+
+class CampaignEntity extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    public const TYPE_CHARACTER = 'character';
+    public const TYPE_NPC = 'npc';
+    public const TYPE_MONSTER = 'monster';
+    public const TYPE_ITEM = 'item';
+    public const TYPE_LOCATION = 'location';
+
+    public const VISIBILITY_GM = 'gm';
+    public const VISIBILITY_PLAYERS = 'players';
+    public const VISIBILITY_PUBLIC = 'public';
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'campaign_id',
+        'group_id',
+        'owner_id',
+        'entity_type',
+        'name',
+        'slug',
+        'alias',
+        'pronunciation',
+        'visibility',
+        'ai_controlled',
+        'initiative_default',
+        'stats',
+        'description',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'ai_controlled' => 'boolean',
+        'initiative_default' => 'integer',
+        'stats' => 'array',
+    ];
+
+    /**
+     * All supported entity archetypes.
+     *
+     * @return array<int, string>
+     */
+    public static function types(): array
+    {
+        return [
+            self::TYPE_CHARACTER,
+            self::TYPE_NPC,
+            self::TYPE_MONSTER,
+            self::TYPE_ITEM,
+            self::TYPE_LOCATION,
+        ];
+    }
+
+    /**
+     * Supported visibility levels.
+     *
+     * @return array<int, string>
+     */
+    public static function visibilities(): array
+    {
+        return [
+            self::VISIBILITY_GM,
+            self::VISIBILITY_PLAYERS,
+            self::VISIBILITY_PUBLIC,
+        ];
+    }
+
+    /**
+     * Scope entities to a given campaign.
+     */
+    public function scopeForCampaign(Builder $query, Campaign $campaign): Builder
+    {
+        return $query->where('campaign_id', $campaign->getKey());
+    }
+
+    /**
+     * Ensure a campaign-scoped slug is generated from the provided name.
+     */
+    public function generateSlug(string $name): string
+    {
+        $baseSlug = Str::slug($name);
+        $slug = $baseSlug;
+        $counter = 1;
+
+        while (static::query()
+            ->where('campaign_id', $this->campaign_id)
+            ->where('slug', $slug)
+            ->when($this->exists, fn (Builder $builder) => $builder->whereKeyNot($this->getKey()))
+            ->exists()) {
+            $slug = Str::slug($baseSlug.'-'.$counter++);
+        }
+
+        return $slug;
+    }
+
+    /**
+     * Owning campaign relationship.
+     */
+    public function campaign(): BelongsTo
+    {
+        return $this->belongsTo(Campaign::class);
+    }
+
+    /**
+     * Optional associated group.
+     */
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(Group::class);
+    }
+
+    /**
+     * Optional owner reference.
+     */
+    public function owner(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'owner_id');
+    }
+
+    /**
+     * Attached tags.
+     */
+    public function tags(): MorphToMany
+    {
+        return $this->morphToMany(Tag::class, 'taggable')->withTimestamps();
+    }
+}

--- a/backend/app/Models/CampaignSession.php
+++ b/backend/app/Models/CampaignSession.php
@@ -28,6 +28,8 @@ class CampaignSession extends Model
         'location',
         'summary',
         'recording_url',
+        'recording_disk',
+        'recording_path',
     ];
 
     /**
@@ -71,5 +73,10 @@ class CampaignSession extends Model
     public function aiRequests(): MorphMany
     {
         return $this->morphMany(AiRequest::class, 'context');
+    }
+
+    public function hasStoredRecording(): bool
+    {
+        return filled($this->recording_disk) && filled($this->recording_path);
     }
 }

--- a/backend/app/Models/Region.php
+++ b/backend/app/Models/Region.php
@@ -28,6 +28,13 @@ class Region extends Model
     ];
 
     /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'ai_controlled' => 'boolean',
+    ];
+
+    /**
      * Parent world for this region.
      */
     public function world(): BelongsTo

--- a/backend/app/Models/Tag.php
+++ b/backend/app/Models/Tag.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Support\Str;
+
+class Tag extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'campaign_id',
+        'label',
+        'slug',
+        'color',
+    ];
+
+    /**
+     * Campaign relationship when scoped.
+     */
+    public function campaign(): BelongsTo
+    {
+        return $this->belongsTo(Campaign::class);
+    }
+
+    /**
+     * Associated campaign entities.
+     */
+    public function entities(): MorphToMany
+    {
+        return $this->morphedByMany(CampaignEntity::class, 'taggable')->withTimestamps();
+    }
+
+    /**
+     * Generate a slug within the campaign scope.
+     */
+    public static function slugFor(string $label): string
+    {
+        $slug = Str::slug($label);
+
+        return $slug !== '' ? $slug : Str::slug(Str::random(6));
+    }
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -26,6 +26,11 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'locale',
+        'timezone',
+        'theme',
+        'high_contrast',
+        'font_scale',
     ];
 
     /**
@@ -48,6 +53,8 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'high_contrast' => 'boolean',
+            'font_scale' => 'integer',
         ];
     }
 

--- a/backend/app/Policies/CampaignEntityPolicy.php
+++ b/backend/app/Policies/CampaignEntityPolicy.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Campaign;
+use App\Models\CampaignEntity;
+use App\Models\User;
+
+class CampaignEntityPolicy
+{
+    public function viewAny(User $user, Campaign $campaign): bool
+    {
+        return app(CampaignPolicy::class)->view($user, $campaign);
+    }
+
+    public function view(User $user, CampaignEntity $entity): bool
+    {
+        return app(CampaignPolicy::class)->view($user, $entity->campaign);
+    }
+
+    public function create(User $user, Campaign $campaign): bool
+    {
+        return app(CampaignPolicy::class)->update($user, $campaign);
+    }
+
+    public function update(User $user, CampaignEntity $entity): bool
+    {
+        return app(CampaignPolicy::class)->update($user, $entity->campaign);
+    }
+
+    public function delete(User $user, CampaignEntity $entity): bool
+    {
+        return app(CampaignPolicy::class)->update($user, $entity->campaign);
+    }
+}

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -10,6 +10,7 @@ use App\Models\Region;
 use App\Models\DiceRoll;
 use App\Models\InitiativeEntry;
 use App\Models\CampaignSession;
+use App\Models\CampaignEntity;
 use App\Models\SessionNote;
 use App\Models\TurnConfiguration;
 use App\Models\World;
@@ -30,6 +31,7 @@ use App\Policies\WorldPolicy;
 use App\Policies\MapPolicy;
 use App\Policies\MapTilePolicy;
 use App\Policies\TileTemplatePolicy;
+use App\Policies\CampaignEntityPolicy;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 
@@ -62,5 +64,6 @@ class AppServiceProvider extends ServiceProvider
         Gate::policy(Map::class, MapPolicy::class);
         Gate::policy(MapTile::class, MapTilePolicy::class);
         Gate::policy(TileTemplate::class, TileTemplatePolicy::class);
+        Gate::policy(CampaignEntity::class, CampaignEntityPolicy::class);
     }
 }

--- a/backend/app/Services/GlobalSearchService.php
+++ b/backend/app/Services/GlobalSearchService.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Campaign;
+use App\Models\CampaignRoleAssignment;
+use App\Models\CampaignSession;
+use App\Models\CampaignTask;
+use App\Models\Group;
+use App\Models\GroupMembership;
+use App\Models\SessionNote;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+
+class GlobalSearchService
+{
+    /**
+     * @var array<int, string>
+     */
+    public const SCOPES = ['campaigns', 'sessions', 'notes', 'tasks'];
+
+    /**
+     * @return array<int, string>
+     */
+    public function availableScopes(): array
+    {
+        return self::SCOPES;
+    }
+
+    /**
+     * @param array<int, string> $scopes
+     * @return array<int, string>
+     */
+    public function normalizeScopes(array $scopes): array
+    {
+        $normalized = array_values(array_intersect(self::SCOPES, $scopes));
+
+        return $normalized === [] ? self::SCOPES : $normalized;
+    }
+
+    /**
+     * @param array<int, string> $scopes
+     * @return array<string, array<int, array<string, mixed>>>
+     */
+    public function search(User $user, ?string $term, array $scopes = []): array
+    {
+        $term = trim((string) $term);
+
+        $results = [
+            'campaigns' => [],
+            'sessions' => [],
+            'notes' => [],
+            'tasks' => [],
+        ];
+
+        if ($term === '') {
+            return $results;
+        }
+
+        $scopes = $this->normalizeScopes($scopes);
+
+        $groupMemberships = $user->groupMemberships()->get(['group_id', 'role']);
+        $groupIds = $groupMemberships->pluck('group_id');
+        $managedGroupIds = $groupMemberships
+            ->whereIn('role', [GroupMembership::ROLE_OWNER, GroupMembership::ROLE_DUNGEON_MASTER])
+            ->pluck('group_id')
+            ->values();
+
+        $campaignVisibility = function (Builder $query) use ($user, $groupIds): void {
+            $query->where(function (Builder $inner) use ($user, $groupIds): void {
+                $inner->whereIn('group_id', $groupIds)
+                    ->orWhere('created_by', $user->id)
+                    ->orWhereHas('roleAssignments', function (Builder $assignments) use ($user, $groupIds): void {
+                        $assignments->where(function (Builder $assignmentQuery) use ($user, $groupIds): void {
+                            $assignmentQuery->where(function (Builder $userAssignments) use ($user): void {
+                                $userAssignments->where('assignee_type', User::class)
+                                    ->where('assignee_id', $user->id);
+                            });
+
+                            if ($groupIds->isNotEmpty()) {
+                                $assignmentQuery->orWhere(function (Builder $groupAssignments) use ($groupIds): void {
+                                    $groupAssignments->where('assignee_type', Group::class)
+                                        ->whereIn('assignee_id', $groupIds);
+                                });
+                            }
+                        });
+                    });
+            });
+        };
+
+        $managedCampaignIds = Campaign::query()
+            ->where(function (Builder $query) use ($user, $managedGroupIds): void {
+                $query->where('created_by', $user->id);
+
+                if ($managedGroupIds->isNotEmpty()) {
+                    $query->orWhereIn('group_id', $managedGroupIds);
+                }
+
+                $query->orWhereHas('roleAssignments', function (Builder $assignments) use ($user): void {
+                    $assignments->where('assignee_type', User::class)
+                        ->where('assignee_id', $user->id)
+                        ->where('role', CampaignRoleAssignment::ROLE_GM);
+                });
+            })
+            ->pluck('id');
+
+        $like = $this->makeLikePattern($term);
+
+        if (in_array('campaigns', $scopes, true)) {
+            $results['campaigns'] = Campaign::query()
+                ->with(['group:id,name', 'region:id,name'])
+                ->where($campaignVisibility)
+                ->where(function (Builder $query) use ($like): void {
+                    $query->where('title', 'like', $like)
+                        ->orWhere('synopsis', 'like', $like);
+                })
+                ->orderByDesc('updated_at')
+                ->limit(10)
+                ->get()
+                ->map(fn (Campaign $campaign) => [
+                    'id' => $campaign->id,
+                    'title' => $campaign->title,
+                    'status' => $campaign->status,
+                    'group' => [
+                        'id' => $campaign->group->id,
+                        'name' => $campaign->group->name,
+                    ],
+                    'region' => $campaign->region ? [
+                        'id' => $campaign->region->id,
+                        'name' => $campaign->region->name,
+                    ] : null,
+                    'updated_at' => $campaign->updated_at?->toIso8601String(),
+                ])
+                ->values()
+                ->all();
+        }
+
+        if (in_array('sessions', $scopes, true)) {
+            $results['sessions'] = CampaignSession::query()
+                ->with(['campaign:id,title'])
+                ->whereHas('campaign', $campaignVisibility)
+                ->where(function (Builder $query) use ($like): void {
+                    $query->where('title', 'like', $like)
+                        ->orWhere('agenda', 'like', $like)
+                        ->orWhere('summary', 'like', $like);
+                })
+                ->orderByDesc('session_date')
+                ->limit(10)
+                ->get()
+                ->map(fn (CampaignSession $session) => [
+                    'id' => $session->id,
+                    'title' => $session->title,
+                    'session_date' => $session->session_date?->toIso8601String(),
+                    'campaign' => [
+                        'id' => $session->campaign->id,
+                        'title' => $session->campaign->title,
+                    ],
+                ])
+                ->values()
+                ->all();
+        }
+
+        if (in_array('notes', $scopes, true)) {
+            $notesQuery = SessionNote::query()
+                ->with(['campaign:id,title', 'session:id,title,campaign_id', 'author:id,name'])
+                ->whereHas('campaign', $campaignVisibility)
+                ->where('content', 'like', $like)
+                ->orderByDesc('updated_at')
+                ->limit(10);
+
+            if ($managedCampaignIds->isEmpty()) {
+                $notesQuery->where('visibility', '!=', SessionNote::VISIBILITY_GM);
+            } else {
+                $notesQuery->where(function (Builder $query) use ($managedCampaignIds): void {
+                    $query->where('visibility', '!=', SessionNote::VISIBILITY_GM)
+                        ->orWhereIn('campaign_id', $managedCampaignIds);
+                });
+            }
+
+            $results['notes'] = $notesQuery
+                ->get()
+                ->map(fn (SessionNote $note) => [
+                    'id' => $note->id,
+                    'visibility' => $note->visibility,
+                    'content_preview' => Str::limit(trim(strip_tags($note->content)), 160),
+                    'campaign' => [
+                        'id' => $note->campaign->id,
+                        'title' => $note->campaign->title,
+                    ],
+                    'session' => $note->session ? [
+                        'id' => $note->session->id,
+                        'title' => $note->session->title,
+                    ] : null,
+                    'author' => [
+                        'id' => $note->author?->id,
+                        'name' => $note->author?->name,
+                    ],
+                    'updated_at' => $note->updated_at?->toIso8601String(),
+                ])
+                ->values()
+                ->all();
+        }
+
+        if (in_array('tasks', $scopes, true)) {
+            $results['tasks'] = CampaignTask::query()
+                ->with('campaign:id,title')
+                ->whereHas('campaign', $campaignVisibility)
+                ->where(function (Builder $query) use ($like): void {
+                    $query->where('title', 'like', $like)
+                        ->orWhere('description', 'like', $like);
+                })
+                ->orderByDesc('updated_at')
+                ->limit(10)
+                ->get()
+                ->map(fn (CampaignTask $task) => [
+                    'id' => $task->id,
+                    'title' => $task->title,
+                    'status' => $task->status,
+                    'due_turn_number' => $task->due_turn_number,
+                    'due_at' => $task->due_at?->toIso8601String(),
+                    'campaign' => [
+                        'id' => $task->campaign->id,
+                        'title' => $task->campaign->title,
+                    ],
+                ])
+                ->values()
+                ->all();
+        }
+
+        return $results;
+    }
+
+    protected function makeLikePattern(string $term): string
+    {
+        $escaped = addcslashes($term, '%_');
+
+        return '%'.$escaped.'%';
+    }
+}

--- a/backend/app/Services/SessionExportService.php
+++ b/backend/app/Services/SessionExportService.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AiRequest;
+use App\Models\CampaignSession;
+use App\Models\SessionNote;
+use App\Models\User;
+use App\Policies\CampaignPolicy;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class SessionExportService
+{
+    public function __construct(private readonly CampaignPolicy $campaignPolicy)
+    {
+    }
+
+    public function buildExportData(CampaignSession $session, User $viewer): array
+    {
+        $session->loadMissing([
+            'campaign.group.memberships',
+            'campaign.roleAssignments',
+            'creator:id,name',
+            'turn:id,number,window_started_at,processed_at',
+            'notes.author:id,name',
+            'diceRolls.roller:id,name',
+            'initiativeEntries',
+            'aiRequests' => fn ($query) => $query
+                ->where('request_type', 'npc_dialogue')
+                ->latest()
+                ->limit(20),
+        ]);
+
+        $canManage = $this->campaignPolicy->update($viewer, $session->campaign);
+
+        $notes = $session->notes
+            ->when(! $canManage, function ($collection) {
+                return $collection->reject(fn (SessionNote $note) => $note->visibility === SessionNote::VISIBILITY_GM);
+            })
+            ->sortByDesc('created_at')
+            ->sortByDesc('is_pinned')
+            ->values()
+            ->map(fn (SessionNote $note) => [
+                'id' => $note->id,
+                'content' => $note->content,
+                'visibility' => $note->visibility,
+                'is_pinned' => $note->is_pinned,
+                'author' => [
+                    'id' => $note->author->id,
+                    'name' => $note->author->name,
+                ],
+                'created_at' => $note->created_at?->clone()->setTimezone('UTC'),
+            ]);
+
+        $diceRolls = $session->diceRolls
+            ->sortByDesc('created_at')
+            ->values()
+            ->map(fn ($roll) => [
+                'id' => $roll->id,
+                'expression' => $roll->expression,
+                'result_total' => $roll->result_total,
+                'result_breakdown' => $roll->result_breakdown,
+                'roller' => [
+                    'id' => $roll->roller->id,
+                    'name' => $roll->roller->name,
+                ],
+                'created_at' => $roll->created_at?->clone()->setTimezone('UTC'),
+            ]);
+
+        $initiative = $session->initiativeEntries
+            ->sortBy('order_index')
+            ->values()
+            ->map(fn ($entry) => [
+                'id' => $entry->id,
+                'name' => $entry->name,
+                'dexterity_mod' => $entry->dexterity_mod,
+                'initiative' => $entry->initiative,
+                'is_current' => $entry->is_current,
+                'order_index' => $entry->order_index,
+            ]);
+
+        $aiDialogues = $session->aiRequests
+            ->sortByDesc('created_at')
+            ->values()
+            ->map(fn (AiRequest $request) => [
+                'id' => $request->id,
+                'npc_name' => $request->meta['npc_name'] ?? null,
+                'tone' => $request->meta['tone'] ?? null,
+                'prompt' => $request->prompt,
+                'reply' => $request->response_text,
+                'status' => $request->status,
+                'created_at' => $request->created_at?->clone()->setTimezone('UTC'),
+            ]);
+
+        $storedRecordingUrl = null;
+        $storedRecordingName = null;
+
+        if ($session->hasStoredRecording()) {
+            $storedRecordingUrl = Storage::disk($session->recording_disk)->url($session->recording_path);
+            $storedRecordingName = basename($session->recording_path);
+        }
+
+        return [
+            'metadata' => [
+                'campaign' => [
+                    'id' => $session->campaign->id,
+                    'title' => $session->campaign->title,
+                ],
+                'session' => [
+                    'id' => $session->id,
+                    'title' => $session->title,
+                    'agenda' => $session->agenda,
+                    'summary' => $session->summary,
+                    'session_date' => $session->session_date?->clone()->setTimezone('UTC'),
+                    'duration_minutes' => $session->duration_minutes,
+                    'location' => $session->location,
+                    'recording_url' => $session->recording_url,
+                    'stored_recording_url' => $storedRecordingUrl,
+                    'stored_recording_name' => $storedRecordingName,
+                    'turn' => $session->turn ? [
+                        'id' => $session->turn->id,
+                        'number' => $session->turn->number,
+                        'window_started_at' => $session->turn->window_started_at?->clone()->setTimezone('UTC'),
+                        'processed_at' => $session->turn->processed_at?->clone()->setTimezone('UTC'),
+                    ] : null,
+                    'creator' => [
+                        'id' => $session->creator->id,
+                        'name' => $session->creator->name,
+                    ],
+                ],
+                'generated_at' => now('UTC'),
+                'viewer' => [
+                    'id' => $viewer->id,
+                    'name' => $viewer->name,
+                    'can_manage' => $canManage,
+                ],
+            ],
+            'notes' => $notes,
+            'dice_rolls' => $diceRolls,
+            'initiative' => $initiative,
+            'ai_dialogues' => $aiDialogues,
+        ];
+    }
+
+    public function generateMarkdown(array $data): string
+    {
+        $metadata = $data['metadata'];
+        $session = $metadata['session'];
+        $campaign = $metadata['campaign'];
+
+        $lines = [];
+        $lines[] = '# Session Chronicle: ' . $session['title'];
+        $lines[] = '';
+        $lines[] = '- Campaign: ' . $campaign['title'];
+        $lines[] = '- Compiled at: ' . $metadata['generated_at']->format('Y-m-d H:i \U\T\C');
+
+        if ($session['session_date'] instanceof Carbon) {
+            $lines[] = '- Session date: ' . $session['session_date']->format('Y-m-d H:i \U\T\C');
+        }
+
+        if ($session['duration_minutes']) {
+            $lines[] = '- Duration: ' . $session['duration_minutes'] . ' minutes';
+        }
+
+        if ($session['location']) {
+            $lines[] = '- Location: ' . $session['location'];
+        }
+
+        if ($session['turn']) {
+            $turn = $session['turn'];
+            $lines[] = '- Linked turn: #' . $turn['number'];
+        }
+
+        if ($session['recording_url']) {
+            $lines[] = '- External recording: ' . $session['recording_url'];
+        }
+
+        if ($session['stored_recording_url']) {
+            $lines[] = '- Vault recording: ' . $session['stored_recording_url'];
+        }
+
+        $lines[] = '';
+        $lines[] = '---';
+        $lines[] = '';
+
+        if ($session['agenda']) {
+            $lines[] = '## Agenda';
+            $lines[] = $session['agenda'];
+            $lines[] = '';
+        }
+
+        if ($session['summary']) {
+            $lines[] = '## Summary';
+            $lines[] = $session['summary'];
+            $lines[] = '';
+        }
+
+        if (count($data['notes']) > 0) {
+            $lines[] = '## Notes';
+            foreach ($data['notes'] as $note) {
+                $timestamp = $note['created_at'] instanceof Carbon
+                    ? $note['created_at']->format('Y-m-d H:i \U\T\C')
+                    : 'Unknown time';
+                $visibility = Str::headline($note['visibility']);
+                $lines[] = "### {$note['author']['name']} ({$visibility}) — {$timestamp}";
+                $lines[] = $note['content'];
+                $lines[] = '';
+            }
+        }
+
+        if (count($data['dice_rolls']) > 0) {
+            $lines[] = '## Dice Rolls';
+            foreach ($data['dice_rolls'] as $roll) {
+                $timestamp = $roll['created_at'] instanceof Carbon
+                    ? $roll['created_at']->format('Y-m-d H:i \U\T\C')
+                    : 'Unknown time';
+                $lines[] = "- {$roll['roller']['name']} rolled {$roll['expression']} = {$roll['result_total']} ({$timestamp})";
+                if (! empty($roll['result_breakdown'])) {
+                    $lines[] = '  - Breakdown: ' . json_encode($roll['result_breakdown']);
+                }
+            }
+            $lines[] = '';
+        }
+
+        if (count($data['initiative']) > 0) {
+            $lines[] = '## Initiative Order';
+            foreach ($data['initiative'] as $entry) {
+                $lines[] = '- ' . $entry['name'] . ' — Initiative ' . $entry['initiative'] . ' (Dex ' . $entry['dexterity_mod'] . ')' . ($entry['is_current'] ? ' ← current' : '');
+            }
+            $lines[] = '';
+        }
+
+        if (count($data['ai_dialogues']) > 0) {
+            $lines[] = '## AI Dialogue Log';
+            foreach ($data['ai_dialogues'] as $dialogue) {
+                $timestamp = $dialogue['created_at'] instanceof Carbon
+                    ? $dialogue['created_at']->format('Y-m-d H:i \U\T\C')
+                    : 'Unknown time';
+                $header = $dialogue['npc_name']
+                    ? $dialogue['npc_name'] . ' (' . ($dialogue['tone'] ?? 'neutral') . ')'
+                    : 'NPC dialogue';
+                $lines[] = "### {$header} — {$timestamp}";
+                $lines[] = '**Prompt**';
+                $lines[] = $dialogue['prompt'];
+                if ($dialogue['reply']) {
+                    $lines[] = '';
+                    $lines[] = '**Reply**';
+                    $lines[] = $dialogue['reply'];
+                }
+                $lines[] = '';
+            }
+        }
+
+        return trim(implode("\n", $lines)) . "\n";
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\ApplyUserPreferences;
 use App\Http\Middleware\HandleInertiaRequests;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -23,6 +24,7 @@ return Application::configure(basePath: dirname(__DIR__))
             \Illuminate\Cookie\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
+            ApplyUserPreferences::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -7,6 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "dompdf/dompdf": "^2.0",
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/framework": "^12.0",
         "laravel/reverb": "^1.6",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5976f73d7e15a66ceb251ea60e4fc96",
+    "content-hash": "1fa4b1f81b2b327f9e7dcab30f6f072e",
     "packages": [
         {
             "name": "brick/math",
@@ -506,6 +506,68 @@
                 }
             ],
             "time": "2024-02-05T11:56:58+00:00"
+        },
+        {
+            "name": "dompdf/dompdf",
+            "version": "v2.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/dompdf.git",
+                "reference": "c20247574601700e1f7c8dab39310fca1964dc52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/c20247574601700e1f7c8dab39310fca1964dc52",
+                "reference": "c20247574601700e1f7c8dab39310fca1964dc52",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "masterminds/html5": "^2.0",
+                "phenx/php-font-lib": ">=0.5.4 <1.0.0",
+                "phenx/php-svg-lib": ">=0.5.2 <1.0.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "ext-zip": "*",
+                "mockery/mockery": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8 || ^9",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "suggest": {
+                "ext-gd": "Needed to process images",
+                "ext-gmagick": "Improves image processing performance",
+                "ext-imagick": "Improves image processing performance",
+                "ext-zlib": "Needed for pdf stream compression"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dompdf\\": "src/"
+                },
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "The Dompdf Community",
+                    "homepage": "https://github.com/dompdf/dompdf/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
+            "homepage": "https://github.com/dompdf/dompdf",
+            "support": {
+                "issues": "https://github.com/dompdf/dompdf/issues",
+                "source": "https://github.com/dompdf/dompdf/tree/v2.0.8"
+            },
+            "time": "2024-04-29T13:06:17+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
@@ -2403,6 +2465,73 @@
             "time": "2024-12-08T08:18:47+00:00"
         },
         {
+            "name": "masterminds/html5",
+            "version": "2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fcf91eb64359852f00d921887b219479b4f21251",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.0"
+            },
+            "time": "2025-07-25T09:04:22+00:00"
+        },
+        {
             "name": "monolog/monolog",
             "version": "3.9.0",
             "source": {
@@ -3001,6 +3130,96 @@
                 "source": "https://github.com/paragonie/sodium_compat/tree/v2.4.0"
             },
             "time": "2025-10-06T08:47:40+00:00"
+        },
+        {
+            "name": "phenx/php-font-lib",
+            "version": "0.5.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-font-lib.git",
+                "reference": "a1681e9793040740a405ac5b189275059e2a9863"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/a1681e9793040740a405ac5b189275059e2a9863",
+                "reference": "a1681e9793040740a405ac5b189275059e2a9863",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3 || ^4 || ^5 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Ménager",
+                    "email": "fabien.menager@gmail.com"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/PhenX/php-font-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-font-lib/issues",
+                "source": "https://github.com/dompdf/php-font-lib/tree/0.5.6"
+            },
+            "time": "2024-01-29T14:45:26+00:00"
+        },
+        {
+            "name": "phenx/php-svg-lib",
+            "version": "0.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-svg-lib.git",
+                "reference": "46b25da81613a9cf43c83b2a8c2c1bdab27df691"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/46b25da81613a9cf43c83b2a8c2c1bdab27df691",
+                "reference": "46b25da81613a9cf43c83b2a8c2c1bdab27df691",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabberworm/php-css-parser": "^8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Svg\\": "src/Svg"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Ménager",
+                    "email": "fabien.menager@gmail.com"
+                }
+            ],
+            "description": "A library to read, parse and export to PDF SVG files.",
+            "homepage": "https://github.com/PhenX/php-svg-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-svg-lib/issues",
+                "source": "https://github.com/dompdf/php-svg-lib/tree/0.5.4"
+            },
+            "time": "2024-04-08T12:52:34+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -4414,6 +4633,72 @@
                 }
             ],
             "time": "2024-06-11T12:45:25+00:00"
+        },
+        {
+            "name": "sabberworm/php-css-parser",
+            "version": "v8.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MyIntervals/PHP-CSS-Parser.git",
+                "reference": "d8e916507b88e389e26d4ab03c904a082aa66bb9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/d8e916507b88e389e26d4ab03c904a082aa66bb9",
+                "reference": "d8e916507b88e389e26d4ab03c904a082aa66bb9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": "^5.6.20 || ^7.0.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "5.7.27 || 6.5.14 || 7.5.20 || 8.5.41",
+                "rawr/cross-data-providers": "^2.0.0"
+            },
+            "suggest": {
+                "ext-mbstring": "for parsing UTF-8 CSS"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sabberworm\\CSS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raphael Schweikert"
+                },
+                {
+                    "name": "Oliver Klee",
+                    "email": "github@oliverklee.de"
+                },
+                {
+                    "name": "Jake Hotson",
+                    "email": "jake.github@qzdesign.co.uk"
+                }
+            ],
+            "description": "Parser for CSS Files written in PHP",
+            "homepage": "https://www.sabberworm.com/blog/2010/6/10/php-css-parser",
+            "keywords": [
+                "css",
+                "parser",
+                "stylesheet"
+            ],
+            "support": {
+                "issues": "https://github.com/MyIntervals/PHP-CSS-Parser/issues",
+                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v8.9.0"
+            },
+            "time": "2025-07-11T13:20:48+00:00"
         },
         {
             "name": "symfony/clock",

--- a/backend/config/preferences.php
+++ b/backend/config/preferences.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'locales' => [
+        'en' => ['label' => 'app.preferences.locale_options.en'],
+        'ro' => ['label' => 'app.preferences.locale_options.ro'],
+    ],
+    'themes' => [
+        'system' => ['label' => 'app.preferences.theme_options.system'],
+        'dark' => ['label' => 'app.preferences.theme_options.dark'],
+        'light' => ['label' => 'app.preferences.theme_options.light'],
+    ],
+    'font_scales' => [90, 100, 110, 125, 150],
+];

--- a/backend/database/factories/CampaignEntityFactory.php
+++ b/backend/database/factories/CampaignEntityFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Campaign;
+use App\Models\CampaignEntity;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<CampaignEntity>
+ */
+class CampaignEntityFactory extends Factory
+{
+    protected $model = CampaignEntity::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->words(3, true);
+
+        return [
+            'campaign_id' => Campaign::factory(),
+            'entity_type' => $this->faker->randomElement(CampaignEntity::types()),
+            'name' => Str::title($name),
+            'slug' => Str::slug($name.'-'.$this->faker->unique()->numberBetween(10, 9999)),
+            'alias' => $this->faker->optional()->words(2, true),
+            'pronunciation' => $this->faker->optional()->lexify('????-????'),
+            'visibility' => $this->faker->randomElement(CampaignEntity::visibilities()),
+            'ai_controlled' => $this->faker->boolean(20),
+            'initiative_default' => $this->faker->optional()->numberBetween(1, 35),
+            'description' => $this->faker->paragraph(),
+            'stats' => [],
+        ];
+    }
+}

--- a/backend/database/factories/UserFactory.php
+++ b/backend/database/factories/UserFactory.php
@@ -29,6 +29,11 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'locale' => 'en',
+            'timezone' => 'UTC',
+            'theme' => 'system',
+            'high_contrast' => false,
+            'font_scale' => 100,
         ];
     }
 

--- a/backend/database/migrations/2025_10_20_120000_add_recording_storage_to_campaign_sessions_table.php
+++ b/backend/database/migrations/2025_10_20_120000_add_recording_storage_to_campaign_sessions_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('campaign_sessions', function (Blueprint $table): void {
+            $table->string('recording_disk')->nullable()->after('recording_url');
+            $table->string('recording_path')->nullable()->after('recording_disk');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('campaign_sessions', function (Blueprint $table): void {
+            $table->dropColumn(['recording_path', 'recording_disk']);
+        });
+    }
+};

--- a/backend/database/migrations/2025_10_21_090000_add_preferences_to_users_table.php
+++ b/backend/database/migrations/2025_10_21_090000_add_preferences_to_users_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->string('locale', 8)->default('en')->after('remember_token');
+            $table->string('timezone')->default('UTC')->after('locale');
+            $table->string('theme')->default('system')->after('timezone');
+            $table->boolean('high_contrast')->default(false)->after('theme');
+            $table->unsignedTinyInteger('font_scale')->default(100)->after('high_contrast');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn([
+                'locale',
+                'timezone',
+                'theme',
+                'high_contrast',
+                'font_scale',
+            ]);
+        });
+    }
+};

--- a/backend/database/migrations/2025_10_22_090000_create_campaign_entities_table.php
+++ b/backend/database/migrations/2025_10_22_090000_create_campaign_entities_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Models\Campaign;
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('campaign_entities', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignIdFor(Campaign::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(Group::class)->nullable()->constrained()->nullOnDelete();
+            $table->foreignIdFor(User::class, 'owner_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('entity_type', 32);
+            $table->string('name');
+            $table->string('slug');
+            $table->string('alias')->nullable();
+            $table->string('pronunciation')->nullable();
+            $table->string('visibility', 16)->default('players');
+            $table->boolean('ai_controlled')->default(false);
+            $table->unsignedTinyInteger('initiative_default')->nullable();
+            $table->json('stats')->nullable();
+            $table->text('description')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->unique(['campaign_id', 'slug']);
+            $table->index(['campaign_id', 'entity_type']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('campaign_entities');
+    }
+};

--- a/backend/database/migrations/2025_10_22_091000_create_tags_table.php
+++ b/backend/database/migrations/2025_10_22_091000_create_tags_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Models\Campaign;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tags', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignIdFor(Campaign::class)->nullable()->constrained()->cascadeOnDelete();
+            $table->string('label');
+            $table->string('slug');
+            $table->string('color', 16)->nullable();
+            $table->timestamps();
+
+            $table->unique(['campaign_id', 'slug']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tags');
+    }
+};

--- a/backend/database/migrations/2025_10_22_091500_create_taggables_table.php
+++ b/backend/database/migrations/2025_10_22_091500_create_taggables_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\Tag;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('taggables', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignIdFor(Tag::class)->constrained()->cascadeOnDelete();
+            $table->morphs('taggable');
+            $table->timestamps();
+
+            $table->unique(['tag_id', 'taggable_type', 'taggable_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('taggables');
+    }
+};

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -19,12 +19,20 @@ class DatabaseSeeder extends Seeder
             'name' => 'Demo GM',
             'email' => 'gm@example.com',
             'password' => 'password',
+            'locale' => 'en',
+            'timezone' => 'UTC',
+            'theme' => 'dark',
         ]);
 
         User::factory()->create([
             'name' => 'Demo Player',
             'email' => 'player@example.com',
             'password' => 'password',
+            'locale' => 'ro',
+            'timezone' => 'Europe/Bucharest',
+            'theme' => 'light',
+            'high_contrast' => true,
+            'font_scale' => 110,
         ]);
     }
 }

--- a/backend/resources/css/app.css
+++ b/backend/resources/css/app.css
@@ -2,12 +2,21 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
+:root[data-color-scheme='dark'] {
     color-scheme: dark;
+}
+
+:root[data-color-scheme='light'] {
+    color-scheme: light;
 }
 
 body {
     font-family: theme('fontFamily.sans');
+}
+
+.high-contrast *:focus-visible {
+    outline: 3px solid theme('colors.amber.400');
+    outline-offset: 3px;
 }
 
 .hero-gradient {

--- a/backend/resources/js/Layouts/AppLayout.tsx
+++ b/backend/resources/js/Layouts/AppLayout.tsx
@@ -1,44 +1,195 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useEffect, useMemo, useState } from 'react';
 
 import { Link, usePage } from '@inertiajs/react';
 
 import { Button } from '@/components/ui/button';
+import { useTranslations } from '@/hooks/useTranslations';
+
+type PreferenceBag = {
+    locale: string;
+    timezone: string;
+    theme: 'system' | 'dark' | 'light';
+    high_contrast: boolean;
+    font_scale: number;
+};
 
 export default function AppLayout({ children }: PropsWithChildren) {
-    const { props } = usePage();
-    const flash = props.flash as { success?: string; error?: string } | undefined;
+    const { t, locale } = useTranslations();
+    const { props } = usePage<{
+        csrf_token?: string;
+        flash?: { success?: string; error?: string };
+        auth?: { user?: { name: string } & PreferenceBag };
+        preferences?: PreferenceBag;
+    }>();
+
+    const flash = props.flash;
     const user = props.auth?.user;
+    const preferences: PreferenceBag = {
+        locale: props.preferences?.locale ?? locale ?? 'en',
+        timezone: props.preferences?.timezone ?? 'UTC',
+        theme: (props.preferences?.theme as PreferenceBag['theme']) ?? 'system',
+        high_contrast: props.preferences?.high_contrast ?? false,
+        font_scale: props.preferences?.font_scale ?? 100,
+    };
+
+    const [isDarkMode, setIsDarkMode] = useState(true);
+
+    useEffect(() => {
+        if (typeof document === 'undefined') {
+            return;
+        }
+
+        document.documentElement.lang = locale ?? 'en';
+    }, [locale]);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') {
+            return undefined;
+        }
+
+        const media = window.matchMedia('(prefers-color-scheme: dark)');
+
+        const applyTheme = () => {
+            const shouldUseDark =
+                preferences.theme === 'dark' || (preferences.theme === 'system' && media.matches);
+
+            setIsDarkMode(shouldUseDark);
+            document.documentElement.classList.toggle('dark', shouldUseDark);
+            document.documentElement.dataset.colorScheme = shouldUseDark ? 'dark' : 'light';
+        };
+
+        applyTheme();
+
+        if (preferences.theme === 'system') {
+            media.addEventListener('change', applyTheme);
+            return () => media.removeEventListener('change', applyTheme);
+        }
+
+        return undefined;
+    }, [preferences.theme]);
+
+    useEffect(() => {
+        if (typeof document === 'undefined') {
+            return;
+        }
+
+        document.documentElement.classList.toggle('high-contrast', Boolean(preferences.high_contrast));
+    }, [preferences.high_contrast]);
+
+    useEffect(() => {
+        if (typeof document === 'undefined') {
+            return;
+        }
+
+        document.documentElement.style.fontSize = `${preferences.font_scale}%`;
+    }, [preferences.font_scale]);
+
+    const containerClass = useMemo(() => {
+        const palette = isDarkMode
+            ? 'bg-zinc-950 text-zinc-100'
+            : 'bg-amber-50 text-slate-900';
+
+        return `min-h-screen transition-colors duration-200 ${palette}`;
+    }, [isDarkMode]);
+
+    const headerClass = useMemo(() => {
+        return isDarkMode
+            ? 'border-zinc-800 bg-zinc-900/80'
+            : 'border-amber-200 bg-white/80 backdrop-blur';
+    }, [isDarkMode]);
+
+    const navLinkClass = useMemo(() => {
+        const base = 'hidden text-sm sm:inline-flex transition focus-visible:outline-none';
+        const color = isDarkMode
+            ? 'text-zinc-400 hover:text-amber-300'
+            : 'text-slate-600 hover:text-amber-600';
+
+        return `${base} ${color}`;
+    }, [isDarkMode]);
+
+    const buttonClass = useMemo(() => {
+        return isDarkMode ? 'text-zinc-300 hover:text-amber-300' : 'text-slate-600 hover:text-amber-600';
+    }, [isDarkMode]);
+
+    const flashSuccessClass = useMemo(() => {
+        return isDarkMode
+            ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200'
+            : 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700';
+    }, [isDarkMode]);
+
+    const flashErrorClass = useMemo(() => {
+        return isDarkMode
+            ? 'border-rose-500/40 bg-rose-500/10 text-rose-200'
+            : 'border-rose-500/40 bg-rose-500/10 text-rose-700';
+    }, [isDarkMode]);
 
     return (
-        <div className="min-h-screen bg-zinc-950 text-zinc-100">
-            <header className="border-b border-zinc-800 bg-zinc-900/80 backdrop-blur">
+        <div className={containerClass}>
+            <a
+                href="#main-content"
+                className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-amber-500 focus:px-4 focus:py-2 focus:text-zinc-950"
+            >
+                {t('a11y.skip_to_content')}
+            </a>
+            <header className={`border-b backdrop-blur ${headerClass}`}>
                 <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
-                    <Link href={route('dashboard')} className="text-lg font-semibold tracking-wide">
-                        Dungen & Dragons
-                    </Link>
-                    <div className="flex items-center gap-3 text-sm text-zinc-300">
-                        {user && <span className="text-zinc-400">{user.name}</span>}
+                    <div className="flex items-center gap-6">
+                        <Link
+                            href={route('dashboard')}
+                            className="text-lg font-semibold tracking-wide focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400"
+                        >
+                            {t('app_name')}
+                        </Link>
+                        {user && (
+                            <Link
+                                href={route('search.index')}
+                                className={`${navLinkClass} focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400`}
+                            >
+                                {t('navigation.search')}
+                            </Link>
+                        )}
+                        {user && (
+                            <Link
+                                href={route('settings.preferences.edit')}
+                                className={`${navLinkClass} focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400`}
+                            >
+                                {t('navigation.preferences')}
+                            </Link>
+                        )}
+                    </div>
+                    <div className="flex items-center gap-3 text-sm">
+                        {user && (
+                            <span className={isDarkMode ? 'text-zinc-400' : 'text-slate-600'} aria-live="polite">
+                                {user.name}
+                            </span>
+                        )}
                         <form method="post" action={route('logout')}>
                             <input
                                 type="hidden"
                                 name="_token"
                                 value={typeof props.csrf_token === 'string' ? props.csrf_token : ''}
                             />
-                            <Button variant="ghost" size="sm" className="text-zinc-300 hover:text-amber-300" type="submit">
-                                Log out
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                className={`${buttonClass} focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400`}
+                                type="submit"
+                                aria-label={t('navigation.logout')}
+                            >
+                                {t('navigation.logout')}
                             </Button>
                         </form>
                     </div>
                 </div>
             </header>
-            <main className="mx-auto max-w-7xl px-6 py-10 space-y-6">
+            <main id="main-content" className="mx-auto max-w-7xl space-y-6 px-6 py-10">
                 {flash?.success && (
-                    <div className="rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
+                    <div className={`rounded-lg border px-4 py-3 text-sm ${flashSuccessClass}`} role="status">
                         {flash.success}
                     </div>
                 )}
                 {flash?.error && (
-                    <div className="rounded-lg border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+                    <div className={`rounded-lg border px-4 py-3 text-sm ${flashErrorClass}`} role="alert">
                         {flash.error}
                     </div>
                 )}

--- a/backend/resources/js/Pages/CampaignEntities/Create.tsx
+++ b/backend/resources/js/Pages/CampaignEntities/Create.tsx
@@ -1,0 +1,446 @@
+import { FormEvent, useState } from 'react';
+
+import { Head, Link, useForm } from '@inertiajs/react';
+
+import AppLayout from '@/Layouts/AppLayout';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { InputError } from '@/components/InputError';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+
+type CampaignSummary = {
+    id: number;
+    title: string;
+};
+
+type TagOption = {
+    id: number;
+    label: string;
+    slug: string;
+};
+
+type GroupSummary = {
+    id: number;
+    name: string;
+};
+
+type MemberSummary = {
+    id: number;
+    name: string;
+};
+
+type CampaignEntityCreateProps = {
+    campaign: CampaignSummary;
+    available_types: string[];
+    visibility_options: string[];
+    available_tags: TagOption[];
+    group: GroupSummary;
+    members: MemberSummary[];
+};
+
+type StatEntry = {
+    label: string;
+    value: string;
+};
+
+const typeLabels: Record<string, string> = {
+    character: 'Character',
+    npc: 'NPC',
+    monster: 'Monster',
+    item: 'Relic / Item',
+    location: 'Location',
+};
+
+const visibilityLabels: Record<string, string> = {
+    gm: 'GM secret',
+    players: 'Shared with party',
+    public: 'Public lore',
+};
+
+const buildInitialStats = (): StatEntry[] => [{ label: '', value: '' }];
+
+export default function CampaignEntityCreate({
+    campaign,
+    available_types,
+    visibility_options,
+    available_tags,
+    group,
+    members,
+}: CampaignEntityCreateProps) {
+    const [tagDraft, setTagDraft] = useState('');
+
+    const { data, setData, post, processing, errors } = useForm({
+        entity_type: available_types[0] ?? 'character',
+        name: '',
+        alias: '',
+        pronunciation: '',
+        visibility: visibility_options.includes('players')
+            ? 'players'
+            : visibility_options[0] ?? 'gm',
+        group_id: group?.id ? String(group.id) : '',
+        owner_id: '',
+        ai_controlled: false,
+        initiative_default: '',
+        description: '',
+        stats: buildInitialStats(),
+        tags: [] as string[],
+    });
+
+    const submit: FormEvent<HTMLFormElement> = (event) => {
+        event.preventDefault();
+
+        post(route('campaigns.entities.store', campaign.id));
+    };
+
+    const toggleTag = (label: string) => {
+        setData(
+            'tags',
+            data.tags.includes(label)
+                ? data.tags.filter((tag) => tag !== label)
+                : [...data.tags, label]
+        );
+    };
+
+    const addTagDraft = () => {
+        const value = tagDraft.trim();
+        if (value.length === 0) {
+            return;
+        }
+
+        if (!data.tags.includes(value)) {
+            setData('tags', [...data.tags, value]);
+        }
+
+        setTagDraft('');
+    };
+
+    const updateStat = (index: number, field: keyof StatEntry, value: string) => {
+        const stats = data.stats.slice();
+        stats[index] = { ...stats[index], [field]: value };
+        setData('stats', stats);
+    };
+
+    const addStatRow = () => {
+        setData('stats', [...data.stats, { label: '', value: '' }]);
+    };
+
+    const removeStatRow = (index: number) => {
+        const next = data.stats.slice();
+        next.splice(index, 1);
+        setData('stats', next.length > 0 ? next : buildInitialStats());
+    };
+
+    return (
+        <AppLayout>
+            <Head title={`Add lore entry · ${campaign.title}`} />
+
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-3xl font-semibold text-zinc-100">Add lore entry</h1>
+                    <p className="mt-1 text-sm text-zinc-400">
+                        Capture the legends, allies, and curiosities adventurers may encounter.
+                    </p>
+                </div>
+                <Button asChild variant="outline" className="border-zinc-700 text-sm text-zinc-300">
+                    <Link href={route('campaigns.entities.index', campaign.id)}>Back to codex</Link>
+                </Button>
+            </div>
+
+            <form onSubmit={submit} className="mt-6 space-y-8">
+                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
+                    <h2 className="text-lg font-semibold text-zinc-100">Essentials</h2>
+                    <p className="text-sm text-zinc-500">
+                        Provide a name and optional epithets so storytellers can reference this entity during play.
+                    </p>
+
+                    <div className="mt-4 grid gap-4 md:grid-cols-2">
+                        <div>
+                            <Label htmlFor="name">Name</Label>
+                            <Input
+                                id="name"
+                                value={data.name}
+                                onChange={(event) => setData('name', event.target.value)}
+                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                                required
+                            />
+                            <InputError message={errors.name} className="mt-2" />
+                        </div>
+
+                        <div>
+                            <Label htmlFor="alias">Alias / epithet</Label>
+                            <Input
+                                id="alias"
+                                value={data.alias}
+                                onChange={(event) => setData('alias', event.target.value)}
+                                placeholder="e.g., The Whispered Blade"
+                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                            />
+                            <InputError message={errors.alias} className="mt-2" />
+                        </div>
+
+                        <div>
+                            <Label htmlFor="pronunciation">Pronunciation</Label>
+                            <Input
+                                id="pronunciation"
+                                value={data.pronunciation}
+                                onChange={(event) => setData('pronunciation', event.target.value)}
+                                placeholder="Optional pronunciation guide"
+                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                            />
+                            <InputError message={errors.pronunciation} className="mt-2" />
+                        </div>
+
+                        <div>
+                            <Label htmlFor="entity_type">Entity type</Label>
+                            <select
+                                id="entity_type"
+                                value={data.entity_type}
+                                onChange={(event) => setData('entity_type', event.target.value)}
+                                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100"
+                            >
+                                {available_types.map((type) => (
+                                    <option key={type} value={type}>
+                                        {typeLabels[type] ?? type}
+                                    </option>
+                                ))}
+                            </select>
+                            <InputError message={errors.entity_type} className="mt-2" />
+                        </div>
+                    </div>
+                </section>
+
+                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
+                    <h2 className="text-lg font-semibold text-zinc-100">Lore & stewardship</h2>
+                    <p className="text-sm text-zinc-500">
+                        Note who tends this entry and how visible it is to the party.
+                    </p>
+
+                    <div className="mt-4 grid gap-4 md:grid-cols-2">
+                        <div>
+                            <Label htmlFor="visibility">Visibility</Label>
+                            <select
+                                id="visibility"
+                                value={data.visibility}
+                                onChange={(event) => setData('visibility', event.target.value)}
+                                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100"
+                            >
+                                {visibility_options.map((visibility) => (
+                                    <option key={visibility} value={visibility}>
+                                        {visibilityLabels[visibility] ?? visibility}
+                                    </option>
+                                ))}
+                            </select>
+                            <InputError message={errors.visibility} className="mt-2" />
+                        </div>
+
+                        <div>
+                            <Label htmlFor="owner_id">Steward</Label>
+                            <select
+                                id="owner_id"
+                                value={data.owner_id}
+                                onChange={(event) => setData('owner_id', event.target.value)}
+                                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100"
+                            >
+                                <option value="">Unassigned</option>
+                                {members.map((member) => (
+                                    <option key={member.id} value={member.id}>
+                                        {member.name}
+                                    </option>
+                                ))}
+                            </select>
+                            <InputError message={errors.owner_id} className="mt-2" />
+                        </div>
+
+                        <div>
+                            <Label htmlFor="group_id">Group alignment</Label>
+                            <select
+                                id="group_id"
+                                value={data.group_id}
+                                onChange={(event) => setData('group_id', event.target.value)}
+                                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100"
+                            >
+                                <option value="">No dedicated group</option>
+                                <option value={group.id}>{group.name}</option>
+                            </select>
+                            <InputError message={errors.group_id} className="mt-2" />
+                        </div>
+
+                        <div>
+                            <Label htmlFor="initiative_default">Initiative default</Label>
+                            <Input
+                                id="initiative_default"
+                                type="number"
+                                min={0}
+                                max={40}
+                                value={data.initiative_default}
+                                onChange={(event) => setData('initiative_default', event.target.value)}
+                                placeholder="Optional initiative baseline"
+                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                            />
+                            <InputError message={errors.initiative_default} className="mt-2" />
+                        </div>
+                    </div>
+
+                    <div className="mt-4 flex items-center gap-2">
+                        <Checkbox
+                            id="ai_controlled"
+                            checked={data.ai_controlled}
+                            onCheckedChange={(checked) => setData('ai_controlled', checked === true)}
+                        />
+                        <Label htmlFor="ai_controlled" className="text-sm text-zinc-300">
+                            AI stewarded lore entry
+                        </Label>
+                        <InputError message={errors.ai_controlled} className="ml-2" />
+                    </div>
+
+                    <div className="mt-4">
+                        <Label htmlFor="description">Lore summary</Label>
+                        <Textarea
+                            id="description"
+                            value={data.description}
+                            onChange={(event) => setData('description', event.target.value)}
+                            placeholder="Describe their history, motives, or significance. Markdown supported."
+                            className="mt-1 min-h-[160px] border-zinc-700 bg-zinc-900/60 text-sm text-zinc-100"
+                        />
+                        <InputError message={errors.description} className="mt-2" />
+                    </div>
+                </section>
+
+                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
+                    <h2 className="text-lg font-semibold text-zinc-100">Stat blocks</h2>
+                    <p className="text-sm text-zinc-500">
+                        Track notable traits or mechanics (AC, HP, key abilities) for quick reference.
+                    </p>
+
+                    <div className="mt-4 space-y-4">
+                        {data.stats.map((stat, index) => (
+                            <div key={index} className="flex flex-col gap-2 rounded-lg border border-zinc-800/80 p-4 md:flex-row">
+                                <div className="md:w-1/3">
+                                    <Label>Label</Label>
+                                    <Input
+                                        value={stat.label}
+                                        onChange={(event) => updateStat(index, 'label', event.target.value)}
+                                        placeholder="e.g., Armor Class"
+                                        className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                                    />
+                                </div>
+                                <div className="md:w-1/3">
+                                    <Label>Value</Label>
+                                    <Input
+                                        value={stat.value}
+                                        onChange={(event) => updateStat(index, 'value', event.target.value)}
+                                        placeholder="e.g., 16 (chain mail)"
+                                        className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                                    />
+                                </div>
+                                <div className="flex items-end justify-end md:w-1/3">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        onClick={() => removeStatRow(index)}
+                                        className="border-rose-700/60 text-sm text-rose-200 hover:bg-rose-900/40"
+                                    >
+                                        Remove
+                                    </Button>
+                                </div>
+                            </div>
+                        ))}
+
+                        <Button
+                            type="button"
+                            onClick={addStatRow}
+                            className="w-full bg-indigo-500/20 text-indigo-200 hover:bg-indigo-500/30"
+                        >
+                            Add another stat
+                        </Button>
+                        <InputError message={errors.stats} />
+                    </div>
+                </section>
+
+                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
+                    <h2 className="text-lg font-semibold text-zinc-100">Tags & themes</h2>
+                    <p className="text-sm text-zinc-500">
+                        Tag entries for quicker discovery during play (factions, arc names, mood cues).
+                    </p>
+
+                    <div className="mt-4 flex flex-wrap gap-2">
+                        {data.tags.length === 0 ? (
+                            <span className="text-xs text-zinc-500">No tags selected yet.</span>
+                        ) : (
+                            data.tags.map((tag) => (
+                                <span
+                                    key={tag}
+                                    className="flex items-center gap-2 rounded-full bg-amber-500/10 px-3 py-1 text-xs text-amber-100"
+                                >
+                                    {tag}
+                                    <button
+                                        type="button"
+                                        onClick={() => toggleTag(tag)}
+                                        className="rounded-full bg-amber-500/40 px-2 text-[10px] uppercase tracking-wide"
+                                    >
+                                        Remove
+                                    </button>
+                                </span>
+                            ))
+                        )}
+                    </div>
+
+                    <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end">
+                        <div className="sm:flex-1">
+                            <Label htmlFor="tagDraft">Add a new tag</Label>
+                            <Input
+                                id="tagDraft"
+                                value={tagDraft}
+                                onChange={(event) => setTagDraft(event.target.value)}
+                                placeholder="e.g., Shadow Court"
+                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                            />
+                        </div>
+                        <Button
+                            type="button"
+                            onClick={addTagDraft}
+                            className="sm:w-auto bg-emerald-500/20 text-emerald-200 hover:bg-emerald-500/30"
+                        >
+                            Add tag
+                        </Button>
+                    </div>
+
+                    {available_tags.length > 0 && (
+                        <div className="mt-4 space-y-2">
+                            <p className="text-xs uppercase tracking-wide text-zinc-500">Popular tags</p>
+                            <div className="flex flex-wrap gap-2">
+                                {available_tags.map((tag) => (
+                                    <button
+                                        type="button"
+                                        key={tag.slug}
+                                        onClick={() => toggleTag(tag.label)}
+                                        className={`rounded-full px-3 py-1 text-xs font-semibold transition ${
+                                            data.tags.includes(tag.label)
+                                                ? 'bg-emerald-500/30 text-emerald-100'
+                                                : 'bg-zinc-800/80 text-zinc-300 hover:bg-zinc-700'
+                                        }`}
+                                    >
+                                        {tag.label}
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+
+                    <InputError message={errors.tags} className="mt-2" />
+                </section>
+
+                <div className="flex items-center justify-end gap-3">
+                    <Button asChild variant="outline" className="border-zinc-700 text-sm text-zinc-300">
+                        <Link href={route('campaigns.entities.index', campaign.id)}>Cancel</Link>
+                    </Button>
+                    <Button type="submit" disabled={processing} className="bg-amber-500/30 text-amber-100">
+                        Save lore entry
+                    </Button>
+                </div>
+            </form>
+        </AppLayout>
+    );
+}

--- a/backend/resources/js/Pages/CampaignEntities/Edit.tsx
+++ b/backend/resources/js/Pages/CampaignEntities/Edit.tsx
@@ -1,0 +1,487 @@
+import { FormEvent, useState } from 'react';
+
+import { Head, Link, router, useForm } from '@inertiajs/react';
+
+import AppLayout from '@/Layouts/AppLayout';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { InputError } from '@/components/InputError';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+
+type CampaignSummary = {
+    id: number;
+    title: string;
+};
+
+type TagOption = {
+    id: number;
+    label: string;
+    slug: string;
+};
+
+type GroupSummary = {
+    id: number;
+    name: string;
+};
+
+type MemberSummary = {
+    id: number;
+    name: string;
+};
+
+type StatEntry = {
+    label: string;
+    value: string;
+};
+
+type EntityPayload = {
+    id: number;
+    entity_type: string;
+    name: string;
+    alias: string | null;
+    pronunciation: string | null;
+    visibility: string;
+    group_id: number | null;
+    owner_id: number | null;
+    ai_controlled: boolean;
+    initiative_default: number | null;
+    description: string | null;
+    stats: StatEntry[] | null;
+    tags: string[];
+};
+
+type CampaignEntityEditProps = {
+    campaign: CampaignSummary;
+    entity: EntityPayload;
+    available_types: string[];
+    visibility_options: string[];
+    available_tags: TagOption[];
+    group: GroupSummary;
+    members: MemberSummary[];
+};
+
+const typeLabels: Record<string, string> = {
+    character: 'Character',
+    npc: 'NPC',
+    monster: 'Monster',
+    item: 'Relic / Item',
+    location: 'Location',
+};
+
+const visibilityLabels: Record<string, string> = {
+    gm: 'GM secret',
+    players: 'Shared with party',
+    public: 'Public lore',
+};
+
+const ensureStats = (stats: StatEntry[] | null | undefined): StatEntry[] => {
+    if (!stats || stats.length === 0) {
+        return [{ label: '', value: '' }];
+    }
+
+    return stats.map((entry) => ({
+        label: entry.label ?? '',
+        value: entry.value ?? '',
+    }));
+};
+
+export default function CampaignEntityEdit({
+    campaign,
+    entity,
+    available_types,
+    visibility_options,
+    available_tags,
+    group,
+    members,
+}: CampaignEntityEditProps) {
+    const [tagDraft, setTagDraft] = useState('');
+
+    const { data, setData, put, processing, errors } = useForm({
+        entity_type: entity.entity_type,
+        name: entity.name,
+        alias: entity.alias ?? '',
+        pronunciation: entity.pronunciation ?? '',
+        visibility: entity.visibility,
+        group_id: entity.group_id ? String(entity.group_id) : '',
+        owner_id: entity.owner_id ? String(entity.owner_id) : '',
+        ai_controlled: entity.ai_controlled,
+        initiative_default: entity.initiative_default?.toString() ?? '',
+        description: entity.description ?? '',
+        stats: ensureStats(entity.stats),
+        tags: entity.tags ?? [],
+    });
+
+    const submit: FormEvent<HTMLFormElement> = (event) => {
+        event.preventDefault();
+
+        put(route('campaigns.entities.update', [campaign.id, entity.id]));
+    };
+
+    const toggleTag = (label: string) => {
+        setData(
+            'tags',
+            data.tags.includes(label)
+                ? data.tags.filter((tag) => tag !== label)
+                : [...data.tags, label]
+        );
+    };
+
+    const addTagDraft = () => {
+        const value = tagDraft.trim();
+        if (value.length === 0) {
+            return;
+        }
+
+        if (!data.tags.includes(value)) {
+            setData('tags', [...data.tags, value]);
+        }
+
+        setTagDraft('');
+    };
+
+    const updateStat = (index: number, field: keyof StatEntry, value: string) => {
+        const stats = data.stats.slice();
+        stats[index] = { ...stats[index], [field]: value };
+        setData('stats', stats);
+    };
+
+    const addStatRow = () => {
+        setData('stats', [...data.stats, { label: '', value: '' }]);
+    };
+
+    const removeStatRow = (index: number) => {
+        const next = data.stats.slice();
+        next.splice(index, 1);
+        setData('stats', next.length > 0 ? next : [{ label: '', value: '' }]);
+    };
+
+    const destroy = () => {
+        if (window.confirm('Archive this lore entry? It can be restored from the database later.')) {
+            router.delete(route('campaigns.entities.destroy', [campaign.id, entity.id]));
+        }
+    };
+
+    return (
+        <AppLayout>
+            <Head title={`Edit lore · ${entity.name}`} />
+
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <h1 className="text-3xl font-semibold text-zinc-100">Edit lore entry</h1>
+                    <p className="mt-1 text-sm text-zinc-400">
+                        Update details as the story evolves. Keep tags and stats aligned with the latest chronicles.
+                    </p>
+                </div>
+                <div className="flex items-center gap-3">
+                    <Button asChild variant="outline" className="border-zinc-700 text-sm text-zinc-300">
+                        <Link href={route('campaigns.entities.show', [campaign.id, entity.id])}>View entry</Link>
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        onClick={destroy}
+                        className="border-rose-700/60 text-sm text-rose-200 hover:bg-rose-900/40"
+                    >
+                        Archive
+                    </Button>
+                </div>
+            </div>
+
+            <form onSubmit={submit} className="mt-6 space-y-8">
+                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
+                    <h2 className="text-lg font-semibold text-zinc-100">Essentials</h2>
+                    <p className="text-sm text-zinc-500">
+                        Provide a name and optional epithets so storytellers can reference this entity during play.
+                    </p>
+
+                    <div className="mt-4 grid gap-4 md:grid-cols-2">
+                        <div>
+                            <Label htmlFor="name">Name</Label>
+                            <Input
+                                id="name"
+                                value={data.name}
+                                onChange={(event) => setData('name', event.target.value)}
+                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                                required
+                            />
+                            <InputError message={errors.name} className="mt-2" />
+                        </div>
+
+                        <div>
+                            <Label htmlFor="alias">Alias / epithet</Label>
+                            <Input
+                                id="alias"
+                                value={data.alias}
+                                onChange={(event) => setData('alias', event.target.value)}
+                                placeholder="e.g., The Whispered Blade"
+                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                            />
+                            <InputError message={errors.alias} className="mt-2" />
+                        </div>
+
+                        <div>
+                            <Label htmlFor="pronunciation">Pronunciation</Label>
+                            <Input
+                                id="pronunciation"
+                                value={data.pronunciation}
+                                onChange={(event) => setData('pronunciation', event.target.value)}
+                                placeholder="Optional pronunciation guide"
+                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                            />
+                            <InputError message={errors.pronunciation} className="mt-2" />
+                        </div>
+
+                        <div>
+                            <Label htmlFor="entity_type">Entity type</Label>
+                            <select
+                                id="entity_type"
+                                value={data.entity_type}
+                                onChange={(event) => setData('entity_type', event.target.value)}
+                                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100"
+                            >
+                                {available_types.map((type) => (
+                                    <option key={type} value={type}>
+                                        {typeLabels[type] ?? type}
+                                    </option>
+                                ))}
+                            </select>
+                            <InputError message={errors.entity_type} className="mt-2" />
+                        </div>
+                    </div>
+                </section>
+
+                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
+                    <h2 className="text-lg font-semibold text-zinc-100">Lore & stewardship</h2>
+                    <p className="text-sm text-zinc-500">
+                        Note who tends this entry and how visible it is to the party.
+                    </p>
+
+                    <div className="mt-4 grid gap-4 md:grid-cols-2">
+                        <div>
+                            <Label htmlFor="visibility">Visibility</Label>
+                            <select
+                                id="visibility"
+                                value={data.visibility}
+                                onChange={(event) => setData('visibility', event.target.value)}
+                                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100"
+                            >
+                                {visibility_options.map((visibility) => (
+                                    <option key={visibility} value={visibility}>
+                                        {visibilityLabels[visibility] ?? visibility}
+                                    </option>
+                                ))}
+                            </select>
+                            <InputError message={errors.visibility} className="mt-2" />
+                        </div>
+
+                        <div>
+                            <Label htmlFor="owner_id">Steward</Label>
+                            <select
+                                id="owner_id"
+                                value={data.owner_id}
+                                onChange={(event) => setData('owner_id', event.target.value)}
+                                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100"
+                            >
+                                <option value="">Unassigned</option>
+                                {members.map((member) => (
+                                    <option key={member.id} value={member.id}>
+                                        {member.name}
+                                    </option>
+                                ))}
+                            </select>
+                            <InputError message={errors.owner_id} className="mt-2" />
+                        </div>
+
+                        <div>
+                            <Label htmlFor="group_id">Group alignment</Label>
+                            <select
+                                id="group_id"
+                                value={data.group_id}
+                                onChange={(event) => setData('group_id', event.target.value)}
+                                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100"
+                            >
+                                <option value="">No dedicated group</option>
+                                <option value={group.id}>{group.name}</option>
+                            </select>
+                            <InputError message={errors.group_id} className="mt-2" />
+                        </div>
+
+                        <div>
+                            <Label htmlFor="initiative_default">Initiative default</Label>
+                            <Input
+                                id="initiative_default"
+                                type="number"
+                                min={0}
+                                max={40}
+                                value={data.initiative_default}
+                                onChange={(event) => setData('initiative_default', event.target.value)}
+                                placeholder="Optional initiative baseline"
+                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                            />
+                            <InputError message={errors.initiative_default} className="mt-2" />
+                        </div>
+                    </div>
+
+                    <div className="mt-4 flex items-center gap-2">
+                        <Checkbox
+                            id="ai_controlled"
+                            checked={data.ai_controlled}
+                            onCheckedChange={(checked) => setData('ai_controlled', checked === true)}
+                        />
+                        <Label htmlFor="ai_controlled" className="text-sm text-zinc-300">
+                            AI stewarded lore entry
+                        </Label>
+                        <InputError message={errors.ai_controlled} className="ml-2" />
+                    </div>
+
+                    <div className="mt-4">
+                        <Label htmlFor="description">Lore summary</Label>
+                        <Textarea
+                            id="description"
+                            value={data.description}
+                            onChange={(event) => setData('description', event.target.value)}
+                            placeholder="Describe their history, motives, or significance. Markdown supported."
+                            className="mt-1 min-h-[160px] border-zinc-700 bg-zinc-900/60 text-sm text-zinc-100"
+                        />
+                        <InputError message={errors.description} className="mt-2" />
+                    </div>
+                </section>
+
+                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
+                    <h2 className="text-lg font-semibold text-zinc-100">Stat blocks</h2>
+                    <p className="text-sm text-zinc-500">
+                        Track notable traits or mechanics (AC, HP, key abilities) for quick reference.
+                    </p>
+
+                    <div className="mt-4 space-y-4">
+                        {data.stats.map((stat, index) => (
+                            <div key={index} className="flex flex-col gap-2 rounded-lg border border-zinc-800/80 p-4 md:flex-row">
+                                <div className="md:w-1/3">
+                                    <Label>Label</Label>
+                                    <Input
+                                        value={stat.label}
+                                        onChange={(event) => updateStat(index, 'label', event.target.value)}
+                                        placeholder="e.g., Armor Class"
+                                        className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                                    />
+                                </div>
+                                <div className="md:w-1/3">
+                                    <Label>Value</Label>
+                                    <Input
+                                        value={stat.value}
+                                        onChange={(event) => updateStat(index, 'value', event.target.value)}
+                                        placeholder="e.g., 16 (chain mail)"
+                                        className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                                    />
+                                </div>
+                                <div className="flex items-end justify-end md:w-1/3">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        onClick={() => removeStatRow(index)}
+                                        className="border-rose-700/60 text-sm text-rose-200 hover:bg-rose-900/40"
+                                    >
+                                        Remove
+                                    </Button>
+                                </div>
+                            </div>
+                        ))}
+
+                        <Button
+                            type="button"
+                            onClick={addStatRow}
+                            className="w-full bg-indigo-500/20 text-indigo-200 hover:bg-indigo-500/30"
+                        >
+                            Add another stat
+                        </Button>
+                        <InputError message={errors.stats} />
+                    </div>
+                </section>
+
+                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
+                    <h2 className="text-lg font-semibold text-zinc-100">Tags & themes</h2>
+                    <p className="text-sm text-zinc-500">
+                        Tag entries for quicker discovery during play (factions, arc names, mood cues).
+                    </p>
+
+                    <div className="mt-4 flex flex-wrap gap-2">
+                        {data.tags.length === 0 ? (
+                            <span className="text-xs text-zinc-500">No tags selected yet.</span>
+                        ) : (
+                            data.tags.map((tag) => (
+                                <span
+                                    key={tag}
+                                    className="flex items-center gap-2 rounded-full bg-amber-500/10 px-3 py-1 text-xs text-amber-100"
+                                >
+                                    {tag}
+                                    <button
+                                        type="button"
+                                        onClick={() => toggleTag(tag)}
+                                        className="rounded-full bg-amber-500/40 px-2 text-[10px] uppercase tracking-wide"
+                                    >
+                                        Remove
+                                    </button>
+                                </span>
+                            ))
+                        )}
+                    </div>
+
+                    <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end">
+                        <div className="sm:flex-1">
+                            <Label htmlFor="tagDraft">Add a new tag</Label>
+                            <Input
+                                id="tagDraft"
+                                value={tagDraft}
+                                onChange={(event) => setTagDraft(event.target.value)}
+                                placeholder="e.g., Shadow Court"
+                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                            />
+                        </div>
+                        <Button
+                            type="button"
+                            onClick={addTagDraft}
+                            className="sm:w-auto bg-emerald-500/20 text-emerald-200 hover:bg-emerald-500/30"
+                        >
+                            Add tag
+                        </Button>
+                    </div>
+
+                    {available_tags.length > 0 && (
+                        <div className="mt-4 space-y-2">
+                            <p className="text-xs uppercase tracking-wide text-zinc-500">Popular tags</p>
+                            <div className="flex flex-wrap gap-2">
+                                {available_tags.map((tag) => (
+                                    <button
+                                        type="button"
+                                        key={tag.slug}
+                                        onClick={() => toggleTag(tag.label)}
+                                        className={`rounded-full px-3 py-1 text-xs font-semibold transition ${
+                                            data.tags.includes(tag.label)
+                                                ? 'bg-emerald-500/30 text-emerald-100'
+                                                : 'bg-zinc-800/80 text-zinc-300 hover:bg-zinc-700'
+                                        }`}
+                                    >
+                                        {tag.label}
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+
+                    <InputError message={errors.tags} className="mt-2" />
+                </section>
+
+                <div className="flex items-center justify-end gap-3">
+                    <Button asChild variant="outline" className="border-zinc-700 text-sm text-zinc-300">
+                        <Link href={route('campaigns.entities.show', [campaign.id, entity.id])}>Cancel</Link>
+                    </Button>
+                    <Button type="submit" disabled={processing} className="bg-amber-500/30 text-amber-100">
+                        Update lore entry
+                    </Button>
+                </div>
+            </form>
+        </AppLayout>
+    );
+}

--- a/backend/resources/js/Pages/CampaignEntities/Index.tsx
+++ b/backend/resources/js/Pages/CampaignEntities/Index.tsx
@@ -1,0 +1,253 @@
+import { FormEvent } from 'react';
+
+import { Head, Link, useForm } from '@inertiajs/react';
+
+import AppLayout from '@/Layouts/AppLayout';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+type CampaignSummary = {
+    id: number;
+    title: string;
+    group: { id: number; name: string };
+};
+
+type EntityTag = {
+    id: number;
+    label: string;
+    slug: string;
+    color?: string | null;
+};
+
+type EntityListItem = {
+    id: number;
+    name: string;
+    entity_type: string;
+    alias: string | null;
+    visibility: string;
+    ai_controlled: boolean;
+    tags: EntityTag[];
+    owner: { id: number; name: string } | null;
+};
+
+type FilterState = {
+    search: string;
+    type: string;
+    tag: string;
+};
+
+type CampaignEntityIndexProps = {
+    campaign: CampaignSummary;
+    entities: EntityListItem[];
+    filters: FilterState;
+    available_types: string[];
+    available_tags: EntityTag[];
+};
+
+const typeLabels: Record<string, string> = {
+    character: 'Character',
+    npc: 'NPC',
+    monster: 'Monster',
+    item: 'Relic / Item',
+    location: 'Location',
+};
+
+const visibilityLabels: Record<string, string> = {
+    gm: 'GM Secret',
+    players: 'Party Shared',
+    public: 'Public Lore',
+};
+
+export default function CampaignEntityIndex({
+    campaign,
+    entities,
+    filters,
+    available_types,
+    available_tags,
+}: CampaignEntityIndexProps) {
+    const { data, setData, get, processing } = useForm<FilterState>({
+        search: filters.search ?? '',
+        type: filters.type ?? '',
+        tag: filters.tag ?? '',
+    });
+
+    const submitFilters = (event: FormEvent) => {
+        event.preventDefault();
+
+        get(route('campaigns.entities.index', campaign.id), {
+            preserveState: true,
+            preserveScroll: true,
+            replace: true,
+        });
+    };
+
+    const resetFilters = () => {
+        setData({ search: '', type: '', tag: '' });
+
+        get(route('campaigns.entities.index', campaign.id), {
+            preserveScroll: true,
+            replace: true,
+        });
+    };
+
+    return (
+        <AppLayout>
+            <Head title={`${campaign.title} · Lore Codex`} />
+
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <h1 className="text-3xl font-semibold text-zinc-100">Lore codex</h1>
+                    <p className="mt-1 text-sm text-zinc-400">
+                        Chronicle the legends, allies, rivals, and relics shaping this campaign.
+                    </p>
+                </div>
+
+                <Button asChild className="bg-amber-500/20 text-amber-200 hover:bg-amber-500/30">
+                    <Link href={route('campaigns.entities.create', campaign.id)}>Add lore entry</Link>
+                </Button>
+            </div>
+
+            <form
+                onSubmit={submitFilters}
+                className="mt-6 grid gap-4 rounded-xl border border-zinc-800 bg-zinc-950/60 p-4 sm:grid-cols-4"
+            >
+                <div className="sm:col-span-2">
+                    <Label htmlFor="search" className="text-xs uppercase tracking-wide text-zinc-500">
+                        Search
+                    </Label>
+                    <Input
+                        id="search"
+                        name="search"
+                        value={data.search}
+                        onChange={(event) => setData('search', event.target.value)}
+                        placeholder="Search by name, alias, or lore"
+                        className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                    />
+                </div>
+
+                <div>
+                    <Label htmlFor="type" className="text-xs uppercase tracking-wide text-zinc-500">
+                        Type
+                    </Label>
+                    <select
+                        id="type"
+                        name="type"
+                        value={data.type}
+                        onChange={(event) => setData('type', event.target.value)}
+                        className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100"
+                    >
+                        <option value="">All types</option>
+                        {available_types.map((type) => (
+                            <option key={type} value={type}>
+                                {typeLabels[type] ?? type}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+
+                <div>
+                    <Label htmlFor="tag" className="text-xs uppercase tracking-wide text-zinc-500">
+                        Tag
+                    </Label>
+                    <select
+                        id="tag"
+                        name="tag"
+                        value={data.tag}
+                        onChange={(event) => setData('tag', event.target.value)}
+                        className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100"
+                    >
+                        <option value="">Any tag</option>
+                        {available_tags.map((tag) => (
+                            <option key={tag.slug} value={tag.slug}>
+                                {tag.label}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+
+                <div className="flex items-end gap-2 sm:col-span-4">
+                    <Button type="submit" disabled={processing} className="flex-1 bg-emerald-500/20 text-emerald-200">
+                        Apply filters
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        onClick={resetFilters}
+                        className="border-zinc-700 text-sm text-zinc-300"
+                    >
+                        Clear
+                    </Button>
+                </div>
+            </form>
+
+            <section className="mt-8 grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
+                {entities.length === 0 ? (
+                    <p className="rounded-xl border border-dashed border-zinc-800 bg-zinc-950/40 p-6 text-sm text-zinc-400">
+                        No lore entries found. Start chronicling this world’s legends with the “Add lore entry” button.
+                    </p>
+                ) : (
+                    entities.map((entity) => (
+                        <article
+                            key={entity.id}
+                            className="flex h-full flex-col justify-between rounded-xl border border-zinc-800 bg-zinc-950/60 p-5 shadow-inner shadow-black/20"
+                        >
+                            <div className="space-y-2">
+                                <div className="flex items-center justify-between">
+                                    <h2 className="text-xl font-semibold text-zinc-100">
+                                        <Link
+                                            href={route('campaigns.entities.show', [campaign.id, entity.id])}
+                                            className="hover:text-amber-300"
+                                        >
+                                            {entity.name}
+                                        </Link>
+                                    </h2>
+                                    <span className="rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-300">
+                                        {typeLabels[entity.entity_type] ?? entity.entity_type}
+                                    </span>
+                                </div>
+                                {entity.alias && (
+                                    <p className="text-sm italic text-zinc-400">“{entity.alias}”</p>
+                                )}
+                                <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-400">
+                                    <span className="rounded border border-zinc-700/80 px-2 py-0.5 font-semibold uppercase tracking-wide text-zinc-300">
+                                        {visibilityLabels[entity.visibility] ?? entity.visibility}
+                                    </span>
+                                    {entity.ai_controlled && (
+                                        <span className="rounded bg-emerald-500/10 px-2 py-0.5 font-semibold text-emerald-200">
+                                            AI guided
+                                        </span>
+                                    )}
+                                    {entity.owner && (
+                                        <span className="rounded bg-zinc-800 px-2 py-0.5 text-zinc-300">
+                                            Steward: {entity.owner.name}
+                                        </span>
+                                    )}
+                                </div>
+                            </div>
+
+                            <footer className="mt-4 flex flex-wrap gap-2">
+                                {entity.tags.length === 0 ? (
+                                    <span className="text-xs text-zinc-500">No tags yet</span>
+                                ) : (
+                                    entity.tags.map((tag) => (
+                                        <span
+                                            key={tag.slug}
+                                            className="rounded-full px-3 py-1 text-xs font-semibold"
+                                            style={{
+                                                backgroundColor: tag.color ?? 'rgba(63,63,70,0.5)',
+                                                color: '#0f172a',
+                                            }}
+                                        >
+                                            {tag.label}
+                                        </span>
+                                    ))
+                                )}
+                            </footer>
+                        </article>
+                    ))
+                )}
+            </section>
+        </AppLayout>
+    );
+}

--- a/backend/resources/js/Pages/CampaignEntities/Show.tsx
+++ b/backend/resources/js/Pages/CampaignEntities/Show.tsx
@@ -1,0 +1,165 @@
+import { Head, Link } from '@inertiajs/react';
+
+import AppLayout from '@/Layouts/AppLayout';
+import { Button } from '@/components/ui/button';
+
+type CampaignSummary = {
+    id: number;
+    title: string;
+};
+
+type EntityTag = {
+    id: number;
+    label: string;
+    slug: string;
+    color?: string | null;
+};
+
+type RelatedRecord = {
+    id: number;
+    name: string;
+} | null;
+
+type StatEntry = {
+    label: string;
+    value: string | null;
+};
+
+type EntityPayload = {
+    id: number;
+    name: string;
+    entity_type: string;
+    alias: string | null;
+    pronunciation: string | null;
+    visibility: string;
+    ai_controlled: boolean;
+    initiative_default: number | null;
+    description: string | null;
+    stats: StatEntry[] | null;
+    group: RelatedRecord;
+    owner: RelatedRecord;
+    tags: EntityTag[];
+};
+
+type CampaignEntityShowProps = {
+    campaign: CampaignSummary;
+    entity: EntityPayload;
+};
+
+const typeLabels: Record<string, string> = {
+    character: 'Character',
+    npc: 'NPC',
+    monster: 'Monster',
+    item: 'Relic / Item',
+    location: 'Location',
+};
+
+const visibilityLabels: Record<string, string> = {
+    gm: 'GM Secret',
+    players: 'Shared with party',
+    public: 'Public lore',
+};
+
+export default function CampaignEntityShow({ campaign, entity }: CampaignEntityShowProps) {
+    return (
+        <AppLayout>
+            <Head title={`${entity.name} · ${campaign.title}`} />
+
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <h1 className="text-3xl font-semibold text-zinc-100">{entity.name}</h1>
+                    <p className="mt-1 text-sm text-zinc-400">
+                        {typeLabels[entity.entity_type] ?? entity.entity_type} ·{' '}
+                        {visibilityLabels[entity.visibility] ?? entity.visibility}
+                    </p>
+                    {entity.alias && (
+                        <p className="mt-1 text-sm italic text-zinc-400">Known as “{entity.alias}”.</p>
+                    )}
+                    {entity.pronunciation && (
+                        <p className="text-sm text-zinc-500">Pronunciation: {entity.pronunciation}</p>
+                    )}
+                </div>
+
+                <div className="flex items-center gap-3">
+                    <Button asChild variant="outline" className="border-zinc-700 text-sm text-zinc-300">
+                        <Link href={route('campaigns.entities.index', campaign.id)}>Back to codex</Link>
+                    </Button>
+                    <Button asChild className="bg-amber-500/30 text-amber-100">
+                        <Link href={route('campaigns.entities.edit', [campaign.id, entity.id])}>Edit entry</Link>
+                    </Button>
+                </div>
+            </div>
+
+            <section className="mt-6 grid gap-6 lg:grid-cols-3">
+                <article className="lg:col-span-2 space-y-6 rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
+                    <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-wide text-zinc-400">
+                        {entity.ai_controlled && (
+                            <span className="rounded bg-emerald-500/10 px-3 py-1 text-emerald-200">AI stewarded</span>
+                        )}
+                        {entity.initiative_default !== null && (
+                            <span className="rounded bg-indigo-500/10 px-3 py-1 text-indigo-200">
+                                Initiative: {entity.initiative_default}
+                            </span>
+                        )}
+                        {entity.owner && (
+                            <span className="rounded bg-zinc-800 px-3 py-1 text-zinc-300">Steward {entity.owner.name}</span>
+                        )}
+                        {entity.group && (
+                            <span className="rounded bg-zinc-800 px-3 py-1 text-zinc-300">Linked to {entity.group.name}</span>
+                        )}
+                    </div>
+
+                    <div className="prose prose-invert max-w-none">
+                        {entity.description ? (
+                            <p className="whitespace-pre-wrap text-sm leading-relaxed text-zinc-100">{entity.description}</p>
+                        ) : (
+                            <p className="text-sm text-zinc-500">No lore recorded yet. Add a summary to brief storytellers.</p>
+                        )}
+                    </div>
+
+                    <div>
+                        <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-500">Tags</h2>
+                        <div className="mt-2 flex flex-wrap gap-2">
+                            {entity.tags.length === 0 ? (
+                                <span className="text-xs text-zinc-500">No tags assigned.</span>
+                            ) : (
+                                entity.tags.map((tag) => (
+                                    <span
+                                        key={tag.slug}
+                                        className="rounded-full px-3 py-1 text-xs font-semibold"
+                                        style={{
+                                            backgroundColor: tag.color ?? 'rgba(63,63,70,0.5)',
+                                            color: '#0f172a',
+                                        }}
+                                    >
+                                        {tag.label}
+                                    </span>
+                                ))
+                            )}
+                        </div>
+                    </div>
+                </article>
+
+                <aside className="space-y-4 rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
+                    <header>
+                        <h2 className="text-lg font-semibold text-zinc-100">Stat block</h2>
+                        <p className="text-xs uppercase tracking-wide text-zinc-500">Quick reference for combat or roleplay</p>
+                    </header>
+
+                    <dl className="space-y-3">
+                        {entity.stats && entity.stats.length > 0 ? (
+                            entity.stats.map((stat, index) => (
+                                <div key={index} className="rounded-lg border border-zinc-800/70 bg-zinc-900/60 px-4 py-3">
+                                    <dt className="text-xs uppercase tracking-wide text-zinc-500">{stat.label}</dt>
+                                    <dd className="text-sm text-zinc-100">{stat.value ?? '—'}</dd>
+                                </div>
+                            ))
+                        ) : (
+                            <p className="text-sm text-zinc-500">No stat entries yet. Add baseline numbers in the edit view.</p>
+                        )}
+                    </dl>
+                </aside>
+            </section>
+        </AppLayout>
+    );
+}

--- a/backend/resources/js/Pages/Campaigns/Show.tsx
+++ b/backend/resources/js/Pages/Campaigns/Show.tsx
@@ -47,6 +47,8 @@ type CampaignPayload = {
     members: CampaignMember[];
     assignments: CampaignAssignment[];
     invitations: CampaignInvitation[];
+    entities_count: number;
+    recent_entities: { id: number; name: string; entity_type: string }[];
 };
 
 type CampaignShowProps = {
@@ -59,6 +61,14 @@ const roleLabels: Record<string, string> = {
     gm: 'Game Master',
     player: 'Adventurer',
     observer: 'Observer',
+};
+
+const entityTypeLabels: Record<string, string> = {
+    character: 'Character',
+    npc: 'NPC',
+    monster: 'Monster',
+    item: 'Item',
+    location: 'Location',
 };
 
 export default function CampaignShow({ campaign, available_roles }: CampaignShowProps) {
@@ -108,6 +118,13 @@ export default function CampaignShow({ campaign, available_roles }: CampaignShow
                         className="border-emerald-600/60 text-sm text-emerald-200 hover:bg-emerald-500/10"
                     >
                         <Link href={route('campaigns.tasks.index', campaign.id)}>Task board</Link>
+                    </Button>
+                    <Button
+                        asChild
+                        variant="outline"
+                        className="border-purple-600/60 text-sm text-purple-200 hover:bg-purple-500/10"
+                    >
+                        <Link href={route('campaigns.entities.index', campaign.id)}>Lore codex</Link>
                     </Button>
                     <Button
                         asChild
@@ -163,6 +180,45 @@ export default function CampaignShow({ campaign, available_roles }: CampaignShow
                                 <dd>{campaign.end_date ?? 'Open'}</dd>
                             </div>
                         </dl>
+                    </article>
+
+                    <article className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/40">
+                        <header className="flex items-center justify-between">
+                            <h2 className="text-lg font-semibold text-zinc-100">Lore codex</h2>
+                            <span className="text-xs uppercase tracking-wide text-zinc-500">
+                                {campaign.entities_count} entr{campaign.entities_count === 1 ? 'y' : 'ies'}
+                            </span>
+                        </header>
+
+                        {campaign.entities_count === 0 ? (
+                            <p className="mt-4 rounded-lg border border-dashed border-zinc-800 bg-zinc-900/40 p-4 text-sm text-zinc-400">
+                                No lore entries captured yet. Chronicle key NPCs, factions, and relics to anchor each session.
+                            </p>
+                        ) : (
+                            <ul className="mt-4 space-y-3">
+                                {campaign.recent_entities.map((entity) => (
+                                    <li key={entity.id} className="flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-900/60 px-4 py-3">
+                                        <div>
+                                            <p className="font-medium text-zinc-100">{entity.name}</p>
+                                            <p className="text-xs text-zinc-500">
+                                                {entityTypeLabels[entity.entity_type] ?? entity.entity_type}
+                                            </p>
+                                        </div>
+                                        <Link
+                                            href={route('campaigns.entities.show', [campaign.id, entity.id])}
+                                            className="text-xs font-semibold uppercase tracking-wide text-amber-300 hover:text-amber-200"
+                                        >
+                                            View
+                                        </Link>
+                                    </li>
+                                ))}
+                                {campaign.entities_count > campaign.recent_entities.length && (
+                                    <li className="text-xs text-zinc-500">
+                                        + {campaign.entities_count - campaign.recent_entities.length} more awaiting discovery
+                                    </li>
+                                )}
+                            </ul>
+                        )}
                     </article>
 
                     <article className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/40">

--- a/backend/resources/js/Pages/Search/Index.tsx
+++ b/backend/resources/js/Pages/Search/Index.tsx
@@ -1,0 +1,363 @@
+import { FormEvent, useMemo, useState } from 'react';
+
+import { Head, Link, router, usePage } from '@inertiajs/react';
+
+import AppLayout from '@/Layouts/AppLayout';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+type CampaignResult = {
+    id: number;
+    title: string;
+    status: string;
+    updated_at: string | null;
+    group: { id: number; name: string };
+    region: { id: number; name: string } | null;
+};
+
+type SessionResult = {
+    id: number;
+    title: string;
+    session_date: string | null;
+    campaign: { id: number; title: string };
+};
+
+type NoteResult = {
+    id: number;
+    visibility: string;
+    content_preview: string;
+    updated_at: string | null;
+    campaign: { id: number; title: string };
+    session: { id: number; title: string } | null;
+    author: { id: number | null; name: string | null };
+};
+
+type TaskResult = {
+    id: number;
+    title: string;
+    status: string;
+    due_turn_number: number | null;
+    due_at: string | null;
+    campaign: { id: number; title: string };
+};
+
+type SearchPageProps = {
+    query: string;
+    active_scopes: string[];
+    available_scopes: string[];
+    results: {
+        campaigns: CampaignResult[];
+        sessions: SessionResult[];
+        notes: NoteResult[];
+        tasks: TaskResult[];
+    };
+};
+
+const scopeLabels: Record<string, string> = {
+    campaigns: 'Campaigns',
+    sessions: 'Sessions',
+    notes: 'Session notes',
+    tasks: 'Tasks',
+};
+
+function formatDateTime(value: string | null): string {
+    if (!value) {
+        return '—';
+    }
+
+    try {
+        const date = new Date(value);
+        return new Intl.DateTimeFormat('en-US', {
+            dateStyle: 'medium',
+            timeStyle: 'short',
+        }).format(date);
+    } catch (error) {
+        return value;
+    }
+}
+
+export default function SearchIndex() {
+    const { query, active_scopes, available_scopes, results } = usePage<SearchPageProps>().props;
+    const [term, setTerm] = useState(query ?? '');
+    const [scopes, setScopes] = useState<string[]>(active_scopes ?? []);
+
+    const activeResultsCount = useMemo(() => {
+        return scopes.reduce((count, scope) => count + (results[scope as keyof typeof results]?.length ?? 0), 0);
+    }, [results, scopes]);
+
+    const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        router.get(
+            route('search.index'),
+            { q: term, scopes },
+            {
+                preserveState: true,
+                preserveScroll: true,
+            }
+        );
+    };
+
+    const toggleScope = (scope: string) => {
+        setScopes((current) => {
+            if (current.includes(scope)) {
+                return current.filter((value) => value !== scope);
+            }
+
+            return [...current, scope];
+        });
+    };
+
+    return (
+        <AppLayout>
+            <Head title="Search" />
+
+            <section className="space-y-8">
+                <header className="space-y-2">
+                    <h1 className="text-3xl font-semibold text-zinc-100">Lorekeeper search</h1>
+                    <p className="max-w-3xl text-sm text-zinc-400">
+                        Find campaigns, sessions, tasks, and notes you have access to across every realm you steward. Filters let
+                        you focus on specific record types when hunting for a detail mid-session.
+                    </p>
+                </header>
+
+                <form onSubmit={handleSubmit} className="grid gap-6 rounded-xl border border-zinc-800 bg-zinc-950/60 p-6">
+                    <div className="space-y-2">
+                        <Label htmlFor="search-term">Search phrase</Label>
+                        <Input
+                            id="search-term"
+                            value={term}
+                            onChange={(event) => setTerm(event.target.value)}
+                            placeholder="Search lore, campaigns, or assignments..."
+                            autoFocus
+                        />
+                    </div>
+
+                    <fieldset className="space-y-3">
+                        <legend className="text-sm font-medium text-zinc-200">Scopes</legend>
+                        <div className="flex flex-wrap gap-4">
+                            {available_scopes.map((scope) => (
+                                <label key={scope} className="flex items-center gap-2 text-sm text-zinc-300">
+                                    <Checkbox
+                                        checked={scopes.includes(scope)}
+                                        onChange={() => toggleScope(scope)}
+                                        name="scopes[]"
+                                        value={scope}
+                                    />
+                                    {scopeLabels[scope] ?? scope}
+                                </label>
+                            ))}
+                        </div>
+                    </fieldset>
+
+                    <div className="flex items-center gap-3">
+                        <Button type="submit" disabled={term.trim() === ''}>
+                            Search archives
+                        </Button>
+                        {term.trim() !== '' && (
+                            <p className="text-sm text-zinc-400">
+                                {activeResultsCount} match{activeResultsCount === 1 ? '' : 'es'} across selected scopes
+                            </p>
+                        )}
+                    </div>
+                </form>
+
+                {term.trim() === '' ? (
+                    <div className="rounded-xl border border-dashed border-zinc-800 bg-zinc-950/40 p-10 text-center text-sm text-zinc-400">
+                        Enter a phrase above to begin searching your worlds.
+                    </div>
+                ) : (
+                    <div className="space-y-6">
+                        {scopes.map((scope) => {
+                            const scopeResults = results[scope as keyof typeof results] ?? [];
+
+                            if (scopeResults.length === 0) {
+                                return (
+                                    <section key={scope} className="rounded-xl border border-dashed border-zinc-800 p-6 text-sm text-zinc-400">
+                                        <h2 className="text-lg font-semibold text-zinc-200">{scopeLabels[scope] ?? scope}</h2>
+                                        <p className="mt-3 text-zinc-500">No matches within this scope.</p>
+                                    </section>
+                                );
+                            }
+
+                            if (scope === 'campaigns') {
+                                return (
+                                    <section key={scope} className="space-y-4">
+                                        <h2 className="text-lg font-semibold text-zinc-200">Campaigns</h2>
+                                        <div className="grid gap-4 md:grid-cols-2">
+                                            {(scopeResults as CampaignResult[]).map((campaign) => (
+                                                <article
+                                                    key={campaign.id}
+                                                    className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-5 shadow-inner shadow-black/40"
+                                                >
+                                                    <div className="flex items-start justify-between gap-4">
+                                                        <div>
+                                                            <h3 className="text-xl font-semibold text-zinc-100">{campaign.title}</h3>
+                                                            <p className="text-sm text-zinc-400">Status: {campaign.status}</p>
+                                                            <p className="text-xs text-zinc-500">
+                                                                {campaign.group.name}
+                                                                {campaign.region ? ` • ${campaign.region.name}` : ''}
+                                                            </p>
+                                                        </div>
+                                                        <span className="rounded-full bg-amber-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-300">
+                                                            Updated {formatDateTime(campaign.updated_at)}
+                                                        </span>
+                                                    </div>
+                                                    <Button
+                                                        asChild
+                                                        variant="outline"
+                                                        size="sm"
+                                                        className="mt-5 border-zinc-700 text-zinc-200 hover:text-amber-200"
+                                                    >
+                                                        <Link href={route('campaigns.show', campaign.id)}>Open campaign</Link>
+                                                    </Button>
+                                                </article>
+                                            ))}
+                                        </div>
+                                    </section>
+                                );
+                            }
+
+                            if (scope === 'sessions') {
+                                return (
+                                    <section key={scope} className="space-y-4">
+                                        <h2 className="text-lg font-semibold text-zinc-200">Sessions</h2>
+                                        <div className="grid gap-4 md:grid-cols-2">
+                                            {(scopeResults as SessionResult[]).map((session) => (
+                                                <article
+                                                    key={session.id}
+                                                    className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-5 shadow-inner shadow-black/40"
+                                                >
+                                                    <header className="flex items-start justify-between gap-3">
+                                                        <div>
+                                                            <h3 className="text-lg font-semibold text-zinc-100">{session.title}</h3>
+                                                            <p className="text-sm text-zinc-400">{session.campaign.title}</p>
+                                                        </div>
+                                                        <span className="rounded-md bg-indigo-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-200">
+                                                            {formatDateTime(session.session_date)}
+                                                        </span>
+                                                    </header>
+                                                    <Button
+                                                        asChild
+                                                        variant="outline"
+                                                        size="sm"
+                                                        className="mt-5 border-zinc-700 text-zinc-200 hover:text-amber-200"
+                                                    >
+                                                        <Link
+                                                            href={route('campaigns.sessions.show', {
+                                                                campaign: session.campaign.id,
+                                                                session: session.id,
+                                                            })}
+                                                        >
+                                                            Jump to workspace
+                                                        </Link>
+                                                    </Button>
+                                                </article>
+                                            ))}
+                                        </div>
+                                    </section>
+                                );
+                            }
+
+                            if (scope === 'notes') {
+                                return (
+                                    <section key={scope} className="space-y-4">
+                                        <h2 className="text-lg font-semibold text-zinc-200">Session notes</h2>
+                                        <div className="space-y-3">
+                                            {(scopeResults as NoteResult[]).map((note) => (
+                                                <article
+                                                    key={note.id}
+                                                    className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-5 shadow-inner shadow-black/40"
+                                                >
+                                                    <div className="flex flex-col gap-2 text-sm text-zinc-300">
+                                                        <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-wide text-zinc-500">
+                                                            <span className="rounded-full bg-zinc-800/80 px-2 py-0.5 text-zinc-300">
+                                                                {note.visibility === 'gm' ? 'GM only' : note.visibility === 'public' ? 'Public' : 'Players'}
+                                                            </span>
+                                                            <span>{formatDateTime(note.updated_at)}</span>
+                                                            {note.author.name && <span>by {note.author.name}</span>}
+                                                        </div>
+                                                        <p className="text-sm text-zinc-200">{note.content_preview}</p>
+                                                        <p className="text-xs text-zinc-500">
+                                                            {note.campaign.title}
+                                                            {note.session ? ` • ${note.session.title}` : ''}
+                                                        </p>
+                                                    </div>
+                                                    <Button
+                                                        asChild
+                                                        variant="outline"
+                                                        size="sm"
+                                                        className="mt-5 border-zinc-700 text-zinc-200 hover:text-amber-200"
+                                                    >
+                                                        <Link
+                                                            href={note.session
+                                                                ? route('campaigns.sessions.show', {
+                                                                      campaign: note.campaign.id,
+                                                                      session: note.session.id,
+                                                                  })
+                                                                : route('campaigns.show', note.campaign.id)}
+                                                        >
+                                                            View in context
+                                                        </Link>
+                                                    </Button>
+                                                </article>
+                                            ))}
+                                        </div>
+                                    </section>
+                                );
+                            }
+
+                            if (scope === 'tasks') {
+                                return (
+                                    <section key={scope} className="space-y-4">
+                                        <h2 className="text-lg font-semibold text-zinc-200">Tasks</h2>
+                                        <div className="grid gap-4 md:grid-cols-2">
+                                            {(scopeResults as TaskResult[]).map((task) => (
+                                                <article
+                                                    key={task.id}
+                                                    className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-5 shadow-inner shadow-black/40"
+                                                >
+                                                    <header className="flex items-start justify-between gap-3">
+                                                        <div>
+                                                            <h3 className="text-lg font-semibold text-zinc-100">{task.title}</h3>
+                                                            <p className="text-sm text-zinc-400">{task.campaign.title}</p>
+                                                        </div>
+                                                        <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-300">
+                                                            {task.status}
+                                                        </span>
+                                                    </header>
+                                                    <dl className="mt-3 space-y-2 text-xs text-zinc-400">
+                                                        <div className="flex items-center justify-between">
+                                                            <dt>Due turn</dt>
+                                                            <dd>{task.due_turn_number ?? '—'}</dd>
+                                                        </div>
+                                                        <div className="flex items-center justify-between">
+                                                            <dt>Due at</dt>
+                                                            <dd>{formatDateTime(task.due_at)}</dd>
+                                                        </div>
+                                                    </dl>
+                                                    <Button
+                                                        asChild
+                                                        variant="outline"
+                                                        size="sm"
+                                                        className="mt-5 border-zinc-700 text-zinc-200 hover:text-amber-200"
+                                                    >
+                                                        <Link href={route('campaigns.tasks.index', task.campaign.id)}>Open task board</Link>
+                                                    </Button>
+                                                </article>
+                                            ))}
+                                        </div>
+                                    </section>
+                                );
+                            }
+
+                            return null;
+                        })}
+                    </div>
+                )}
+            </section>
+        </AppLayout>
+    );
+}

--- a/backend/resources/js/Pages/Settings/Preferences.tsx
+++ b/backend/resources/js/Pages/Settings/Preferences.tsx
@@ -1,0 +1,141 @@
+import { FormEvent } from 'react';
+
+import { Head, useForm, usePage } from '@inertiajs/react';
+
+import AppLayout from '@/Layouts/AppLayout';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { InputError } from '@/components/InputError';
+import { Label } from '@/components/ui/label';
+import { useTranslations } from '@/hooks/useTranslations';
+
+type PreferenceForm = {
+    locale: string;
+    timezone: string;
+    theme: string;
+    high_contrast: boolean;
+    font_scale: number;
+};
+
+type PreferenceOptions = {
+    locales: string[];
+    themes: string[];
+    font_scales: number[];
+    timezones: string[];
+};
+
+type PreferencesPageProps = {
+    form: PreferenceForm;
+    options: PreferenceOptions;
+};
+
+export default function Preferences() {
+    const { t } = useTranslations();
+    const { form: defaults, options } = usePage<PreferencesPageProps>().props;
+    const { data, setData, put, processing, errors } = useForm<PreferenceForm>(defaults);
+
+    const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        put(route('settings.preferences.update'));
+    };
+
+    return (
+        <AppLayout>
+            <Head title={t('preferences.title')} />
+            <section className="space-y-6">
+                <header className="space-y-2">
+                    <h1 className="text-3xl font-semibold">{t('preferences.title')}</h1>
+                    <p className="max-w-3xl text-sm text-zinc-500 dark:text-zinc-400">
+                        {t('preferences.description')}
+                    </p>
+                </header>
+                <form onSubmit={handleSubmit} className="space-y-8" noValidate>
+                    <div className="grid gap-6 sm:grid-cols-2">
+                        <div className="space-y-2">
+                            <Label htmlFor="locale">{t('preferences.locale_label')}</Label>
+                            <select
+                                id="locale"
+                                name="locale"
+                                value={data.locale}
+                                onChange={(event) => setData('locale', event.target.value)}
+                                className="w-full rounded-md border border-zinc-400/40 bg-white/80 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-300 dark:border-zinc-700/60 dark:bg-zinc-900/80 dark:text-zinc-100"
+                            >
+                                {options.locales.map((value) => (
+                                    <option key={value} value={value} className="bg-inherit text-inherit">
+                                        {t(`preferences.locale_options.${value}`)}
+                                    </option>
+                                ))}
+                            </select>
+                            <InputError message={errors.locale} className="text-sm" />
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="timezone">{t('preferences.timezone_label')}</Label>
+                            <select
+                                id="timezone"
+                                name="timezone"
+                                value={data.timezone}
+                                onChange={(event) => setData('timezone', event.target.value)}
+                                className="w-full rounded-md border border-zinc-400/40 bg-white/80 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-300 dark:border-zinc-700/60 dark:bg-zinc-900/80 dark:text-zinc-100"
+                            >
+                                {options.timezones.map((zone) => (
+                                    <option key={zone} value={zone} className="bg-inherit text-inherit">
+                                        {zone}
+                                    </option>
+                                ))}
+                            </select>
+                            <InputError message={errors.timezone} className="text-sm" />
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="theme">{t('preferences.theme_label')}</Label>
+                            <select
+                                id="theme"
+                                name="theme"
+                                value={data.theme}
+                                onChange={(event) => setData('theme', event.target.value)}
+                                className="w-full rounded-md border border-zinc-400/40 bg-white/80 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-300 dark:border-zinc-700/60 dark:bg-zinc-900/80 dark:text-zinc-100"
+                            >
+                                {options.themes.map((theme) => (
+                                    <option key={theme} value={theme} className="bg-inherit text-inherit">
+                                        {t(`preferences.theme_options.${theme}`)}
+                                    </option>
+                                ))}
+                            </select>
+                            <InputError message={errors.theme} className="text-sm" />
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="font_scale">{t('preferences.font_scale_label')}</Label>
+                            <select
+                                id="font_scale"
+                                name="font_scale"
+                                value={data.font_scale}
+                                onChange={(event) => setData('font_scale', Number.parseInt(event.target.value, 10))}
+                                className="w-full rounded-md border border-zinc-400/40 bg-white/80 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-300 dark:border-zinc-700/60 dark:bg-zinc-900/80 dark:text-zinc-100"
+                            >
+                                {options.font_scales.map((scale) => (
+                                    <option key={scale} value={scale} className="bg-inherit text-inherit">
+                                        {t(`preferences.font_scale_options.${scale}`)}
+                                    </option>
+                                ))}
+                            </select>
+                            <p className="text-xs text-zinc-600 dark:text-zinc-400">{t('preferences.font_scale_help')}</p>
+                            <InputError message={errors.font_scale} className="text-sm" />
+                        </div>
+                    </div>
+                    <div className="flex items-center gap-3">
+                        <Checkbox
+                            id="high_contrast"
+                            checked={data.high_contrast}
+                            onCheckedChange={(checked) => setData('high_contrast', Boolean(checked))}
+                        />
+                        <Label htmlFor="high_contrast" className="text-sm">
+                            {t('preferences.contrast_label')}
+                        </Label>
+                    </div>
+                    <Button type="submit" disabled={processing} className="inline-flex items-center gap-2">
+                        {t('preferences.submit')}
+                    </Button>
+                </form>
+            </section>
+        </AppLayout>
+    );
+}

--- a/backend/resources/js/hooks/useTranslations.ts
+++ b/backend/resources/js/hooks/useTranslations.ts
@@ -1,0 +1,44 @@
+import { useCallback } from 'react';
+
+import { usePage } from '@inertiajs/react';
+
+type TranslationShape = Record<string, unknown>;
+
+type TranslationProps = {
+    locale?: string;
+    translations?: Record<string, TranslationShape>;
+};
+
+function resolve(path: string, translations: TranslationShape): unknown {
+    return path.split('.').reduce<unknown>((accumulator, segment) => {
+        if (accumulator && typeof accumulator === 'object' && segment in accumulator) {
+            return (accumulator as Record<string, unknown>)[segment];
+        }
+
+        return undefined;
+    }, translations);
+}
+
+export function useTranslations(namespace = 'app') {
+    const { props } = usePage<TranslationProps>();
+    const dictionary = (props.translations?.[namespace] as TranslationShape) ?? {};
+
+    const translate = useCallback(
+        (key: string, fallback?: string) => {
+            const value = resolve(key, dictionary);
+
+            if (typeof value === 'string') {
+                return value;
+            }
+
+            if (value === undefined && fallback !== undefined) {
+                return fallback;
+            }
+
+            return typeof value === 'string' ? value : key;
+        },
+        [dictionary]
+    );
+
+    return { t: translate, locale: props.locale ?? 'en' };
+}

--- a/backend/resources/lang/en/app.php
+++ b/backend/resources/lang/en/app.php
@@ -1,0 +1,41 @@
+<?php
+
+return [
+    'app_name' => 'Dungen & Dragons',
+    'navigation' => [
+        'search' => 'Search',
+        'preferences' => 'Preferences',
+        'logout' => 'Log out',
+    ],
+    'a11y' => [
+        'skip_to_content' => 'Skip to main content',
+    ],
+    'preferences' => [
+        'title' => 'Accessibility & appearance',
+        'description' => 'Tune the interface for your table: choose language, theme, contrast, and font size.',
+        'locale_label' => 'Language',
+        'locale_options' => [
+            'en' => 'English',
+            'ro' => 'Română',
+        ],
+        'timezone_label' => 'Timezone',
+        'theme_label' => 'Theme',
+        'theme_options' => [
+            'system' => 'Match system',
+            'dark' => 'Midnight (dark)',
+            'light' => 'Dawn (light)',
+        ],
+        'contrast_label' => 'High contrast focus outlines',
+        'font_scale_label' => 'Font size',
+        'font_scale_help' => 'Increase or decrease interface text size.',
+        'font_scale_options' => [
+            '90' => 'Small',
+            '100' => 'Normal',
+            '110' => 'Large',
+            '125' => 'Extra large',
+            '150' => 'Huge',
+        ],
+        'submit' => 'Save preferences',
+        'success' => 'Preferences updated.',
+    ],
+];

--- a/backend/resources/lang/ro/app.php
+++ b/backend/resources/lang/ro/app.php
@@ -1,0 +1,41 @@
+<?php
+
+return [
+    'app_name' => 'Dungen & Dragons',
+    'navigation' => [
+        'search' => 'Căutare',
+        'preferences' => 'Preferințe',
+        'logout' => 'Deconectare',
+    ],
+    'a11y' => [
+        'skip_to_content' => 'Sari la conținutul principal',
+    ],
+    'preferences' => [
+        'title' => 'Accesibilitate și aspect',
+        'description' => 'Ajustează interfața pentru masa ta: alege limba, tema, contrastul și dimensiunea fontului.',
+        'locale_label' => 'Limba',
+        'locale_options' => [
+            'en' => 'Engleză',
+            'ro' => 'Română',
+        ],
+        'timezone_label' => 'Fus orar',
+        'theme_label' => 'Temă',
+        'theme_options' => [
+            'system' => 'Potrivit cu sistemul',
+            'dark' => 'Miez de noapte (întunecat)',
+            'light' => 'Zori (luminos)',
+        ],
+        'contrast_label' => 'Contururi de focus cu contrast ridicat',
+        'font_scale_label' => 'Dimensiunea fontului',
+        'font_scale_help' => 'Mărește sau micșorează textul interfeței.',
+        'font_scale_options' => [
+            '90' => 'Mic',
+            '100' => 'Normal',
+            '110' => 'Mare',
+            '125' => 'Foarte mare',
+            '150' => 'Imens',
+        ],
+        'submit' => 'Salvează preferințele',
+        'success' => 'Preferințele au fost actualizate.',
+    ],
+];

--- a/backend/resources/views/app.blade.php
+++ b/backend/resources/views/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="h-full" data-theme="dark">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="h-full">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -10,7 +10,7 @@
         @vite(['resources/css/app.css', 'resources/js/app.tsx'])
         @inertiaHead
     </head>
-    <body class="antialiased min-h-screen bg-slate-950 text-slate-100">
+    <body class="antialiased min-h-screen">
         @inertia
     </body>
 </html>

--- a/backend/resources/views/exports/session.blade.php
+++ b/backend/resources/views/exports/session.blade.php
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{{ $metadata['session']['title'] }} – Session Chronicle</title>
+    <style>
+        body {
+            font-family: 'Helvetica Neue', Arial, sans-serif;
+            color: #111827;
+            margin: 0;
+            padding: 2.5rem;
+            font-size: 14px;
+            line-height: 1.6;
+            background-color: #f8fafc;
+        }
+
+        h1, h2, h3, h4 {
+            color: #111827;
+            margin-bottom: 0.5rem;
+        }
+
+        h1 {
+            font-size: 28px;
+        }
+
+        h2 {
+            font-size: 20px;
+            margin-top: 2rem;
+        }
+
+        h3 {
+            font-size: 16px;
+            margin-top: 1.5rem;
+        }
+
+        p {
+            margin-top: 0.35rem;
+            margin-bottom: 0.35rem;
+        }
+
+        .meta-list {
+            list-style: none;
+            padding: 0;
+            margin: 0 0 1.5rem 0;
+        }
+
+        .meta-list li {
+            margin-bottom: 0.25rem;
+        }
+
+        .section {
+            background-color: #ffffff;
+            border-radius: 12px;
+            padding: 1.5rem;
+            margin-bottom: 1.5rem;
+            box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+            border: 1px solid #e2e8f0;
+        }
+
+        .note-card,
+        .dice-card,
+        .dialogue-card {
+            border-radius: 8px;
+            border: 1px solid #e2e8f0;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            background-color: #fdfdfd;
+        }
+
+        .muted {
+            color: #64748b;
+            font-size: 12px;
+        }
+
+        .divider {
+            border-top: 1px solid #e2e8f0;
+            margin: 2rem 0;
+        }
+    </style>
+</head>
+<body>
+@php
+    $session = $metadata['session'];
+    $campaign = $metadata['campaign'];
+    $viewer = $metadata['viewer'];
+    $format = fn($carbon) => $carbon ? $carbon->format('Y-m-d H:i \U\T\C') : null;
+@endphp
+
+    <h1>{{ $session['title'] }}</h1>
+    <ul class="meta-list">
+        <li><strong>Campaign:</strong> {{ $campaign['title'] }}</li>
+        <li><strong>Generated:</strong> {{ $format($metadata['generated_at']) }}</li>
+        @if($session['session_date'])
+            <li><strong>Session date:</strong> {{ $format($session['session_date']) }}</li>
+        @endif
+        @if($session['duration_minutes'])
+            <li><strong>Duration:</strong> {{ $session['duration_minutes'] }} minutes</li>
+        @endif
+        @if($session['location'])
+            <li><strong>Location:</strong> {{ $session['location'] }}</li>
+        @endif
+        @if($session['turn'])
+            <li><strong>Linked turn:</strong> #{{ $session['turn']['number'] }}</li>
+        @endif
+        @if($session['recording_url'])
+            <li><strong>External recording:</strong> {{ $session['recording_url'] }}</li>
+        @endif
+        @if($session['stored_recording_url'])
+            <li><strong>Vault recording:</strong> {{ $session['stored_recording_name'] }}</li>
+        @endif
+        <li><strong>Compiled for:</strong> {{ $viewer['name'] }} {{ $viewer['can_manage'] ? '(GM)' : '' }}</li>
+    </ul>
+
+    <div class="section">
+        <h2>Agenda</h2>
+        <p>{!! nl2br(e($session['agenda'] ?? 'No agenda recorded.')) !!}</p>
+    </div>
+
+    <div class="section">
+        <h2>Summary</h2>
+        <p>{!! nl2br(e($session['summary'] ?? 'No summary captured yet.')) !!}</p>
+    </div>
+
+    <div class="section">
+        <h2>Notes</h2>
+        @forelse($notes as $note)
+            <div class="note-card">
+                <h3>{{ $note['author']['name'] }} – {{ $format($note['created_at']) ?? 'Unknown time' }}</h3>
+                <p class="muted">Visibility: {{ ucfirst($note['visibility']) }} @if($note['is_pinned']) • Pinned @endif</p>
+                <p>{!! nl2br(e($note['content'])) !!}</p>
+            </div>
+        @empty
+            <p class="muted">No notes available.</p>
+        @endforelse
+    </div>
+
+    <div class="section">
+        <h2>Dice Log</h2>
+        @forelse($dice_rolls as $roll)
+            <div class="dice-card">
+                <h3>{{ $roll['expression'] }} → {{ $roll['result_total'] }}</h3>
+                <p class="muted">
+                    {{ $roll['roller']['name'] }} • {{ $format($roll['created_at']) ?? 'Unknown time' }}
+                </p>
+                @if(!empty($roll['result_breakdown']))
+                    <p>Breakdown: {{ json_encode($roll['result_breakdown']) }}</p>
+                @endif
+            </div>
+        @empty
+            <p class="muted">No dice rolls were logged.</p>
+        @endforelse
+    </div>
+
+    <div class="section">
+        <h2>Initiative Order</h2>
+        @if(count($initiative) > 0)
+            <ul>
+                @foreach($initiative as $entry)
+                    <li>
+                        {{ $entry['name'] }} — Initiative {{ $entry['initiative'] }} (Dex {{ $entry['dexterity_mod'] }})
+                        @if($entry['is_current'])
+                            <strong> ← current</strong>
+                        @endif
+                    </li>
+                @endforeach
+            </ul>
+        @else
+            <p class="muted">No initiative entries recorded.</p>
+        @endif
+    </div>
+
+    <div class="section">
+        <h2>AI Dialogue</h2>
+        @forelse($ai_dialogues as $dialogue)
+            <div class="dialogue-card">
+                <h3>
+                    {{ $dialogue['npc_name'] ? $dialogue['npc_name'] : 'NPC Dialogue' }}
+                    @if($dialogue['tone'])
+                        ({{ $dialogue['tone'] }})
+                    @endif
+                </h3>
+                <p class="muted">{{ $format($dialogue['created_at']) ?? 'Unknown time' }}</p>
+                <p><strong>Prompt:</strong> {!! nl2br(e($dialogue['prompt'])) !!}</p>
+                @if($dialogue['reply'])
+                    <div class="divider"></div>
+                    <p><strong>Reply:</strong> {!! nl2br(e($dialogue['reply'])) !!}</p>
+                @endif
+            </div>
+        @empty
+            <p class="muted">No AI dialogue captured this session.</p>
+        @endforelse
+    </div>
+</body>
+</html>

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\CampaignController;
 use App\Http\Controllers\CampaignInvitationController;
 use App\Http\Controllers\CampaignRoleAssignmentController;
 use App\Http\Controllers\CampaignTaskController;
+use App\Http\Controllers\CampaignEntityController;
 use App\Http\Controllers\DiceRollController;
 use App\Http\Controllers\GroupController;
 use App\Http\Controllers\GroupJoinController;
@@ -19,6 +20,8 @@ use App\Http\Controllers\MapTileController;
 use App\Http\Controllers\TileTemplateController;
 use App\Http\Controllers\SessionController;
 use App\Http\Controllers\SessionNoteController;
+use App\Http\Controllers\SearchController;
+use App\Http\Controllers\UserPreferenceController;
 use App\Http\Controllers\WorldController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -37,6 +40,8 @@ Route::middleware('guest')->group(function (): void {
 
 Route::middleware('auth')->group(function (): void {
     Route::get('/dashboard', fn () => Inertia::render('Dashboard'))->name('dashboard');
+    Route::get('/settings/preferences', [UserPreferenceController::class, 'edit'])->name('settings.preferences.edit');
+    Route::put('/settings/preferences', [UserPreferenceController::class, 'update'])->name('settings.preferences.update');
     Route::get('groups/join', [GroupJoinController::class, 'create'])->name('groups.join');
     Route::post('groups/join', [GroupJoinController::class, 'store'])->name('groups.join.store');
     Route::resource('groups', GroupController::class);
@@ -69,10 +74,16 @@ Route::middleware('auth')->group(function (): void {
     Route::patch('campaigns/{campaign}/tasks/{task}', [CampaignTaskController::class, 'update'])->name('campaigns.tasks.update');
     Route::post('campaigns/{campaign}/tasks/reorder', [CampaignTaskController::class, 'reorder'])->name('campaigns.tasks.reorder');
     Route::delete('campaigns/{campaign}/tasks/{task}', [CampaignTaskController::class, 'destroy'])->name('campaigns.tasks.destroy');
+    Route::resource('campaigns.entities', CampaignEntityController::class);
     Route::resource('campaigns.sessions', SessionController::class);
+    Route::get('campaigns/{campaign}/sessions/{session}/exports/markdown', [SessionController::class, 'exportMarkdown'])->name('campaigns.sessions.exports.markdown');
+    Route::get('campaigns/{campaign}/sessions/{session}/exports/pdf', [SessionController::class, 'exportPdf'])->name('campaigns.sessions.exports.pdf');
+    Route::post('campaigns/{campaign}/sessions/{session}/recording', [SessionController::class, 'storeRecording'])->name('campaigns.sessions.recording.store');
+    Route::delete('campaigns/{campaign}/sessions/{session}/recording', [SessionController::class, 'destroyRecording'])->name('campaigns.sessions.recording.destroy');
     Route::post('campaigns/{campaign}/sessions/{session}/notes', [SessionNoteController::class, 'store'])->name('campaigns.sessions.notes.store');
     Route::patch('campaigns/{campaign}/sessions/{session}/notes/{note}', [SessionNoteController::class, 'update'])->name('campaigns.sessions.notes.update');
     Route::delete('campaigns/{campaign}/sessions/{session}/notes/{note}', [SessionNoteController::class, 'destroy'])->name('campaigns.sessions.notes.destroy');
+    Route::get('search', [SearchController::class, 'index'])->name('search.index');
     Route::post('campaigns/{campaign}/sessions/{session}/dice-rolls', [DiceRollController::class, 'store'])->name('campaigns.sessions.dice-rolls.store');
     Route::delete('campaigns/{campaign}/sessions/{session}/dice-rolls/{roll}', [DiceRollController::class, 'destroy'])->name('campaigns.sessions.dice-rolls.destroy');
     Route::post('campaigns/{campaign}/sessions/{session}/initiative', [InitiativeEntryController::class, 'store'])->name('campaigns.sessions.initiative.store');

--- a/backend/tests/Feature/CampaignEntityTest.php
+++ b/backend/tests/Feature/CampaignEntityTest.php
@@ -1,0 +1,139 @@
+<?php
+
+use App\Models\Campaign;
+use App\Models\CampaignEntity;
+use App\Models\Group;
+use App\Models\GroupMembership;
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function seedCampaignWithMembers(): array
+{
+    $manager = User::factory()->create();
+    $group = Group::factory()->for($manager, 'creator')->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $manager->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    $campaign = Campaign::factory()->for($group)->create([
+        'created_by' => $manager->id,
+    ]);
+
+    $player = User::factory()->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $player->id,
+        'role' => GroupMembership::ROLE_PLAYER,
+    ]);
+
+    return [$manager, $campaign, $group, $player];
+}
+
+it('allows campaign managers to author lore with tags and stats', function () {
+    [$manager, $campaign, $group, $player] = seedCampaignWithMembers();
+
+    $response = $this->actingAs($manager)->post(route('campaigns.entities.store', [
+        'campaign' => $campaign,
+    ]), [
+        'entity_type' => CampaignEntity::TYPE_NPC,
+        'name' => 'Aveline Duskmantle',
+        'alias' => 'Mistwarden',
+        'pronunciation' => 'ah-veh-leen dusk-man-tul',
+        'visibility' => CampaignEntity::VISIBILITY_PLAYERS,
+        'group_id' => $group->id,
+        'owner_id' => $player->id,
+        'ai_controlled' => true,
+        'initiative_default' => 18,
+        'description' => 'An enigmatic guardian bound to the moonlit archives.',
+        'stats' => [
+            ['label' => 'Armor Class', 'value' => '17 (shadowplate)'],
+            ['label' => 'Hit Points', 'value' => '142 (15d8 + 75)'],
+        ],
+        'tags' => ['Moon Court', 'Guardian'],
+    ]);
+
+    $response->assertRedirect();
+
+    $entity = CampaignEntity::query()->where('campaign_id', $campaign->id)->first();
+
+    expect($entity)->not->toBeNull();
+    expect($entity->name)->toBe('Aveline Duskmantle');
+    expect($entity->ai_controlled)->toBeTrue();
+    expect($entity->initiative_default)->toBe(18);
+    expect($entity->owner_id)->toBe($player->id);
+    expect($entity->stats)->toHaveCount(2);
+    expect($entity->tags)->toHaveCount(2);
+    expect(Tag::query()->where('campaign_id', $campaign->id)->count())->toBe(2);
+});
+
+it('updates lore entries and syncs tags while regenerating slugs when renamed', function () {
+    [$manager, $campaign] = array_slice(seedCampaignWithMembers(), 0, 2);
+
+    $entity = CampaignEntity::factory()->for($campaign)->create([
+        'name' => 'Velkan the Bold',
+        'slug' => 'velkan-the-bold',
+        'entity_type' => CampaignEntity::TYPE_MONSTER,
+        'visibility' => CampaignEntity::VISIBILITY_GM,
+        'stats' => [
+            ['label' => 'Armor Class', 'value' => '15'],
+        ],
+    ]);
+
+    $existingTag = Tag::create([
+        'campaign_id' => $campaign->id,
+        'label' => 'Legacy',
+        'slug' => 'legacy',
+    ]);
+
+    $entity->tags()->attach($existingTag);
+
+    $response = $this->actingAs($manager)->put(route('campaigns.entities.update', [
+        'campaign' => $campaign,
+        'entity' => $entity,
+    ]), [
+        'entity_type' => CampaignEntity::TYPE_MONSTER,
+        'name' => 'Velkan the Redeemed',
+        'alias' => 'Beacon of Dawn',
+        'pronunciation' => 'vell-kahn',
+        'visibility' => CampaignEntity::VISIBILITY_PUBLIC,
+        'group_id' => '',
+        'owner_id' => '',
+        'ai_controlled' => false,
+        'initiative_default' => 12,
+        'description' => 'A titan who now defends the light.',
+        'stats' => [
+            ['label' => 'Armor Class', 'value' => '18'],
+            ['label' => 'Speed', 'value' => '40 ft.'],
+        ],
+        'tags' => ['Beacon', 'Redeemed'],
+    ]);
+
+    $response->assertRedirect();
+
+    $entity->refresh();
+
+    expect($entity->name)->toBe('Velkan the Redeemed');
+    expect($entity->slug)->toContain('velkan-the-redeemed');
+    expect($entity->visibility)->toBe(CampaignEntity::VISIBILITY_PUBLIC);
+    expect($entity->tags()->pluck('label')->all())->toMatchArray(['Beacon', 'Redeemed']);
+    expect($entity->stats)->toHaveCount(2);
+});
+
+it('prevents players from creating lore entries', function () {
+    [$manager, $campaign, $group, $player] = seedCampaignWithMembers();
+
+    $this->actingAs($player)
+        ->post(route('campaigns.entities.store', ['campaign' => $campaign]), [
+            'entity_type' => CampaignEntity::TYPE_CHARACTER,
+            'name' => 'Unseen Scribe',
+            'visibility' => CampaignEntity::VISIBILITY_PLAYERS,
+        ])
+        ->assertForbidden();
+});

--- a/backend/tests/Feature/GlobalSearchTest.php
+++ b/backend/tests/Feature/GlobalSearchTest.php
@@ -1,0 +1,146 @@
+<?php
+
+use App\Models\Campaign;
+use App\Models\CampaignSession;
+use App\Models\CampaignTask;
+use App\Models\Group;
+use App\Models\GroupMembership;
+use App\Models\SessionNote;
+use App\Models\User;
+use App\Services\GlobalSearchService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('returns accessible records that match the query', function () {
+    /** @var GlobalSearchService $service */
+    $service = app(GlobalSearchService::class);
+
+    $user = User::factory()->create();
+    $group = Group::factory()->for($user, 'creator')->create(['name' => 'Moonlarks']);
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $user->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    $campaign = Campaign::factory()
+        ->for($group)
+        ->for($user, 'creator')
+        ->create([
+            'title' => 'Shadowfall Chronicle',
+            'synopsis' => 'The creeping shadow encroaches upon the Vale.',
+        ]);
+
+    $session = CampaignSession::factory()
+        ->for($campaign)
+        ->for($user, 'creator')
+        ->create([
+            'title' => 'Shadow Council',
+            'agenda' => 'Discuss defenses against the shadow tide',
+        ]);
+
+    $note = SessionNote::factory()->create([
+        'campaign_id' => $campaign->id,
+        'campaign_session_id' => $session->id,
+        'author_id' => $user->id,
+        'content' => 'Recorded a whispered warning about the shadow gate.',
+    ]);
+
+    $task = CampaignTask::factory()
+        ->for($campaign)
+        ->create([
+            'title' => 'Secure the Shadow Gate',
+            'description' => 'Seal the rift before nightfall.',
+        ]);
+
+    // Foreign data that should not appear
+    Campaign::factory()->create(['title' => 'Sunrise Covenant']);
+
+    $results = $service->search($user, 'shadow');
+
+    expect($results['campaigns'])->toHaveCount(1)
+        ->and($results['campaigns'][0]['id'])->toBe($campaign->id);
+
+    expect($results['sessions'])->toHaveCount(1)
+        ->and($results['sessions'][0]['id'])->toBe($session->id);
+
+    expect($results['notes'])->toHaveCount(1)
+        ->and($results['notes'][0]['id'])->toBe($note->id);
+
+    expect($results['tasks'])->toHaveCount(1)
+        ->and($results['tasks'][0]['id'])->toBe($task->id);
+});
+
+it('hides gm-only notes from non-managers', function () {
+    /** @var GlobalSearchService $service */
+    $service = app(GlobalSearchService::class);
+
+    $owner = User::factory()->create();
+    $player = User::factory()->create();
+    $group = Group::factory()->for($owner, 'creator')->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $owner->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $player->id,
+        'role' => GroupMembership::ROLE_PLAYER,
+    ]);
+
+    $campaign = Campaign::factory()->for($group)->for($owner, 'creator')->create(['title' => 'Shattered Sigil']);
+
+    SessionNote::factory()
+        ->for($campaign)
+        ->for($owner, 'author')
+        ->create([
+            'visibility' => SessionNote::VISIBILITY_GM,
+            'content' => 'GM shadow directive.',
+        ]);
+
+    $results = $service->search($player, 'shadow');
+
+    expect($results['notes'])->toBeEmpty();
+});
+
+it('shows gm-only notes to campaign managers', function () {
+    /** @var GlobalSearchService $service */
+    $service = app(GlobalSearchService::class);
+
+    $owner = User::factory()->create();
+    $manager = User::factory()->create();
+    $group = Group::factory()->for($owner, 'creator')->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $owner->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $manager->id,
+        'role' => GroupMembership::ROLE_DUNGEON_MASTER,
+    ]);
+
+    $campaign = Campaign::factory()->for($group)->for($owner, 'creator')->create(['title' => 'Veiled Depths']);
+
+    $note = SessionNote::factory()
+        ->for($campaign)
+        ->for($owner, 'author')
+        ->create([
+            'visibility' => SessionNote::VISIBILITY_GM,
+            'content' => 'Shadow ritual instructions.',
+        ]);
+
+    $results = $service->search($manager, 'shadow');
+
+    expect($results['notes'])
+        ->toHaveCount(1)
+        ->and($results['notes'][0]['id'])->toBe($note->id);
+});

--- a/backend/tests/Feature/SessionExportTest.php
+++ b/backend/tests/Feature/SessionExportTest.php
@@ -1,0 +1,133 @@
+<?php
+
+use App\Models\Campaign;
+use App\Models\CampaignSession;
+use App\Models\Group;
+use App\Models\GroupMembership;
+use App\Models\SessionNote;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class);
+
+function seedCampaignSession(): array
+{
+    $manager = User::factory()->create();
+    $group = Group::factory()->for($manager, 'creator')->create();
+
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $manager->id,
+        'role' => GroupMembership::ROLE_OWNER,
+    ]);
+
+    $campaign = Campaign::factory()->for($group)->create([
+        'created_by' => $manager->id,
+    ]);
+
+    $session = CampaignSession::factory()->for($campaign)->create([
+        'created_by' => $manager->id,
+        'title' => 'Vault of echoes',
+    ]);
+
+    return [$manager, $campaign, $group, $session];
+}
+
+it('includes gm notes for managers and hides them from players in markdown export', function () {
+    [$manager, $campaign, $group, $session] = seedCampaignSession();
+
+    $gmNote = SessionNote::create([
+        'campaign_id' => $campaign->id,
+        'campaign_session_id' => $session->id,
+        'author_id' => $manager->id,
+        'visibility' => SessionNote::VISIBILITY_GM,
+        'content' => 'Secret treaty details.',
+    ]);
+
+    SessionNote::create([
+        'campaign_id' => $campaign->id,
+        'campaign_session_id' => $session->id,
+        'author_id' => $manager->id,
+        'visibility' => SessionNote::VISIBILITY_PLAYERS,
+        'content' => 'Public celebration log.',
+    ]);
+
+    $managerResponse = $this->actingAs($manager)->get(route('campaigns.sessions.exports.markdown', [
+        'campaign' => $campaign,
+        'session' => $session,
+    ]));
+
+    $managerResponse->assertOk();
+    expect($managerResponse->headers->get('content-type'))->toContain('text/markdown');
+    expect($managerResponse->getContent())->toContain('Secret treaty details.');
+
+    $player = User::factory()->create();
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $player->id,
+        'role' => GroupMembership::ROLE_PLAYER,
+    ]);
+
+    $playerResponse = $this->actingAs($player)->get(route('campaigns.sessions.exports.markdown', [
+        'campaign' => $campaign,
+        'session' => $session,
+    ]));
+
+    $playerResponse->assertOk();
+    expect($playerResponse->getContent())->not->toContain($gmNote->content);
+    expect($playerResponse->getContent())->toContain('Public celebration log.');
+});
+
+it('streams pdf exports for any authorized viewer', function () {
+    [$manager, $campaign, , $session] = seedCampaignSession();
+
+    $response = $this->actingAs($manager)->get(route('campaigns.sessions.exports.pdf', [
+        'campaign' => $campaign,
+        'session' => $session,
+    ]));
+
+    $response->assertOk();
+    expect($response->headers->get('content-type'))->toContain('application/pdf');
+    expect($response->headers->get('content-disposition'))->toContain('attachment; filename="session-');
+});
+
+it('allows managers to upload and remove stored recordings while blocking players', function () {
+    [$manager, $campaign, $group, $session] = seedCampaignSession();
+    Storage::fake('public');
+
+    $upload = UploadedFile::fake()->create('recap.mp3', 1000, 'audio/mpeg');
+
+    $this->actingAs($manager)
+        ->post(route('campaigns.sessions.recording.store', ['campaign' => $campaign, 'session' => $session]), [
+            'recording' => $upload,
+        ])
+        ->assertRedirect(route('campaigns.sessions.show', [$campaign, $session]));
+
+    $session->refresh();
+    $storedPath = $session->recording_path;
+    expect($storedPath)->not->toBeNull();
+    Storage::disk('public')->assertExists($storedPath);
+
+    $player = User::factory()->create();
+    GroupMembership::create([
+        'group_id' => $group->id,
+        'user_id' => $player->id,
+        'role' => GroupMembership::ROLE_PLAYER,
+    ]);
+
+    $this->actingAs($player)
+        ->post(route('campaigns.sessions.recording.store', ['campaign' => $campaign, 'session' => $session]), [
+            'recording' => UploadedFile::fake()->create('blocked.mp3', 500, 'audio/mpeg'),
+        ])
+        ->assertForbidden();
+
+    $this->actingAs($manager)
+        ->delete(route('campaigns.sessions.recording.destroy', ['campaign' => $campaign, 'session' => $session]))
+        ->assertRedirect(route('campaigns.sessions.show', [$campaign, $session]));
+
+    $session->refresh();
+    expect($session->recording_path)->toBeNull();
+    Storage::disk('public')->assertMissing($storedPath);
+});

--- a/backend/tests/Feature/UserPreferenceTest.php
+++ b/backend/tests/Feature/UserPreferenceTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Lang;
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+use function Pest\Laravel\put;
+
+uses(RefreshDatabase::class);
+
+it('renders the preference editor for authenticated users', function (): void {
+    $user = User::factory()->create();
+    config()->set('app.asset_url', 'http://localhost/build');
+    $version = hash('xxh128', config('app.asset_url'));
+
+    $response = actingAs($user)
+        ->withHeaders([
+            'X-Inertia' => 'true',
+            'X-Inertia-Version' => $version,
+        ])
+        ->get(route('settings.preferences.edit'));
+
+    $response->assertOk();
+    expect($response->json('component'))->toBe('Settings/Preferences');
+});
+
+it('persists updated accessibility preferences', function (): void {
+    $user = User::factory()->create([
+        'locale' => 'en',
+        'timezone' => 'UTC',
+        'theme' => 'system',
+        'high_contrast' => false,
+        'font_scale' => 100,
+    ]);
+
+    actingAs($user)
+        ->from(route('settings.preferences.edit'))
+        ->put(route('settings.preferences.update'), [
+            'locale' => 'ro',
+            'timezone' => 'Europe/Bucharest',
+            'theme' => 'dark',
+            'high_contrast' => true,
+            'font_scale' => 125,
+        ])
+        ->assertRedirect(route('settings.preferences.edit'))
+        ->assertSessionHas('success', Lang::get('app.preferences.success'));
+
+    expect($user->fresh())->toMatchArray([
+        'locale' => 'ro',
+        'timezone' => 'Europe/Bucharest',
+        'theme' => 'dark',
+        'high_contrast' => true,
+        'font_scale' => 125,
+    ]);
+});
+
+it('validates unsupported preference values', function (): void {
+    $user = User::factory()->create();
+
+    actingAs($user)
+        ->put(route('settings.preferences.update'), [
+            'locale' => 'xx',
+            'timezone' => 'Mars/Olympus',
+            'theme' => 'neon',
+            'high_contrast' => 'maybe',
+            'font_scale' => 200,
+        ])
+        ->assertSessionHasErrors(['locale', 'timezone', 'theme', 'high_contrast', 'font_scale']);
+});


### PR DESCRIPTION
## Summary
- add campaign entity schema, models, policy, and controller endpoints powering a lore codex with stat blocks and visibility controls
- ship Inertia pages for listing, creating, editing, and viewing lore entries with tag editing, filters, and dashboard integration
- document Task 17/18 completion and expand progress artifacts with the new lore codex capabilities

## Testing
- php artisan test *(fails: vendor/autoload.php missing in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68efdb9e1b3c83329ce475822a55f28e