### PR TITLE
Clarify condition timer transparency roadmap and documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,11 +9,13 @@
 - Approach tasks as both a seasoned full-stack engineer and a creative D&D designer. Features should feel thematic, accessible, and extensible for multiple groups, tiles, AI-driven helpers, and turn-based pacing.
 - When implementing mechanics (e.g., initiative, tile maps, AI DM/NPC helpers), seek solutions that balance usability for casual players with depth for power users.
 - Maintain and update progress artifacts (`TASK_PLAN.md`, `PROGRESS_LOG.md`, and per-task notes under `Tasks/`) whenever work is completed or scope changes.
+- Treat condition timer transparency features (Tasks 38–44) as the current program focus. Review meeting notes, README roadmap, and task briefs before contributing so UX, narrative, and telemetry expectations stay aligned.
 
 ## Technical Conventions
 - Follow Laravel best practices: Form Requests for validation, Policies for authorization, Pest for tests, and queue/real-time integrations through Laravel Reverb as planned.
 - Frontend code should live inside `backend/resources/js` and use Inertia pages/components. Prefer composition, strong typing, and Tailwind utility classes aligned with the D&D aesthetic already established.
 - Keep code modular and well-documented. Include inline comments when domain concepts might be non-obvious (e.g., tile adjacency rules, AI hand-off flows).
+- Projection services that surface player-safe data must document cache invalidation, telemetry, and privacy checks alongside the implementation (see Tasks 39–41).
 
 ## Process Expectations
 - Before starting a task, review relevant task files under `Tasks/Week X/` and update them with intent, subtasks, and status.

--- a/Meetings/2025-10-28-strategic-sync.md
+++ b/Meetings/2025-10-28-strategic-sync.md
@@ -1,0 +1,70 @@
+# Strategic Sync – Condition Timer Transparency Initiative
+- **Date:** 2025-10-28 09:30 UTC
+- **Attendees & Roles:**
+  - Product Owner – reviews delivery roadmap and player value
+  - Software Architect – validates technical direction and scalability
+  - UI Designer – assesses usability and visual cohesion
+  - D&D Experience Lead – ensures mechanics feel authentic and table-ready
+
+## Pre-Meeting Audit
+- Reviewed `PROGRESS_LOG.md`, recent task notes (Tasks 30–37), and the dashboard prototypes to confirm timer creation, countdown automation, alerts, filters, and quick adjust/clear flows are implemented with realtime broadcasting.
+- Confirmed README reflects core platform pillars but noted it lacks guidance on the upcoming projection layer and player-facing transparency work.
+- Identified that Task 38–41 briefs exist but require clearer success criteria, privacy guidelines, and UX acceptance details before sprint planning.
+
+## Agenda
+1. Celebrate progress across the token condition timer roadmap
+2. Evaluate architecture and UX readiness for the remaining backlog
+3. Identify gaps for player-facing visibility and DM workflow polish
+4. Align on next sprint scope, documentation updates, and cross-discipline assets (wireframes, narrative copy deck)
+
+## Highlights of Completed Work
+- Condition timer ecosystem (presets, timers, countdown automation, alerts, dashboards, quick adjust/clear, and filters) is fully shipped and covered with Pest/Dusk suites, aligning with the Week 3 roadmap.
+- Realtime collaboration via Laravel Reverb continues to provide stable synchronization for map tokens, condition badges, and dashboard updates.
+- Supporting infrastructure—AI narration, search, exports, accessibility, and localization—remains healthy, enabling downstream features to stay cohesive with campaign management flows.
+- Existing condition copy and iconography already map to core spell effects, giving us a narrative baseline for player-safe summaries.
+
+## Perspective Reviews
+### Product Owner
+- Value delivery for GMs is strong; timers, alerts, and dashboards reduce bookkeeping friction during encounters.
+- Player-facing transparency is still missing; upcoming backlog items should prioritize safe redaction and narrative-friendly summaries to keep immersion high without leaking GM-only intel.
+- Recommend bundling remaining timer work with session recap/reporting touchpoints to amplify cross-feature value.
+- Call out need for a player trust metric in research sessions once summaries launch to validate immersion impact.
+
+### Software Architect
+- Current timer services reuse turn scheduler queues and broadcasting channels effectively; no architectural blockers for batch adjustments or player summaries.
+- Need to extend validation/form request coverage for multi-select timer operations and ensure optimistic updates reconcile correctly with server truth to avoid race conditions.
+- Suggest introducing a read-model projection (cached JSON payload) for player summaries to keep payloads lightweight and privacy-aware.
+- Flagged requirement to document projection invalidation hooks and failure logging so Ops can monitor desync scenarios.
+
+### UI Designer
+- Dashboard interactions are consistent with the existing shadcn/ui toolkit, but bulk adjustment flows require additional affordances (selection states, confirmation banners, mobile gestures).
+- Player summary surfaces should mirror existing recap cards, leveraging Tailwind typography scales for narrative beats and iconography for urgency.
+- Recommend documenting responsive breakpoints for new modals/sidebars introduced by batch operations.
+- Identified need for dedicated wireframes covering desktop, tablet, and mobile experiences before implementation kicks off.
+
+### D&D Experience Lead
+- Current mechanics align with tabletop cadence—automated countdowns mirror initiative rounds while preserving GM authority.
+- Bulk adjustments must support common spell effects (e.g., Bless, Bane) that impact multiple tokens simultaneously; presets should allow shared duration tweaks without repetitive input.
+- Player summaries should translate mechanical statuses into in-world fiction ("Arcane winds falter around you in 1 round") to maintain immersion.
+- Request collaboration with narrative writer to seed 12–15 reusable snippets keyed to conditions and urgency tiers.
+
+## Decisions
+- Proceed with Task 38 focusing on multi-select UX and backend safeguards before exposing player summaries.
+- Split player-facing work into two phases: narrative summary delivery (existing Task 39) and a follow-up task for mobile-first recap widgets.
+- Capture architectural patterns for reusable timer projections within developer documentation once implemented.
+- Update README and AGENTS guidance to reflect projection expectations and narrative alignment guardrails.
+
+## Action Items
+1. **Product Owner:** Update task plan backlog to reflect phased player transparency strategy and note dependencies on timer projection service.
+2. **Software Architect:** Define data contract for batch adjustment API and projection caching layer prior to implementation (document in upcoming task notes).
+3. **UI Designer:** Draft wireframes for multi-select adjustments and player summary cards, aligning with existing Inertia layout conventions.
+4. **D&D Experience Lead:** Curate list of common condition narratives to seed player summaries and QA the copy during implementation.
+5. **All:** Review README/AGENTS revisions next sync to confirm onboarding materials match the transparency roadmap.
+
+## Risks & Mitigations
+- **Risk:** Batch adjustments introduce conflicting writes when multiple facilitators act simultaneously. _Mitigation:_ Implement queued reconciliation with clear error toasts and add telemetry for conflict frequency.
+- **Risk:** Player summaries could leak hidden enemy intel. _Mitigation:_ Enforce projection service redaction rules, add automated tests for faction/visibility edge cases, and document manual QA checklist.
+- **Risk:** Mobile recap widgets may regress performance on low-end devices. _Mitigation:_ Prototype with virtualization and offline caching, run Lighthouse audits pre-release.
+
+## Next Checkpoint
+- Target follow-up sync on 2025-10-31 15:00 UTC to review batch adjustment progress, validate projection design, and sign off on player summary copy deck.

--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -43,5 +43,7 @@
 | 2025-10-27 15:35 | Token Condition Timer Quick Adjustments | Added dashboard plus/minus controls, optimistic syncing, and coverage so facilitators can tweak condition timers without opening each token editor. |
 | 2025-10-27 18:20 | Token Condition Timer Filters | Introduced faction-aware filtering, urgency toggles, and search controls so facilitators can focus on the timers that need attention most. |
 | 2025-10-27 21:30 | Token Condition Timer Quick Clearing | Delivered dashboard clear controls with optimistic syncing so facilitators can remove expired effects without diving into each token editor. |
+| 2025-10-28 09:30 | Strategic Sync | Captured cross-discipline meeting notes for condition timer transparency initiative, aligned on batch adjustment priorities, and expanded backlog with player transparency phases. |
+| 2025-10-28 10:15 | Roadmap Refresh | Updated README roadmap, AGENTS guidance, and task briefs (38–44) to clarify projection requirements, UX assets, narrative copy needs, and telemetry expectations. |
 
 > Update this log as features move from backlog to completion. Keep entries in UTC and 24-hour time.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ Build a collaborative, browser-based Dungeon & Dragons campaign platform for dis
 - Adjust pacing when recording or running in CI with `--delay=<seconds>` (defaults to `1.1`). Provide `--delay=0` for fast local verification or automated tests.
 - Use `--source=path/to/log.md` when previewing unreleased notes or running unit tests against fixture data.
 
+## Condition Timer Transparency Roadmap
+- **Batch Adjustments (Task 38):** Expand the existing dashboard to support multi-select controls, shared delta tooling, and conflict-aware telemetry while preserving optimistic UX.
+- **Player Summaries (Task 39):** Introduce a projection cache that redacts GM-only intel, feeds immersive copy from the narrative deck, and streams realtime updates to player-facing panels.
+- **Mobile Recap Widgets (Task 40):** Deliver responsive Inertia components with offline caching, performance budgets, and analytics so tablet/phone players stay informed.
+- **Developer Guide (Task 41):** Document projection patterns, invalidation hooks, and QA rituals so future systems reuse the same privacy-conscious architecture.
+- **Interaction Wireframes (Task 42):** Provide annotated frames and accessibility notes that drive a consistent shadcn/Tailwind implementation across devices.
+- **Narrative Copy Deck (Task 43):** Supply condition-themed snippets keyed by urgency tier, localization notes, and spoiler safeguards.
+- **Research & Telemetry (Task 44):** Measure trust and immersion via surveys, analytics, and beta feedback loops, ensuring future iterations remain player-first.
+
+> All timer-related work must respect UTC turn cadence, privacy policies, and lore tone. Refer to the updated task briefs in `Tasks/Week 3` and `Tasks/Week 4` before starting implementation.
+
 ## Quest Log & Progress Tracking
 - Every campaign now includes a quest log with priority/status filters and progress journaling so story arcs stay visible alongside the task board.
 - Quests can be tied to regions, assigned a target turn, and archived when they conclude; summaries flow back into the campaign dashboard spotlight.

--- a/TASK_PLAN.md
+++ b/TASK_PLAN.md
@@ -1,8 +1,13 @@
 # Task Plan
 
 ## Backlog
-- [ ] Task 38 – Token Condition Timer Batch Adjustments (multi-select timers, bulk delta tooling, optimistic syncing).
-- [ ] Task 39 – Condition Timer Player Summaries (redacted player view, realtime updates, narrative-friendly copy).
+- [ ] Task 38 – Token Condition Timer Batch Adjustments (finalize API contract, multi-select UX, bulk delta tooling, conflict telemetry, optimistic syncing safeguards, and expanded Form Request validation).
+- [ ] Task 39 – Condition Timer Player Summaries (projection cache layer, redacted payloads, narrative-friendly copy seeded from curated condition templates, automated visibility regression suite).
+- [ ] Task 40 – Condition Timer Mobile Recap Widgets (responsive Inertia panels, offline-friendly state caching, and integration with player summaries, plus performance/lighthouse budget).
+- [ ] Task 41 – Timer Projection Developer Guide (document reusable projection/service pattern, invalidation hooks, ops logging, and QA checklist in developer docs).
+- [ ] Task 42 – Condition Timer Interaction Wireframes (Figma wireframes for desktop/tablet/mobile, component specs, and handoff notes for shadcn/Tailwind implementation).
+- [ ] Task 43 – Condition Narrative Copy Deck (author 12–15 lore-friendly snippets by urgency tier, localization notes, and QA sign-off checklist).
+- [ ] Task 44 – Player Transparency Research & Telemetry (define trust/immersion survey, instrument analytics events, and prep beta feedback plan post-launch).
 - [x] Create group management (create/join/roles) and policies.
 - [x] Establish milestone demo flow automation that runs at a human reading pace with verbose console narration to showcase completed work for each milestone.
 - [x] Develop turn scheduler service and API (process turn, AI fallback).

--- a/Tasks/Week 3/Task 38 - Token Condition Timer Batch Adjustments.md
+++ b/Tasks/Week 3/Task 38 - Token Condition Timer Batch Adjustments.md
@@ -8,14 +8,19 @@
 Provide facilitators with the ability to select multiple timers and apply a shared adjustment (extend, reduce, or reset) so mass status updates between rounds are quick and consistent.
 
 ## Subtasks
-- [ ] Design lightweight multi-select affordances that work across factions and filtered states.
-- [ ] Apply bulk adjustments optimistically while queueing a consolidated payload to the server.
-- [ ] Surface summary feedback (e.g., "3 timers extended by 1 round") without overwhelming the dashboard.
+- [ ] Audit current dashboard data contract and document the batch adjustment API payload, validation rules, and optimistic update expectations.
+- [ ] Design lightweight multi-select affordances that work across factions, filtered states, and mobile breakpoints.
+- [ ] Extend Form Requests and policies to validate multi-entity adjustments and guard against race conditions.
+- [ ] Apply bulk adjustments optimistically while queueing a consolidated payload to the server and reconciling on acknowledgement.
+- [ ] Surface summary feedback (e.g., "3 timers extended by 1 round") without overwhelming the dashboard, including confirmation banners and accessibility-friendly alerts.
+- [ ] Instrument conflict/error telemetry and define alerts for repeated reconciliation failures.
 
 ## Notes
 - Batch controls should respect maximum duration boundaries and avoid partial failures.
 - Consider keyboard shortcuts or focus management for speed-running between turns.
 - Coordinate with future player-facing summaries so mass updates remain transparent.
+- Validate multi-select behavior against wireframes from Task 42 before development starts.
+- Provide rollback guidance in case telemetry surfaces regression spikes.
 
 ## Log
 - 2025-10-27 20:05 UTC – Identified the need for batch adjustments while defining quick clear flows.

--- a/Tasks/Week 3/Task 39 - Condition Timer Player Summaries.md
+++ b/Tasks/Week 3/Task 39 - Condition Timer Player Summaries.md
@@ -8,14 +8,19 @@
 Expose a read-only, lore-friendly summary of active condition timers to players so they understand looming effects without leaking GM-only information or disrupting surprise mechanics.
 
 ## Subtasks
-- [ ] Define which timer details are safe for players and how to redact hidden factions or GM-only notes.
-- [ ] Implement a player-facing panel (session workspace + optional shareable link) with responsive styling.
-- [ ] Coordinate alert copy with narrative tone to keep the experience immersive.
+- [ ] Define which timer details are safe for players and how to redact hidden factions or GM-only notes, feeding into a projection cache schema and invalidation rules.
+- [ ] Implement projection service and broadcast pipeline that emits player-safe JSON distinct from GM payloads, with logging for cache misses and rebuild attempts.
+- [ ] Implement a player-facing panel (session workspace + optional shareable link) with responsive styling and offline-friendly hydration.
+- [ ] Coordinate alert copy with narrative tone, leveraging curated condition templates for immersive summaries.
+- [ ] Add automated tests covering faction redaction, localization hooks, and stale cache recovery scenarios.
+- [ ] Document QA checklist covering manual scenarios (hidden enemies, simultaneous expirations) for Task 41 reuse.
 
 ## Notes
 - Player view should update in realtime alongside GM adjustments but avoid showing exact rounds for hidden enemies unless flagged.
 - Consider integrating with the session recap log for historical context.
 - Ensure localization hooks exist for future translation work.
+- Reference narrative copy deck outputs from Task 43 during implementation.
+- Prepare analytics emitters defined in Task 44 for launch readiness.
 
 ## Log
 - 2025-10-27 20:20 UTC – Logged follow-up to extend timer visibility to players after batch tooling.

--- a/Tasks/Week 4/Task 40 - Condition Timer Mobile Recap Widgets.md
+++ b/Tasks/Week 4/Task 40 - Condition Timer Mobile Recap Widgets.md
@@ -1,0 +1,26 @@
+# Task 40 – Condition Timer Mobile Recap Widgets
+
+**Status:** Planned
+**Owner:** UI/Frontend
+**Dependencies:** Task 39
+
+## Intent
+Deliver a mobile-first recap experience that surfaces player-safe timer summaries within the Inertia session workspace, ensuring tables using tablets or phones stay informed without overwhelming the main dashboard.
+
+## Subtasks
+- [ ] Prototype responsive panels or bottom sheets that integrate with existing session layout patterns and Task 42 wireframes.
+- [ ] Implement offline-friendly caching so the view remains available during connectivity hiccups.
+- [ ] Sync urgency iconography and typography with existing Tailwind design tokens.
+- [ ] Validate accessibility (focus order, screen reader labels) for mobile interactions.
+- [ ] Run Lighthouse/performance audits against baseline budgets and document results.
+- [ ] Integrate analytics/tracking events defined in Task 44 without impacting load times.
+
+## Notes
+- Coordinate with localization to keep copy expandable without breaking layouts.
+- Ensure the component degrades gracefully on narrow widths and landscape orientations.
+- Consider hooking into recap exports for long-term archiving.
+- Keep offline cache payloads consistent with projection invalidation rules from Task 39.
+- Provide QA scenarios for gesture interactions introduced in Task 42.
+
+## Log
+- 2025-10-28 09:40 UTC – Added after strategic sync to phase player transparency rollout.

--- a/Tasks/Week 4/Task 41 - Timer Projection Developer Guide.md
+++ b/Tasks/Week 4/Task 41 - Timer Projection Developer Guide.md
@@ -1,0 +1,25 @@
+# Task 41 – Timer Projection Developer Guide
+
+**Status:** Planned
+**Owner:** Engineering Enablement
+**Dependencies:** Task 39
+
+## Intent
+Document the reusable projection/service pattern introduced for player-safe timer summaries so future features can leverage the same approach without duplicating logic.
+
+## Subtasks
+- [ ] Capture architecture overview (data flow, caching strategy, invalidation triggers) in `/backend/docs` including failure telemetry expectations.
+- [ ] Provide code samples covering projection creation, broadcast usage, and testing guidelines.
+- [ ] Update onboarding docs to reference new projection utilities and relevant Form Requests.
+- [ ] Coordinate with QA to list new test cases required for projections.
+- [ ] Document integration points for analytics events defined in Task 44 and narrative copy hooks from Task 43.
+
+## Notes
+- Emphasize privacy boundaries between GM and player payloads.
+- Highlight failure modes (stale cache, broadcast miss) and mitigation tactics.
+- Align doc styling with existing engineering handbook conventions.
+- Include checklist references for Tasks 38–40 to keep implementation and docs in sync.
+- Capture expectations for adding future projection consumers (mobile apps, exports).
+
+## Log
+- 2025-10-28 09:42 UTC – Logged as outcome of strategic sync action items.

--- a/Tasks/Week 4/Task 42 - Condition Timer Interaction Wireframes.md
+++ b/Tasks/Week 4/Task 42 - Condition Timer Interaction Wireframes.md
@@ -1,0 +1,22 @@
+# Task 42 – Condition Timer Interaction Wireframes
+
+**Status:** Planned
+**Owner:** UI/Frontend
+**Dependencies:** Task 38
+
+## Intent
+Provide high-fidelity wireframes and interaction notes that capture how batch adjustments, player summaries, and mobile recap widgets should behave across desktop, tablet, and mobile breakpoints before engineering begins implementation.
+
+## Subtasks
+- [ ] Audit existing dashboard and session layouts to map insertion points for batch controls and player panels.
+- [ ] Produce annotated wireframes for desktop, tablet, and mobile, covering empty, loading, conflict, and success states.
+- [ ] Define component handoff notes (Tailwind tokens, shadcn primitives, motion guidance) and focus order expectations.
+- [ ] Review prototypes with D&D Experience Lead to ensure thematic alignment and gather copy/layout feedback.
+
+## Notes
+- Include gesture guidance for mobile (swipe to select, long-press actions) and fallback patterns when gestures are unavailable.
+- Document accessibility considerations (focus traps, screen reader labels, contrast ratios) alongside each frame.
+- Capture responsive behavior for banners/toasts so success and error states remain visible without occluding gameplay.
+
+## Log
+- 2025-10-28 10:05 UTC – Added after sync to unblock engineering stories with ready-to-build UX artifacts.

--- a/Tasks/Week 4/Task 43 - Condition Narrative Copy Deck.md
+++ b/Tasks/Week 4/Task 43 - Condition Narrative Copy Deck.md
@@ -1,0 +1,22 @@
+# Task 43 – Condition Narrative Copy Deck
+
+**Status:** Planned
+**Owner:** Narrative Design
+**Dependencies:** Task 39
+
+## Intent
+Author reusable, lore-friendly narrative snippets that explain active conditions, impending expirations, and resolution events so player-facing summaries remain immersive while respecting secrecy constraints.
+
+## Subtasks
+- [ ] Draft copy variants for the top 12–15 conditions across urgency tiers (calm, warning, critical) with redaction guidance for hidden factions.
+- [ ] Collaborate with localization to capture tone notes, character limits, and pluralization requirements.
+- [ ] Validate copy against gameplay scenarios with the D&D Experience Lead and iterate on phrasing for clarity versus mystery.
+- [ ] Produce QA checklist covering spelling, spoiler prevention, and localization placeholders for engineering handoff.
+
+## Notes
+- Ensure copy can surface without exact round counts when hidden enemies are involved; emphasize sensory cues over mechanics.
+- Include optional flavor hooks for AI-driven summaries to expand upon when Gemma3 is invoked.
+- Maintain alignment with accessibility guidance (avoid idioms that translate poorly, provide gender-neutral language).
+
+## Log
+- 2025-10-28 10:08 UTC – Added to fulfill narrative action item from strategic sync and unblock Task 39 content requirements.

--- a/Tasks/Week 4/Task 44 - Player Transparency Research & Telemetry.md
+++ b/Tasks/Week 4/Task 44 - Player Transparency Research & Telemetry.md
@@ -1,0 +1,22 @@
+# Task 44 – Player Transparency Research & Telemetry
+
+**Status:** Planned
+**Owner:** Product & Analytics
+**Dependencies:** Task 39
+
+## Intent
+Establish qualitative and quantitative feedback loops to evaluate how player-visible condition summaries affect trust, immersion, and decision-making so we can iterate quickly after launch.
+
+## Subtasks
+- [ ] Define research brief covering target cohorts, interview scripts, and player trust/immersion survey questions.
+- [ ] Instrument analytics events for summary views, interactions, and dismissal reasons with privacy-safe metadata.
+- [ ] Draft rollout success metrics (engagement, retention, satisfaction) and reporting cadence for the leadership dashboard.
+- [ ] Coordinate with QA to capture edge cases requiring manual verification during beta (e.g., hidden faction reveals).
+
+## Notes
+- Ensure analytics respect existing privacy policies and avoid storing sensitive narrative content.
+- Include plan for A/B testing narrative copy variants once enough data accumulates.
+- Document how telemetry hooks integrate with existing Laravel event broadcasting and queue systems.
+
+## Log
+- 2025-10-28 10:10 UTC – Added to measure impact of transparency features and inform follow-up iterations.


### PR DESCRIPTION
## Summary
- deepen the 2025-10-28 strategic sync notes with pre-work audit, risk tracking, and cross-discipline action items for condition timer transparency
- refresh README, AGENTS guidance, task plan, and progress log to spotlight Tasks 38–44 and articulate projection, UX, narrative, and telemetry expectations
- expand backlog briefs with updated subtasks and add new documentation tasks covering wireframes, narrative copy, and research/telemetry support

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68f0adaa963083329937a21bce9dcd65