### PR TITLE
Add condition timer adjustment chronicle

### DIFF
--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -54,5 +54,7 @@
 | 2025-10-31 15:10 | Player Transparency Research & Telemetry | Established research brief, surveys, analytics events, success metrics, and beta rollout plan for transparency initiative. |
 | 2025-10-31 17:40 | Condition Timer Analytics Instrumentation | Implemented telemetry event pipeline, group opt-out controls, and UI hooks for summary views/dismissals plus refreshed projector analytics. |
 | 2025-11-01 10:45 | Condition Summary Copy Integration | Synced narrative templates with supported conditions, updated documentation, and added regression tests ensuring every timer summary renders immersive player-safe copy. |
+| 2025-11-02 11:20 | Condition Timer Acknowledgement Trails | Added acknowledgement persistence, realtime broadcasts, analytics instrumentation, and Inertia controls so players can mark conditions as reviewed while DMs track receipt counts. |
+| 2025-11-02 15:30 | Condition Timer Adjustment Chronicle | Logged timer adjustment history with analytics, timeline hydration, export hooks, and facilitator/ player privacy filters alongside UI updates and coverage. |
 
 > Update this log as features move from backlog to completion. Keep entries in UTC and 24-hour time.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Build a collaborative, browser-based Dungeon & Dragons campaign platform for dis
 - **Interaction Wireframes (Task 42):** Provide annotated frames and accessibility notes that drive a consistent shadcn/Tailwind implementation across devices.
 - **Narrative Copy Deck (Task 43):** Supply condition-themed snippets keyed by urgency tier, localization notes, and spoiler safeguards.
 - **Research & Telemetry (Task 44):** Measure trust and immersion via surveys, analytics, and beta feedback loops, ensuring future iterations remain player-first.
+- **Acknowledgement Trails (Task 46):** Allow players to mark summaries as reviewed while facilitators monitor acknowledgement counts in real time with analytics coverage.
+- **Adjustment Chronicle (Task 47):** Preserve every timer tweak with privacy-aware timelines, facilitator detail, analytics hooks, and export-ready chronicles so groups can audit pacing decisions.
 
 ### Documentation & Research Assets
 - [Condition Timer Summary Projection Guide](backend/docs/projections/condition-timer-summary-projection-guide.md) – architecture, caching, analytics, and QA expectations for the reusable projection service.

--- a/TASK_PLAN.md
+++ b/TASK_PLAN.md
@@ -18,6 +18,9 @@
 - [x] Add search/filter infrastructure across entities, tasks, notes.
 - [x] Implement exports (Markdown/PDF) and session recording storage.
 - [x] Finalize localization, accessibility, theming, and docs.
+- [x] Task 46 – Condition Timer Acknowledgement Trails (player review toggles, GM receipt overview, analytics hooks, and realtime hydration).
+- [x] Task 47 – Condition Timer Adjustment Chronicle (persist timer adjustment history, surface timeline UI, export hooks, and privacy filters).
+- [ ] Task 48 – Condition Timer Chronicle Integration (embed acknowledgements and timelines into session recap exports, share links, and AI briefings).
 ## In Progress
 - _None_
 

--- a/Tasks/Week 5/Task 46 - Condition Timer Acknowledgement Trails.md
+++ b/Tasks/Week 5/Task 46 - Condition Timer Acknowledgement Trails.md
@@ -1,0 +1,36 @@
+# Task 46 – Condition Timer Acknowledgement Trails
+
+## Intent
+Extend the player-facing condition timer transparency by letting players mark the conditions they have reviewed, surfacing receipt counts to facilitators, and streaming acknowledgement state changes to all connected clients.
+
+## Background & Alignment
+- Builds directly on Tasks 38–45 (batch adjust, summaries, mobile widgets, documentation, copy, telemetry).
+- Supports the transparency initiative’s focus on trust by giving DMs feedback about which players have seen urgent effects.
+- Must respect privacy guardrails: acknowledgements only reference condition keys already exposed to the viewer.
+
+## Success Criteria
+- Players can acknowledge individual condition entries from the summary panel without leaving the session or group summary views.
+- Facilitators (owners/DMs) can see aggregate acknowledgement counts per condition.
+- Realtime updates propagate acknowledgements to other viewers without requiring a full page reload.
+- Analytics event `timer_summary.acknowledged` records actor, group, condition key, and urgency context when an acknowledgement is logged.
+- Automated feature coverage verifies acknowledgement storage rules and summary hydration.
+
+## Proposed Implementation
+1. **Persistence** – Add a `condition_timer_acknowledgements` table keyed by group, token, condition key, and user with timestamps for acknowledgement and the summary generation timestamp they correspond to.
+2. **Domain Layer** – Introduce a `ConditionTimerAcknowledgement` model and `ConditionTimerAcknowledgementService` responsible for hydrating summaries with acknowledgement metadata and recording updates.
+3. **API & Validation** – Provide a Form Request + controller endpoint to accept acknowledgement submissions, verifying the token belongs to the group and the condition is still active.
+4. **Realtime Broadcast** – Emit a dedicated broadcast event when acknowledgements are recorded so other viewers update counts immediately.
+5. **UI** – Enhance the player summary panel (and supporting hooks) with acknowledgement toggles, optimistic UX, and DM aggregate badges while preserving the mobile recap experience.
+6. **Analytics** – Hook into the acknowledgement controller to log the analytics event with timer urgency context.
+7. **Tests** – Feature tests covering acknowledgement storage, duplicate avoidance, and summary hydration plus unit coverage for the acknowledgement service.
+
+## Milestones
+- [x] Schema & model scaffolding
+- [x] Service + analytics + broadcast wiring
+- [x] Controller endpoint & validation
+- [x] React acknowledgement controls + realtime listeners
+- [x] Feature & unit tests
+- [x] Documentation updates
+
+## Status
+Completed

--- a/Tasks/Week 5/Task 47 - Condition Timer Adjustment Chronicle.md
+++ b/Tasks/Week 5/Task 47 - Condition Timer Adjustment Chronicle.md
@@ -1,0 +1,35 @@
+# Task 47 – Condition Timer Adjustment Chronicle
+
+## Intent
+Give facilitators and players a trustworthy record of how condition timers evolve by persisting every adjustment, presenting a privacy-aware timeline alongside the player summary, and piping the chronicle into session exports.
+
+## Background & Alignment
+- Builds directly on Tasks 38–46 that introduced timer adjustments, summaries, acknowledgements, and telemetry.
+- Supports transparency goals by showing when timers were extended, reduced, or cleared without exposing GM-only secrets to players.
+- Must respect privacy rules for obscured tokens and continue logging analytics to quantify usage.
+
+## Success Criteria
+- Timer adjustments (manual batches, token edits, automated turn ticks) persist to a chronicle table with reason, actor, and delta metadata.
+- Player summary conditions show a condensed adjustment timeline; facilitators receive enriched actor/context detail without leaking hidden info to players.
+- Session exports include a condition timer chronicle section filtered by viewer permissions.
+- Analytics event `timer_summary.adjusted` fires with change context for manual and automated adjustments.
+- Feature tests cover chronicle persistence, privacy filters, and summary hydration.
+
+## Proposed Implementation
+1. **Persistence Layer** – Create a `condition_timer_adjustments` table, model, and factory capturing group/token/condition, previous & new rounds, delta, reason, actor role, context, and recorded timestamp.
+2. **Chronicle Service** – Add a `ConditionTimerChronicleService` with helpers to record adjustments from batch controllers, token CRUD, and the turn scheduler, log analytics, and fetch timelines with privacy filters.
+3. **Projection & Hydration** – Extend the summary projector to append sanitized timelines to each condition; update controllers to enrich timelines per viewer and surface them in exports.
+4. **UI** – Update the player summary panel to render the timeline with relative timestamps and facilitator-only detail while keeping mobile recap lightweight.
+5. **Docs & Telemetry** – Update roadmap/task docs plus PROGRESS_LOG, and ensure analytics captures `timer_summary.adjusted` with reason/delta context.
+6. **Tests** – Write feature coverage to assert recorded adjustments and timeline visibility differences between players and facilitators.
+
+## Milestones
+- [x] Schema, model, and factory scaffolding
+- [x] Chronicle service with recording + analytics hooks
+- [x] Projector, controller, and export integration
+- [x] React timeline UI & accessibility polish
+- [x] Feature and unit tests
+- [x] Documentation updates
+
+## Status
+Completed

--- a/backend/app/Events/ConditionTimerAcknowledgementRecorded.php
+++ b/backend/app/Events/ConditionTimerAcknowledgementRecorded.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ConditionTimerAcknowledgementRecorded implements ShouldBroadcastNow
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public int $groupId,
+        public int $tokenId,
+        public string $conditionKey,
+        public string $summaryGeneratedAt,
+        public int $acknowledgedCount,
+        public int $actorId
+    ) {
+    }
+
+    /**
+     * @return array<int, Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel("groups.{$this->groupId}.condition-timers")];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'condition-timer-acknowledgement.recorded';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'token_id' => $this->tokenId,
+            'condition_key' => $this->conditionKey,
+            'summary_generated_at' => $this->summaryGeneratedAt,
+            'acknowledged_count' => $this->acknowledgedCount,
+            'actor_id' => $this->actorId,
+        ];
+    }
+}

--- a/backend/app/Http/Controllers/ConditionTimerAcknowledgementController.php
+++ b/backend/app/Http/Controllers/ConditionTimerAcknowledgementController.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Events\ConditionTimerAcknowledgementRecorded;
+use App\Http\Requests\ConditionTimerAcknowledgementStoreRequest;
+use App\Models\Group;
+use App\Models\MapToken;
+use App\Services\AnalyticsRecorder;
+use App\Services\ConditionTimerAcknowledgementService;
+use App\Support\ConditionTimerInsights;
+use Carbon\CarbonImmutable;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Arr;
+use Illuminate\Validation\ValidationException;
+
+class ConditionTimerAcknowledgementController extends Controller
+{
+    public function __construct(
+        private readonly ConditionTimerAcknowledgementService $acknowledgements,
+        private readonly AnalyticsRecorder $analytics
+    ) {
+    }
+
+    public function store(ConditionTimerAcknowledgementStoreRequest $request, Group $group): JsonResponse
+    {
+        $this->authorize('view', $group);
+
+        /** @var Authenticatable $user */
+        $user = $request->user();
+
+        $tokenId = $request->integer('map_token_id');
+        $conditionKey = $request->string('condition_key')->toString();
+
+        try {
+            $summaryGeneratedAt = CarbonImmutable::parse($request->input('summary_generated_at'))->setTimezone('UTC');
+        } catch (\Throwable $exception) {
+            throw ValidationException::withMessages([
+                'summary_generated_at' => 'Provide a valid ISO 8601 timestamp.',
+            ]);
+        }
+
+        $token = MapToken::query()
+            ->whereKey($tokenId)
+            ->whereHas('map', fn ($query) => $query->where('group_id', $group->id))
+            ->first();
+
+        if ($token === null) {
+            throw ValidationException::withMessages([
+                'map_token_id' => 'Selected token is not part of this group.',
+            ]);
+        }
+
+        $activeConditions = $token->status_conditions ?? [];
+
+        if (! in_array($conditionKey, $activeConditions, true)) {
+            throw ValidationException::withMessages([
+                'condition_key' => 'The condition is no longer active for this token.',
+            ]);
+        }
+
+        $durations = $token->status_condition_durations ?? [];
+        $rounds = Arr::get($durations, $conditionKey);
+
+        if ($rounds !== null && (int) $rounds <= 0) {
+            throw ValidationException::withMessages([
+                'condition_key' => 'The condition has already expired.',
+            ]);
+        }
+
+        $acknowledgement = $this->acknowledgements->recordAcknowledgement(
+            $group,
+            $token,
+            $conditionKey,
+            $summaryGeneratedAt,
+            $user,
+        );
+
+        $acknowledgedCount = $this->acknowledgements->countForSummary(
+            $group,
+            $token,
+            $conditionKey,
+            $summaryGeneratedAt,
+        );
+
+        $urgency = ConditionTimerInsights::urgency($rounds !== null ? (int) $rounds : null);
+
+        $this->analytics->record(
+            'timer_summary.acknowledged',
+            [
+                'group_id' => $group->id,
+                'map_token_id' => $token->id,
+                'condition_key' => $conditionKey,
+                'urgency' => $urgency,
+                'summary_generated_at' => $summaryGeneratedAt->toIso8601String(),
+            ],
+            $user,
+            $group,
+        );
+
+        event(new ConditionTimerAcknowledgementRecorded(
+            $group->id,
+            $token->id,
+            $conditionKey,
+            $summaryGeneratedAt->toIso8601String(),
+            $acknowledgedCount,
+            (int) $user->getAuthIdentifier(),
+        ));
+
+        return response()->json([
+            'acknowledgement' => [
+                'token_id' => $acknowledgement->map_token_id,
+                'condition_key' => $acknowledgement->condition_key,
+                'summary_generated_at' => $acknowledgement->summary_generated_at->toIso8601String(),
+                'acknowledged_by_viewer' => true,
+                'acknowledged_count' => $acknowledgedCount,
+            ],
+        ]);
+    }
+}

--- a/backend/app/Http/Controllers/ConditionTimerSummaryController.php
+++ b/backend/app/Http/Controllers/ConditionTimerSummaryController.php
@@ -3,13 +3,21 @@
 namespace App\Http\Controllers;
 
 use App\Models\Group;
+use App\Models\GroupMembership;
+use App\Services\ConditionTimerAcknowledgementService;
+use App\Services\ConditionTimerChronicleService;
 use App\Services\ConditionTimerSummaryProjector;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class ConditionTimerSummaryController extends Controller
 {
-    public function __construct(private readonly ConditionTimerSummaryProjector $projector)
+    public function __construct(
+        private readonly ConditionTimerSummaryProjector $projector,
+        private readonly ConditionTimerAcknowledgementService $acknowledgements,
+        private readonly ConditionTimerChronicleService $chronicle
+    )
     {
     }
 
@@ -17,11 +25,34 @@ class ConditionTimerSummaryController extends Controller
     {
         $this->authorize('view', $group);
 
+        /** @var Authenticatable $user */
+        $user = auth()->user();
+
         $summary = $this->projector->projectForGroup($group);
 
         $viewerRole = $group->memberships()
             ->where('user_id', auth()->id())
             ->value('role');
+
+        $canViewAggregate = in_array(
+            $viewerRole,
+            [GroupMembership::ROLE_OWNER, GroupMembership::ROLE_DUNGEON_MASTER],
+            true,
+        );
+
+        $summary = $this->acknowledgements->hydrateSummaryForUser(
+            $summary,
+            $group,
+            $user,
+            $canViewAggregate,
+        );
+
+        $summary = $this->chronicle->hydrateSummaryForUser(
+            $summary,
+            $group,
+            $user,
+            $canViewAggregate,
+        );
 
         return Inertia::render('Groups/ConditionTimerSummary', [
             'group' => [

--- a/backend/app/Http/Requests/ConditionTimerAcknowledgementStoreRequest.php
+++ b/backend/app/Http/Requests/ConditionTimerAcknowledgementStoreRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\MapToken;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class ConditionTimerAcknowledgementStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'map_token_id' => ['required', 'integer', 'exists:map_tokens,id'],
+            'condition_key' => ['required', 'string', 'max:64', Rule::in(MapToken::CONDITIONS)],
+            'summary_generated_at' => ['required', 'date'],
+        ];
+    }
+}

--- a/backend/app/Models/ConditionTimerAcknowledgement.php
+++ b/backend/app/Models/ConditionTimerAcknowledgement.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ConditionTimerAcknowledgement extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'group_id',
+        'map_token_id',
+        'user_id',
+        'condition_key',
+        'summary_generated_at',
+        'acknowledged_at',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'summary_generated_at' => 'immutable_datetime',
+        'acknowledged_at' => 'immutable_datetime',
+    ];
+
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(Group::class);
+    }
+
+    public function token(): BelongsTo
+    {
+        return $this->belongsTo(MapToken::class, 'map_token_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/backend/app/Models/ConditionTimerAdjustment.php
+++ b/backend/app/Models/ConditionTimerAdjustment.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ConditionTimerAdjustment extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'group_id',
+        'map_token_id',
+        'condition_key',
+        'previous_rounds',
+        'new_rounds',
+        'delta',
+        'reason',
+        'context',
+        'actor_id',
+        'actor_role',
+        'recorded_at',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'context' => 'array',
+        'recorded_at' => 'immutable_datetime',
+    ];
+
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(Group::class);
+    }
+
+    public function token(): BelongsTo
+    {
+        return $this->belongsTo(MapToken::class, 'map_token_id');
+    }
+
+    public function actor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'actor_id');
+    }
+}

--- a/backend/app/Services/ConditionTimerAcknowledgementService.php
+++ b/backend/app/Services/ConditionTimerAcknowledgementService.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\ConditionTimerAcknowledgement;
+use App\Models\Group;
+use App\Models\MapToken;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Arr;
+
+class ConditionTimerAcknowledgementService
+{
+    /**
+     * @param  array<string, mixed>  $summary
+     * @return array<string, mixed>
+     */
+    public function hydrateSummaryForUser(
+        array $summary,
+        Group $group,
+        User $user,
+        bool $canViewAggregate = false
+    ): array {
+        $entries = $summary['entries'] ?? [];
+
+        if ($entries === []) {
+            return $summary;
+        }
+
+        $tokenIds = [];
+        $conditionKeys = [];
+
+        foreach ($entries as $entry) {
+            $tokenId = Arr::get($entry, 'token.id');
+
+            if ($tokenId === null) {
+                continue;
+            }
+
+            $tokenIds[] = $tokenId;
+
+            foreach (Arr::get($entry, 'conditions', []) as $condition) {
+                $conditionKey = Arr::get($condition, 'key');
+
+                if ($conditionKey !== null) {
+                    $conditionKeys[] = $conditionKey;
+                }
+            }
+        }
+
+        if ($tokenIds === [] || $conditionKeys === []) {
+            return $summary;
+        }
+
+        $tokenIds = array_values(array_unique($tokenIds));
+        $conditionKeys = array_values(array_unique($conditionKeys));
+
+        $summaryTimestamp = null;
+
+        if (! empty($summary['generated_at'])) {
+            try {
+                $summaryTimestamp = CarbonImmutable::parse($summary['generated_at']);
+            } catch (\Throwable $exception) {
+                $summaryTimestamp = null;
+            }
+        }
+
+        $acknowledgementsQuery = ConditionTimerAcknowledgement::query()
+            ->where('group_id', $group->id)
+            ->whereIn('map_token_id', $tokenIds)
+            ->whereIn('condition_key', $conditionKeys);
+
+        if ($summaryTimestamp !== null) {
+            $acknowledgementsQuery->where('summary_generated_at', $summaryTimestamp);
+        }
+
+        $acknowledgements = $acknowledgementsQuery->get();
+
+        $viewerMap = [];
+        $aggregateMap = [];
+
+        foreach ($acknowledgements as $acknowledgement) {
+            $key = $this->composeKey($acknowledgement->map_token_id, $acknowledgement->condition_key);
+
+            if ($acknowledgement->user_id === $user->getAuthIdentifier()) {
+                $viewerMap[$key] = true;
+            }
+
+            if ($canViewAggregate) {
+                $aggregateMap[$key] = ($aggregateMap[$key] ?? 0) + 1;
+            }
+        }
+
+        $summary['entries'] = array_map(function (array $entry) use ($viewerMap, $aggregateMap, $canViewAggregate) {
+            $entry['conditions'] = array_map(function (array $condition) use ($entry, $viewerMap, $aggregateMap, $canViewAggregate) {
+                $tokenId = Arr::get($entry, 'token.id');
+                $conditionKey = Arr::get($condition, 'key');
+
+                if ($tokenId === null || $conditionKey === null) {
+                    return $condition;
+                }
+
+                $compositeKey = $this->composeKey($tokenId, $conditionKey);
+
+                $condition['acknowledged_by_viewer'] = (bool) ($viewerMap[$compositeKey] ?? false);
+
+                if ($canViewAggregate) {
+                    $condition['acknowledged_count'] = (int) ($aggregateMap[$compositeKey] ?? 0);
+                }
+
+                return $condition;
+            }, $entry['conditions'] ?? []);
+
+            return $entry;
+        }, $entries);
+
+        return $summary;
+    }
+
+    public function recordAcknowledgement(
+        Group $group,
+        MapToken $token,
+        string $conditionKey,
+        CarbonImmutable $summaryGeneratedAt,
+        User $user
+    ): ConditionTimerAcknowledgement {
+        return ConditionTimerAcknowledgement::query()->updateOrCreate(
+            [
+                'group_id' => $group->id,
+                'map_token_id' => $token->id,
+                'user_id' => $user->getAuthIdentifier(),
+                'condition_key' => $conditionKey,
+            ],
+            [
+                'summary_generated_at' => $summaryGeneratedAt,
+                'acknowledged_at' => CarbonImmutable::now('UTC'),
+            ],
+        );
+    }
+
+    public function countForSummary(
+        Group $group,
+        MapToken $token,
+        string $conditionKey,
+        CarbonImmutable $summaryGeneratedAt
+    ): int {
+        return ConditionTimerAcknowledgement::query()
+            ->where('group_id', $group->id)
+            ->where('map_token_id', $token->id)
+            ->where('condition_key', $conditionKey)
+            ->where('summary_generated_at', $summaryGeneratedAt)
+            ->count();
+    }
+
+    protected function composeKey(int $tokenId, string $conditionKey): string
+    {
+        return sprintf('%d|%s', $tokenId, $conditionKey);
+    }
+}

--- a/backend/app/Services/ConditionTimerChronicleService.php
+++ b/backend/app/Services/ConditionTimerChronicleService.php
@@ -1,0 +1,611 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\ConditionTimerAdjustment;
+use App\Models\Group;
+use App\Models\GroupMembership;
+use App\Models\MapToken;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+
+class ConditionTimerChronicleService
+{
+    public function __construct(private readonly AnalyticsRecorder $analytics)
+    {
+    }
+
+    /**
+     * @param  array<int, array{condition: string, previous: int|null, next: int|null, context?: array<mixed>}>  $adjustments
+     * @return array<int, ConditionTimerAdjustment>
+     */
+    public function recordAdjustments(
+        Group $group,
+        MapToken $token,
+        array $adjustments,
+        string $reason,
+        ?User $actor = null,
+        array $context = []
+    ): array {
+        if ($adjustments === []) {
+            return [];
+        }
+
+        $actorId = $actor?->getAuthIdentifier();
+        $actorRole = null;
+
+        if ($actorId !== null) {
+            $actorRole = GroupMembership::query()
+                ->where('group_id', $group->id)
+                ->where('user_id', $actorId)
+                ->value('role');
+        }
+
+        $records = [];
+
+        foreach ($adjustments as $adjustment) {
+            $condition = Arr::get($adjustment, 'condition');
+
+            if (! is_string($condition) || $condition === '') {
+                continue;
+            }
+
+            $previous = $this->normalizeRoundValue(Arr::get($adjustment, 'previous'));
+            $next = $this->normalizeRoundValue(Arr::get($adjustment, 'next'));
+
+            if ($previous === $next) {
+                continue;
+            }
+
+            if ($previous === null && $next === null) {
+                continue;
+            }
+
+            $delta = $this->calculateDelta($previous, $next);
+            $composedContext = $this->mergeContext($context, Arr::get($adjustment, 'context', []));
+
+            $record = ConditionTimerAdjustment::create([
+                'group_id' => $group->id,
+                'map_token_id' => $token->id,
+                'condition_key' => $condition,
+                'previous_rounds' => $previous,
+                'new_rounds' => $next,
+                'delta' => $delta,
+                'reason' => $reason,
+                'context' => $composedContext,
+                'actor_id' => $actorId,
+                'actor_role' => $actorRole,
+                'recorded_at' => CarbonImmutable::now('UTC'),
+            ]);
+
+            $records[] = $record;
+
+            $this->analytics->record(
+                'timer_summary.adjusted',
+                [
+                    'group_id' => $group->id,
+                    'map_token_id' => $token->id,
+                    'condition_key' => $condition,
+                    'reason' => $reason,
+                    'delta' => $delta,
+                    'previous_rounds' => $previous,
+                    'new_rounds' => $next,
+                    'context' => $composedContext,
+                ],
+                $actor,
+                $group,
+            );
+        }
+
+        return $records;
+    }
+
+    /**
+     * @return array<int, ConditionTimerAdjustment>
+     */
+    public function recordDiff(
+        Group $group,
+        MapToken $token,
+        array $beforeConditions,
+        array $beforeDurations,
+        array $afterConditions,
+        array $afterDurations,
+        string $reason,
+        ?User $actor = null,
+        array $context = []
+    ): array {
+        $beforeDurations = $this->normalizeDurationMap($beforeDurations);
+        $afterDurations = $this->normalizeDurationMap($afterDurations);
+
+        $conditionKeys = array_unique(array_merge(
+            array_keys($beforeDurations),
+            array_keys($afterDurations),
+            $beforeConditions,
+            $afterConditions,
+        ));
+
+        $changes = [];
+
+        foreach ($conditionKeys as $condition) {
+            if (! is_string($condition) || $condition === '') {
+                continue;
+            }
+
+            $previous = $beforeDurations[$condition] ?? null;
+            $next = $afterDurations[$condition] ?? null;
+
+            if (! in_array($condition, $afterConditions, true)) {
+                $next = null;
+            }
+
+            if (! in_array($condition, $beforeConditions, true) && ! array_key_exists($condition, $beforeDurations)) {
+                $previous = null;
+            }
+
+            if ($previous === $next) {
+                continue;
+            }
+
+            if ($previous === null && $next === null) {
+                continue;
+            }
+
+            $changes[] = [
+                'condition' => $condition,
+                'previous' => $previous,
+                'next' => $next,
+            ];
+        }
+
+        if ($changes === []) {
+            return [];
+        }
+
+        return $this->recordAdjustments($group, $token, $changes, $reason, $actor, $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     * @return array<string, mixed>
+     */
+    public function attachPublicTimeline(Group $group, array $summary, int $perCondition = 5): array
+    {
+        $entries = $summary['entries'] ?? [];
+
+        if ($entries === []) {
+            return $summary;
+        }
+
+        $tokenIds = [];
+        $conditionKeys = [];
+
+        foreach ($entries as $entry) {
+            $tokenId = Arr::get($entry, 'token.id');
+
+            if ($tokenId === null) {
+                continue;
+            }
+
+            $tokenIds[] = (int) $tokenId;
+
+            foreach (Arr::get($entry, 'conditions', []) as $condition) {
+                $key = Arr::get($condition, 'key');
+
+                if (! is_string($key)) {
+                    continue;
+                }
+
+                $conditionKeys[] = $key;
+            }
+        }
+
+        $tokenIds = array_values(array_unique($tokenIds));
+        $conditionKeys = array_values(array_unique($conditionKeys));
+
+        if ($tokenIds === [] || $conditionKeys === []) {
+            return $summary;
+        }
+
+        $potentialLimit = max(count($tokenIds) * $perCondition * 2, 50);
+
+        $adjustments = ConditionTimerAdjustment::query()
+            ->where('group_id', $group->id)
+            ->whereIn('map_token_id', $tokenIds)
+            ->whereIn('condition_key', $conditionKeys)
+            ->orderByDesc('recorded_at')
+            ->orderByDesc('id')
+            ->limit($potentialLimit)
+            ->get();
+
+        $grouped = $adjustments->groupBy(function (ConditionTimerAdjustment $adjustment): string {
+            return $this->composeKey($adjustment->map_token_id, $adjustment->condition_key);
+        });
+
+        $summary['entries'] = array_map(function (array $entry) use ($grouped, $perCondition) {
+            $conditions = Arr::get($entry, 'conditions', []);
+            $tokenId = Arr::get($entry, 'token.id');
+
+            $conditions = array_map(function (array $condition) use ($grouped, $tokenId, $perCondition) {
+                $conditionKey = Arr::get($condition, 'key');
+
+                if (! is_string($conditionKey) || $tokenId === null) {
+                    return $condition;
+                }
+
+                $compositeKey = $this->composeKey((int) $tokenId, $conditionKey);
+                /** @var Collection<int, ConditionTimerAdjustment>|null $entries */
+                $entries = $grouped->get($compositeKey);
+
+                if ($entries === null) {
+                    $condition['timeline'] = [];
+
+                    return $condition;
+                }
+
+                $exposeNumbers = (bool) Arr::get($condition, 'exposes_exact_rounds', false);
+
+                $condition['timeline'] = $entries
+                    ->take($perCondition)
+                    ->map(function (ConditionTimerAdjustment $adjustment) use ($exposeNumbers) {
+                        return $this->presentAdjustment($adjustment, $exposeNumbers);
+                    })
+                    ->values()
+                    ->all();
+
+                return $condition;
+            }, $conditions);
+
+            $entry['conditions'] = $conditions;
+
+            return $entry;
+        }, $summary['entries']);
+
+        return $summary;
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     * @return array<string, mixed>
+     */
+    public function hydrateSummaryForUser(
+        array $summary,
+        Group $group,
+        User $user,
+        bool $canViewSensitive = false
+    ): array {
+        if (! $canViewSensitive) {
+            return $summary;
+        }
+
+        $entries = $summary['entries'] ?? [];
+
+        if ($entries === []) {
+            return $summary;
+        }
+
+        $timelineIds = [];
+
+        foreach ($entries as $entry) {
+            foreach (Arr::get($entry, 'conditions', []) as $condition) {
+                foreach (Arr::get($condition, 'timeline', []) as $event) {
+                    $id = Arr::get($event, 'id');
+
+                    if ($id !== null) {
+                        $timelineIds[] = (int) $id;
+                    }
+                }
+            }
+        }
+
+        $timelineIds = array_values(array_unique($timelineIds));
+
+        if ($timelineIds === []) {
+            return $summary;
+        }
+
+        $adjustments = ConditionTimerAdjustment::query()
+            ->whereIn('id', $timelineIds)
+            ->with('actor')
+            ->get()
+            ->keyBy('id');
+
+        $summary['entries'] = array_map(function (array $entry) use ($adjustments) {
+            $entry['conditions'] = array_map(function (array $condition) use ($adjustments) {
+                $condition['timeline'] = array_map(function (array $event) use ($adjustments) {
+                    $id = Arr::get($event, 'id');
+
+                    if ($id === null) {
+                        return $event;
+                    }
+
+                    /** @var ConditionTimerAdjustment|null $adjustment */
+                    $adjustment = $adjustments->get((int) $id);
+
+                    if (! $adjustment) {
+                        return $event;
+                    }
+
+                    $event['detail'] = [
+                        'summary' => $this->buildDetailedSummary($adjustment),
+                        'previous_rounds' => $adjustment->previous_rounds,
+                        'new_rounds' => $adjustment->new_rounds,
+                        'delta' => $adjustment->delta,
+                        'actor' => $adjustment->actor ? [
+                            'id' => $adjustment->actor->id,
+                            'name' => $adjustment->actor->name,
+                            'role' => $adjustment->actor_role,
+                        ] : null,
+                        'context' => $adjustment->context,
+                    ];
+
+                    return $event;
+                }, Arr::get($condition, 'timeline', []));
+
+                return $condition;
+            }, Arr::get($entry, 'conditions', []));
+
+            return $entry;
+        }, $summary['entries']);
+
+        return $summary;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function exportChronicle(Group $group, bool $includeSensitive = false, int $limit = 50): array
+    {
+        $adjustments = ConditionTimerAdjustment::query()
+            ->where('group_id', $group->id)
+            ->with(['token.map', 'actor'])
+            ->orderByDesc('recorded_at')
+            ->orderByDesc('id')
+            ->limit($limit)
+            ->get();
+
+        return $adjustments
+            ->map(function (ConditionTimerAdjustment $adjustment) use ($includeSensitive) {
+                $token = $adjustment->token;
+                $map = $token?->map;
+
+                $exposeNumbers = $includeSensitive;
+
+                if (! $includeSensitive && $token) {
+                    $exposeNumbers = $this->shouldExposeExactRounds($token->faction, (bool) $token->hidden);
+                }
+
+                return [
+                    'id' => $adjustment->id,
+                    'recorded_at' => $adjustment->recorded_at?->clone()->setTimezone('UTC'),
+                    'map' => $map ? [
+                        'id' => $map->id,
+                        'title' => $map->title,
+                    ] : null,
+                    'token' => $token ? [
+                        'id' => $token->id,
+                        'label' => $token->name ?? 'Unknown token',
+                        'visibility' => $token->hidden ? 'obscured' : 'visible',
+                    ] : null,
+                    'condition_key' => $adjustment->condition_key,
+                    'reason' => $adjustment->reason,
+                    'summary' => $this->presentAdjustment($adjustment, $exposeNumbers)['summary'],
+                    'previous_rounds' => $includeSensitive ? $adjustment->previous_rounds : null,
+                    'new_rounds' => $includeSensitive ? $adjustment->new_rounds : null,
+                    'delta' => $includeSensitive ? $adjustment->delta : null,
+                    'actor' => $includeSensitive && $adjustment->actor ? [
+                        'id' => $adjustment->actor->id,
+                        'name' => $adjustment->actor->name,
+                        'role' => $adjustment->actor_role,
+                    ] : null,
+                    'context' => $includeSensitive ? $adjustment->context : null,
+                ];
+            })
+            ->values()
+            ->all();
+    }
+
+    protected function normalizeRoundValue(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (! is_numeric($value)) {
+            return null;
+        }
+
+        $int = (int) $value;
+
+        return $int > 0 ? $int : null;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $values
+     * @return array<string, int|null>
+     */
+    protected function normalizeDurationMap(?array $values): array
+    {
+        if ($values === null) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($values as $key => $value) {
+            if (! is_string($key)) {
+                continue;
+            }
+
+            $normalized[$key] = $this->normalizeRoundValue($value);
+        }
+
+        return $normalized;
+    }
+
+    protected function calculateDelta(?int $previous, ?int $next): ?int
+    {
+        if ($previous === null && $next === null) {
+            return null;
+        }
+
+        if ($previous === null && $next !== null) {
+            return $next;
+        }
+
+        if ($previous !== null && $next === null) {
+            return -$previous;
+        }
+
+        if ($previous === null || $next === null) {
+            return null;
+        }
+
+        return $next - $previous;
+    }
+
+    /**
+     * @param  array<string, mixed>  $base
+     * @param  array<string, mixed>|null  $override
+     * @return array<string, mixed>|null
+     */
+    protected function mergeContext(array $base, ?array $override): ?array
+    {
+        $merged = array_filter(array_merge($base, $override ?? []), static function ($value) {
+            return $value !== null;
+        });
+
+        return $merged === [] ? null : $merged;
+    }
+
+    protected function composeKey(int $tokenId, string $conditionKey): string
+    {
+        return sprintf('%d:%s', $tokenId, $conditionKey);
+    }
+
+    protected function presentAdjustment(ConditionTimerAdjustment $adjustment, bool $exposeNumbers): array
+    {
+        $previous = $adjustment->previous_rounds;
+        $next = $adjustment->new_rounds;
+        $reason = $adjustment->reason;
+
+        $kind = $this->resolveKind($adjustment);
+        $summary = $this->buildPublicSummary($kind, $reason, $previous, $next, $exposeNumbers);
+
+        return [
+            'id' => $adjustment->id,
+            'recorded_at' => $adjustment->recorded_at?->toIso8601String() ?? $adjustment->created_at?->toIso8601String(),
+            'reason' => $reason,
+            'kind' => $kind,
+            'summary' => $summary,
+        ];
+    }
+
+    protected function resolveKind(ConditionTimerAdjustment $adjustment): string
+    {
+        $previous = $adjustment->previous_rounds;
+        $next = $adjustment->new_rounds;
+
+        if ($adjustment->reason === 'turn_advance' && $next !== null) {
+            return 'ticked';
+        }
+
+        if ($next === null && $previous !== null) {
+            return 'cleared';
+        }
+
+        if ($previous === null && $next !== null) {
+            return 'started';
+        }
+
+        if ($previous !== null && $next !== null) {
+            return $next > $previous ? 'extended' : ($next < $previous ? 'reduced' : 'adjusted');
+        }
+
+        return 'adjusted';
+    }
+
+    protected function buildPublicSummary(
+        string $kind,
+        string $reason,
+        ?int $previous,
+        ?int $next,
+        bool $exposeNumbers
+    ): string {
+        return match ($kind) {
+            'started' => $exposeNumbers && $next !== null
+                ? sprintf('Timer started at %d rounds.', $next)
+                : 'Timer started.',
+            'extended' => $exposeNumbers && $next !== null
+                ? sprintf('Timer extended to %d rounds.', $next)
+                : 'Timer extended.',
+            'reduced' => $exposeNumbers && $next !== null
+                ? sprintf('Timer reduced to %d rounds.', $next)
+                : 'Timer reduced.',
+            'cleared' => 'Timer cleared.',
+            'ticked' => $exposeNumbers && $next !== null
+                ? sprintf('Countdown advanced to %d rounds.', $next)
+                : 'Countdown advanced.',
+            default => match ($reason) {
+                'turn_advance' => 'Countdown advanced.',
+                default => $exposeNumbers && $next !== null
+                    ? sprintf('Timer adjusted to %d rounds.', $next)
+                    : 'Timer adjusted.',
+            },
+        };
+    }
+
+    protected function buildDetailedSummary(ConditionTimerAdjustment $adjustment): string
+    {
+        $reason = $this->describeReason($adjustment->reason);
+        $actor = $adjustment->actor?->name ?? 'Automated process';
+        $range = $this->describeRange($adjustment->previous_rounds, $adjustment->new_rounds);
+
+        return trim(sprintf('%s by %s%s', ucfirst($reason), $actor, $range ? ': '.$range : ''));
+    }
+
+    protected function describeReason(string $reason): string
+    {
+        return match ($reason) {
+            'manual_adjustment' => 'manual adjustment',
+            'token_update' => 'token update',
+            'token_created' => 'token placement',
+            'turn_advance' => 'turn advance',
+            default => str_replace('_', ' ', $reason),
+        };
+    }
+
+    protected function describeRange(?int $previous, ?int $next): string
+    {
+        if ($previous === null && $next === null) {
+            return 'set to linger';
+        }
+
+        if ($previous === null && $next !== null) {
+            return sprintf('started at %d rounds', $next);
+        }
+
+        if ($previous !== null && $next === null) {
+            return sprintf('cleared (was %d rounds)', $previous);
+        }
+
+        if ($previous !== null && $next !== null) {
+            return sprintf('%d → %d rounds', $previous, $next);
+        }
+
+        return '';
+    }
+
+    protected function shouldExposeExactRounds(?string $faction, bool $hidden): bool
+    {
+        if ($hidden) {
+            return false;
+        }
+
+        return in_array($faction, [
+            MapToken::FACTION_ALLIED,
+            MapToken::FACTION_NEUTRAL,
+        ], true);
+    }
+}

--- a/backend/app/Support/ConditionTimerInsights.php
+++ b/backend/app/Support/ConditionTimerInsights.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Support;
+
+class ConditionTimerInsights
+{
+    public static function urgency(?int $rounds): string
+    {
+        if ($rounds === null) {
+            return 'warning';
+        }
+
+        if ($rounds <= 2) {
+            return 'critical';
+        }
+
+        if ($rounds <= 4) {
+            return 'warning';
+        }
+
+        return 'calm';
+    }
+}

--- a/backend/database/factories/ConditionTimerAcknowledgementFactory.php
+++ b/backend/database/factories/ConditionTimerAcknowledgementFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ConditionTimerAcknowledgement;
+use App\Models\Group;
+use App\Models\MapToken;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ConditionTimerAcknowledgement>
+ */
+class ConditionTimerAcknowledgementFactory extends Factory
+{
+    protected $model = ConditionTimerAcknowledgement::class;
+
+    public function definition(): array
+    {
+        $timestamp = $this->faker->dateTimeBetween('-1 hour', 'now', 'UTC');
+
+        return [
+            'group_id' => Group::factory(),
+            'map_token_id' => MapToken::factory(),
+            'user_id' => User::factory(),
+            'condition_key' => $this->faker->randomElement(MapToken::CONDITIONS),
+            'summary_generated_at' => $timestamp,
+            'acknowledged_at' => $timestamp,
+        ];
+    }
+}

--- a/backend/database/factories/ConditionTimerAdjustmentFactory.php
+++ b/backend/database/factories/ConditionTimerAdjustmentFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ConditionTimerAdjustment;
+use App\Models\Group;
+use App\Models\MapToken;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+
+/**
+ * @extends Factory<ConditionTimerAdjustment>
+ */
+class ConditionTimerAdjustmentFactory extends Factory
+{
+    protected $model = ConditionTimerAdjustment::class;
+
+    public function definition(): array
+    {
+        $token = MapToken::factory()->create();
+        $token->load('map');
+
+        /** @var Group $group */
+        $group = $token->map->group ?? Group::factory()->create();
+        $actor = User::factory()->create();
+
+        return [
+            'group_id' => $group->id,
+            'map_token_id' => $token->id,
+            'condition_key' => $this->faker->randomElement(MapToken::CONDITIONS),
+            'previous_rounds' => $this->faker->numberBetween(1, 5),
+            'new_rounds' => $this->faker->numberBetween(1, 5),
+            'delta' => $this->faker->numberBetween(-3, 3),
+            'reason' => 'manual_adjustment',
+            'context' => ['source' => 'factory'],
+            'actor_id' => $actor->id,
+            'actor_role' => 'dungeon-master',
+            'recorded_at' => Carbon::now('UTC'),
+        ];
+    }
+}

--- a/backend/database/migrations/2025_11_02_090000_create_condition_timer_acknowledgements_table.php
+++ b/backend/database/migrations/2025_11_02_090000_create_condition_timer_acknowledgements_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use App\Models\Group;
+use App\Models\MapToken;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('condition_timer_acknowledgements', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignIdFor(Group::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(MapToken::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
+            $table->string('condition_key', 64);
+            $table->timestampTz('summary_generated_at');
+            $table->timestampTz('acknowledged_at');
+            $table->timestamps();
+
+            $table->unique([
+                'group_id',
+                'map_token_id',
+                'user_id',
+                'condition_key',
+            ], 'condition_acknowledgements_unique');
+
+            $table->index([
+                'group_id',
+                'summary_generated_at',
+            ]);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('condition_timer_acknowledgements');
+    }
+};

--- a/backend/database/migrations/2025_11_02_091500_create_condition_timer_adjustments_table.php
+++ b/backend/database/migrations/2025_11_02_091500_create_condition_timer_adjustments_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('condition_timer_adjustments', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('group_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('map_token_id')->constrained()->cascadeOnDelete();
+            $table->string('condition_key');
+            $table->integer('previous_rounds')->nullable();
+            $table->integer('new_rounds')->nullable();
+            $table->integer('delta')->nullable();
+            $table->string('reason');
+            $table->json('context')->nullable();
+            $table->foreignId('actor_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('actor_role')->nullable();
+            $table->timestamp('recorded_at')->useCurrent();
+            $table->timestamps();
+
+            $table->index(['group_id', 'map_token_id', 'condition_key', 'recorded_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('condition_timer_adjustments');
+    }
+};

--- a/backend/resources/js/lib/conditionAcknowledgements.ts
+++ b/backend/resources/js/lib/conditionAcknowledgements.ts
@@ -1,0 +1,53 @@
+import type { ConditionTimerSummaryResource } from '@/components/condition-timers/PlayerConditionTimerSummaryPanel';
+
+export type ConditionAcknowledgementPayload = {
+    token_id: number;
+    condition_key: string;
+    summary_generated_at: string;
+    acknowledged_count?: number;
+    acknowledged_by_viewer?: boolean;
+    actor_id?: number;
+};
+
+export function applyAcknowledgementToSummary(
+    summary: ConditionTimerSummaryResource,
+    payload: ConditionAcknowledgementPayload | undefined,
+    viewerId: number | null | undefined = undefined,
+): ConditionTimerSummaryResource {
+    if (!payload || summary.generated_at !== payload.summary_generated_at) {
+        return summary;
+    }
+
+    return {
+        ...summary,
+        entries: summary.entries.map((entry) => {
+            if (entry.token.id !== payload.token_id) {
+                return entry;
+            }
+
+            return {
+                ...entry,
+                conditions: entry.conditions.map((condition) => {
+                    if (condition.key !== payload.condition_key) {
+                        return condition;
+                    }
+
+                    const acknowledgedByViewer =
+                        payload.actor_id !== undefined && viewerId !== undefined
+                            ? payload.actor_id === viewerId
+                            : payload.acknowledged_by_viewer;
+
+                    return {
+                        ...condition,
+                        acknowledged_by_viewer:
+                            acknowledgedByViewer ?? condition.acknowledged_by_viewer ?? false,
+                        acknowledged_count:
+                            typeof payload.acknowledged_count === 'number'
+                                ? payload.acknowledged_count
+                                : condition.acknowledged_count,
+                    };
+                }),
+            };
+        }),
+    };
+}

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\CampaignTaskController;
 use App\Http\Controllers\CampaignEntityController;
 use App\Http\Controllers\CampaignQuestController;
 use App\Http\Controllers\CampaignQuestUpdateController;
+use App\Http\Controllers\ConditionTimerAcknowledgementController;
 use App\Http\Controllers\ConditionTimerSummaryController;
 use App\Http\Controllers\DiceRollController;
 use App\Http\Controllers\GroupController;
@@ -60,6 +61,10 @@ Route::middleware('auth')->group(function (): void {
         'groups/{group}/condition-timers/player-summary',
         [ConditionTimerSummaryController::class, 'show']
     )->name('groups.condition-timers.player-summary');
+    Route::post(
+        'groups/{group}/condition-timers/acknowledgements',
+        [ConditionTimerAcknowledgementController::class, 'store']
+    )->name('groups.condition-timers.acknowledgements.store');
     Route::resource('groups.memberships', GroupMembershipController::class)
         ->only(['store', 'update', 'destroy'])
         ->scoped();

--- a/backend/tests/Feature/ConditionTimerAcknowledgementTest.php
+++ b/backend/tests/Feature/ConditionTimerAcknowledgementTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use App\Events\ConditionTimerAcknowledgementRecorded;
+use App\Models\AnalyticsEvent;
+use App\Models\Group;
+use App\Models\GroupMembership;
+use App\Models\Map;
+use App\Models\MapToken;
+use App\Models\User;
+use App\Services\ConditionTimerAcknowledgementService;
+use App\Services\ConditionTimerSummaryProjector;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Event;
+
+it('records acknowledgements and broadcasts updates', function () {
+    Event::fake([ConditionTimerAcknowledgementRecorded::class]);
+
+    $user = User::factory()->create();
+    $group = Group::factory()->create();
+    GroupMembership::query()->create([
+        'group_id' => $group->id,
+        'user_id' => $user->id,
+        'role' => GroupMembership::ROLE_PLAYER,
+    ]);
+
+    $map = Map::factory()->for($group)->create();
+    $token = MapToken::factory()->for($map)->create([
+        'status_conditions' => ['blinded'],
+        'status_condition_durations' => ['blinded' => 3],
+    ]);
+
+    $summaryTimestamp = Carbon::now('UTC')->toIso8601String();
+
+    Carbon::setTestNow(Carbon::parse($summaryTimestamp));
+
+    $response = $this
+        ->actingAs($user)
+        ->postJson(route('groups.condition-timers.acknowledgements.store', $group), [
+            'map_token_id' => $token->id,
+            'condition_key' => 'blinded',
+            'summary_generated_at' => $summaryTimestamp,
+        ]);
+
+    $response->assertOk();
+    $response->assertJsonPath('acknowledgement.acknowledged_by_viewer', true);
+    $response->assertJsonPath('acknowledgement.acknowledged_count', 1);
+
+    $this->assertDatabaseHas('condition_timer_acknowledgements', [
+        'group_id' => $group->id,
+        'map_token_id' => $token->id,
+        'user_id' => $user->id,
+        'condition_key' => 'blinded',
+    ]);
+
+    Event::assertDispatched(ConditionTimerAcknowledgementRecorded::class, function (ConditionTimerAcknowledgementRecorded $event) use ($group, $token) {
+        return $event->groupId === $group->id
+            && $event->tokenId === $token->id
+            && $event->conditionKey === 'blinded'
+            && $event->acknowledgedCount === 1;
+    });
+
+    expect(AnalyticsEvent::query()->where('key', 'timer_summary.acknowledged')->count())->toBe(1);
+
+    Carbon::setTestNow();
+});
+
+it('hydrates summaries with acknowledgement metadata', function () {
+    $acknowledgements = app(ConditionTimerAcknowledgementService::class);
+    $projector = app(ConditionTimerSummaryProjector::class);
+
+    $group = Group::factory()->create();
+    $player = User::factory()->create();
+    $dm = User::factory()->create();
+
+    GroupMembership::query()->insert([
+        [
+            'group_id' => $group->id,
+            'user_id' => $player->id,
+            'role' => GroupMembership::ROLE_PLAYER,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ],
+        [
+            'group_id' => $group->id,
+            'user_id' => $dm->id,
+            'role' => GroupMembership::ROLE_DUNGEON_MASTER,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ],
+    ]);
+
+    $map = Map::factory()->for($group)->create();
+    $token = MapToken::factory()->for($map)->create([
+        'status_conditions' => ['blinded'],
+        'status_condition_durations' => ['blinded' => 2],
+    ]);
+
+    $summary = $projector->projectForGroup($group);
+
+    $generatedAt = CarbonImmutable::parse($summary['generated_at']);
+
+    $acknowledgements->recordAcknowledgement($group, $token, 'blinded', $generatedAt, $player);
+
+    $playerSummary = $acknowledgements->hydrateSummaryForUser($summary, $group, $player, false);
+    $dmSummary = $acknowledgements->hydrateSummaryForUser($summary, $group, $dm, true);
+
+    $playerCondition = $playerSummary['entries'][0]['conditions'][0];
+    $dmCondition = $dmSummary['entries'][0]['conditions'][0];
+
+    expect($playerCondition['acknowledged_by_viewer'])->toBeTrue();
+    expect($playerCondition)->not->toHaveKey('acknowledged_count');
+
+    expect($dmCondition['acknowledged_by_viewer'])->toBeFalse();
+    expect($dmCondition['acknowledged_count'])->toBe(1);
+});

--- a/backend/tests/Feature/ConditionTimerChronicleTest.php
+++ b/backend/tests/Feature/ConditionTimerChronicleTest.php
@@ -1,0 +1,154 @@
+<?php
+
+use App\Models\Group;
+use App\Models\GroupMembership;
+use App\Models\Map;
+use App\Models\MapToken;
+use App\Models\User;
+use App\Services\ConditionTimerChronicleService;
+use App\Services\ConditionTimerSummaryProjector;
+
+it('records adjustments and hydrates timelines by role', function () {
+    $dm = User::factory()->create();
+    $player = User::factory()->create();
+    $group = Group::factory()->create();
+
+    GroupMembership::query()->insert([
+        [
+            'group_id' => $group->id,
+            'user_id' => $dm->id,
+            'role' => GroupMembership::ROLE_DUNGEON_MASTER,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ],
+        [
+            'group_id' => $group->id,
+            'user_id' => $player->id,
+            'role' => GroupMembership::ROLE_PLAYER,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ],
+    ]);
+
+    $map = Map::factory()->for($group)->create();
+    $token = MapToken::factory()->for($map)->create([
+        'status_conditions' => ['blinded'],
+        'status_condition_durations' => ['blinded' => 3],
+        'hidden' => false,
+        'faction' => MapToken::FACTION_ALLIED,
+    ]);
+
+    $response = $this
+        ->actingAs($dm)
+        ->post(route('groups.maps.tokens.condition-timers.batch', [$group, $map]), [
+            'adjustments' => [
+                [
+                    'token_id' => $token->id,
+                    'condition' => 'blinded',
+                    'delta' => 2,
+                ],
+            ],
+        ]);
+
+    $response->assertRedirect();
+
+    $this->assertDatabaseHas('condition_timer_adjustments', [
+        'group_id' => $group->id,
+        'map_token_id' => $token->id,
+        'condition_key' => 'blinded',
+        'reason' => 'manual_adjustment',
+    ]);
+
+    /** @var ConditionTimerSummaryProjector $projector */
+    $projector = app(ConditionTimerSummaryProjector::class);
+    /** @var ConditionTimerChronicleService $chronicle */
+    $chronicle = app(ConditionTimerChronicleService::class);
+
+    $projector->refreshForGroup($group, 'test', false);
+    $summary = $projector->projectForGroup($group);
+
+    $playerSummary = $chronicle->hydrateSummaryForUser($summary, $group, $player, false);
+    $dmSummary = $chronicle->hydrateSummaryForUser($summary, $group, $dm, true);
+
+    $playerTimeline = $playerSummary['entries'][0]['conditions'][0]['timeline'] ?? [];
+    expect($playerTimeline)->not->toBeEmpty();
+    expect($playerTimeline[0])->not->toHaveKey('detail');
+    expect($playerTimeline[0]['summary'])->toContain('Timer extended');
+
+    $dmTimeline = $dmSummary['entries'][0]['conditions'][0]['timeline'] ?? [];
+    expect($dmTimeline)->not->toBeEmpty();
+    expect($dmTimeline[0]['detail']['actor']['id'])->toBe($dm->id);
+    expect($dmTimeline[0]['detail']['previous_rounds'])->toBe(3);
+    expect($dmTimeline[0]['detail']['new_rounds'])->toBe(5);
+    expect($dmTimeline[0]['detail']['summary'])->toContain('Manual adjustment');
+});
+
+it('exposes chronicle entries in exports based on permissions', function () {
+    $dm = User::factory()->create();
+    $player = User::factory()->create();
+    $group = Group::factory()->create();
+
+    GroupMembership::query()->insert([
+        [
+            'group_id' => $group->id,
+            'user_id' => $dm->id,
+            'role' => GroupMembership::ROLE_DUNGEON_MASTER,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ],
+        [
+            'group_id' => $group->id,
+            'user_id' => $player->id,
+            'role' => GroupMembership::ROLE_PLAYER,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ],
+    ]);
+
+    $map = Map::factory()->for($group)->create();
+    $token = MapToken::factory()->for($map)->create([
+        'status_conditions' => ['poisoned'],
+        'status_condition_durations' => ['poisoned' => 4],
+        'hidden' => false,
+        'faction' => MapToken::FACTION_ALLIED,
+    ]);
+
+    /** @var ConditionTimerChronicleService $chronicle */
+    $chronicle = app(ConditionTimerChronicleService::class);
+    $chronicle->recordAdjustments(
+        $group,
+        $token,
+        [
+            [
+                'condition' => 'poisoned',
+                'previous' => 4,
+                'next' => 2,
+            ],
+        ],
+        'manual_adjustment',
+        $dm,
+        ['source' => 'export_test'],
+    );
+
+    $campaign = \App\Models\Campaign::factory()->for($group)->create(['created_by' => $dm->id]);
+    $session = \App\Models\CampaignSession::factory()
+        ->for($campaign)
+        ->create([
+            'created_by' => $dm->id,
+            'summary' => 'Test session summary.',
+        ]);
+
+    /** @var \App\Services\SessionExportService $exports */
+    $exports = app(\App\Services\SessionExportService::class);
+
+    $dmExport = $exports->buildExportData($session->fresh(), $dm);
+    $playerExport = $exports->buildExportData($session->fresh(), $player);
+
+    expect($dmExport['condition_timer_chronicle'])->not->toBeEmpty();
+    expect($dmExport['condition_timer_chronicle'][0]['previous_rounds'])->toBe(4);
+    expect($dmExport['condition_timer_chronicle'][0]['actor']['id'])->toBe($dm->id);
+
+    expect($playerExport['condition_timer_chronicle'])->not->toBeEmpty();
+    expect($playerExport['condition_timer_chronicle'][0]['previous_rounds'])->toBeNull();
+    expect($playerExport['condition_timer_chronicle'][0]['actor'])->toBeNull();
+});


### PR DESCRIPTION
## Summary
- persist condition timer adjustments with a dedicated model, service, analytics event, and integrations across batch updates, token CRUD, and turn processing
- extend summary projection, controllers, exports, and the player summary UI to surface privacy-aware adjustment timelines for players and facilitators
- document Task 47 completion and add feature coverage for chronicle persistence and export visibility rules

## Testing
- php artisan test *(fails: vendor autoload not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f0ee8aa74083329096e1b301f9a651