### PR TITLE
Add transparency follow-up tasks and dossier kickoff notes

### DIFF
--- a/Meetings/2025-11-12-po-focus-group-sync.md
+++ b/Meetings/2025-11-12-po-focus-group-sync.md
@@ -1,0 +1,44 @@
+# PO & Focus Group Sync – Transparency Next Steps
+- **Date:** 2025-11-12 15:00 UTC
+- **Facilitator:** Product Owner
+- **Attendees & Roles:**
+  - Product Owner – backlog stewardship, consent policy alignment
+  - Engineering Lead – implementation planning and timeline validation
+  - QA Lead – coverage strategy and beta readiness
+  - Narrative & AI Lead – mentor briefings tone and localization
+  - D&D Focus Group Representatives – table-play feedback, session reports
+
+## Agenda
+1. Review outcomes from Tasks 57–58 and identify open acceptance items.
+2. Gather tabletop feedback on share link consent flows and mentor briefings.
+3. Prioritize improvements for Tasks 59–63 before beta graduation.
+4. Confirm ownership and sequencing for the next two-week sprint.
+
+## Highlights & Feedback
+- Share link consent toggles were praised for clarity, but facilitators want **preset bundles** ("one-shot preview", "extended ally access") to avoid manual reconfiguration during live play.
+- Focus group players reported anxiety when mentor briefings surfaced while they were offline; they requested **asynchronous catch-up prompts** in the recap feed instead of surprise push alerts.
+- QA reiterated that the synthetic monitoring spikes during load testing did not mirror real party cadence; they need **scenario scripts** based on actual encounter pacing from the focus group logs.
+- Consent auditors flagged that guest acknowledgements should call out **who unlocked a link extension** to keep the audit trail readable.
+- D&D reps asked for **ritual-style narrative variants** for long-duration conditions so mentor briefings feel distinct from combat scenarios.
+
+## Decisions
+- Introduce share link preset bundles as part of Task 61 so facilitators can rapidly select expiry + visibility combinations that match party expectations.
+- Task 58’s outstanding moderation queue will ship with an **AI playback digest** that summarizes any suppressed mentor briefings for facilitators.
+- Task 59 will anchor the structured beta playtest using the focus group’s encounter scripts and require a sign-off form from each table.
+- Task 62 will absorb telemetry work for tracking who extends or revokes share links, exposing that data in the insights dashboard.
+- Task 63 will extend the guest experience polish scope to add recap-feed catch-up prompts for players who missed mentor briefings.
+
+## Action Items
+1. **Engineering Lead (2025-11-13):** Draft API contract for share link preset bundles and audit trail metadata. Document under Task 61.
+2. **QA Lead (2025-11-14):** Convert focus group combat logs into repeatable load/perf scripts; attach to Task 59 and CI notes.
+3. **Narrative & AI Lead (2025-11-15):** Produce ritual-style mentor copy variants and update Task 58 moderation queue acceptance criteria.
+4. **Product Owner (2025-11-16):** Update Tasks 59–63 briefs to capture new acceptance criteria and telemetry expectations.
+5. **Focus Group Coordinators (2025-11-18):** Deliver signed beta playtest commitment forms; archive in project drive and reference in Task 59 log.
+
+## Risks & Follow-Ups
+- **Risk:** Preset bundles could create inconsistent privacy defaults if custom overrides persist. *Mitigation:* enforce explicit confirmation modal showing final consent states before saving.
+- **Risk:** Additional telemetry for extension tracking might impact analytics performance. *Mitigation:* reuse existing projection cache write pipeline with batched inserts.
+- **Risk:** Catch-up prompts may spam players who intentionally muted mentor briefings. *Mitigation:* respect per-channel opt-outs and surface prompts only within recap feed, never via push notifications.
+
+## Next Checkpoint
+- Schedule follow-up on 2025-11-19 15:00 UTC to demo preset bundles, review AI moderation queue UX, and validate updated QA scripts.

--- a/Meetings/2025-11-13-transparency-task-retro.md
+++ b/Meetings/2025-11-13-transparency-task-retro.md
@@ -1,0 +1,45 @@
+# Transparency Initiative Task Review – Cross-Discipline Retro
+- **Date:** 2025-11-13 16:00 UTC
+- **Facilitator:** Delivery Lead
+- **Attendees & Roles:**
+  - Product Owner – backlog curation and stakeholder liaison
+  - Engineering Lead – implementation status and technical debt triage
+  - QA Lead – validation coverage and regression monitoring
+  - Narrative & AI Lead – mentor briefing tone, localization, and AI guardrails
+  - Data & Telemetry Lead – analytics, consent audit trails, and KPI tracking
+  - D&D Focus Group Coordinators – live-play insights and player sentiment
+
+## Agenda
+1. Walk through Tasks 1–63 deliverables to confirm acceptance and documentation coverage.
+2. Identify cross-task patterns in condition transparency UX, telemetry, and offline support.
+3. Surface lingering risks, tech debt, or knowledge gaps before expanding scope beyond transparency.
+4. Align on retro-inspired improvements to feed into the next sprint planning session.
+
+## Completion Review Highlights
+- **Foundational Platform (Tasks 1–20):** Authentication, campaign/session scaffolding, tile maps, and realtime collaboration are fully shipped with Pest/Dusk coverage. Documentation remains current, but attendees flagged the need for a refreshed onboarding quickstart that references the latest Inertia flows.
+- **Task Board, AI, and Search Enhancements (Tasks 21–37):** Kanban workflows, AI DM support, and global search are stable in production with telemetry verifying adoption. AI mentors now include audit logging, yet the team wants to consolidate AI prompt libraries to ease localization.
+- **Condition Timer Transparency Core (Tasks 38–52):** Player-safe projections, mobile widgets, narrative copy decks, analytics, and wireframes are complete. Focus group feedback confirms the dashboards and alerts meet accessibility goals, though preset bundle UX (Task 61) must inherit these lessons.
+- **Transparency Expansion & Stewardship (Tasks 53–63):** Share trail logging, expiry stewardship, facilitator insights, QA automation, and guest experience polish are on track post-11/12 sync updates. Remaining acceptance items center on share preset bundles, mentor moderation playback digests, and recap catch-up prompts tied to Tasks 58, 61, and 63.
+- **Process & Documentation:** PROGRESS_LOG.md and task briefs are current through 2025-11-12. All meeting minutes captured to date align with roadmap adjustments, and demo automation remains healthy per CI telemetry.
+
+## Decisions & Improvements
+- Publish a **Transparency Initiative Completion Dossier** compiling architecture overviews, QA scripts, telemetry dashboards, and narrative assets for stakeholders by 2025-11-20.
+- Convert recurring insights dashboards into a **shared Inertia component library** to accelerate upcoming non-transparency initiatives.
+- Bundle AI mentor prompt variants into a **centralized localization manifest** to simplify future language drops and consistency reviews.
+- Schedule a **knowledge transfer series** (2 sessions) for new engineers to cover condition timer architecture, share link governance, and telemetry pipelines.
+
+## Action Items
+1. **Engineering Lead (2025-11-15):** Draft outline and asset inventory for the Transparency Initiative Completion Dossier; attach to TASK_PLAN.md and share with stakeholders.
+2. **QA Lead (2025-11-16):** Normalize the end-to-end QA scripts into reusable scenarios and update Tasks/Week 7/Task 59 with regression tagging guidance.
+3. **Narrative & AI Lead (2025-11-18):** Produce consolidated AI mentor prompt manifest and file under `backend/resources/lang/en/transparency-ai.json` with documentation notes.
+4. **Product Owner (2025-11-19):** Coordinate the knowledge transfer sessions, logging agendas in Meetings/ and updating PROGRESS_LOG.md upon completion.
+5. **Data & Telemetry Lead (2025-11-20):** Extract consent audit KPIs into a recurring Looker dashboard and reference setup steps in Tasks/Week 7/Task 62.
+
+## Risks & Watchpoints
+- **Documentation Drift:** As we prepare the dossier, there is risk of duplicate truth sources. *Mitigation:* designate TASK_PLAN.md as authoritative and embed links instead of copying content.
+- **AI Prompt Consistency:** Without a manifest, translation updates could diverge from approved tone. *Mitigation:* require narrative sign-off on any prompt additions via pull request template checklist.
+- **Telemetry Load:** Consolidating dashboards may increase query volume. *Mitigation:* batch refresh windows and reuse existing caching strategies validated during Tasks 53–57.
+- **New Team Onboarding:** Incoming engineers might miss historical context. *Mitigation:* ensure knowledge transfer recordings and slides are archived alongside meeting notes.
+
+## Next Steps
+- Reconvene on 2025-11-21 16:00 UTC to review dossier progress, confirm action item completion, and decide whether transparency scope can transition to maintenance mode.

--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -71,4 +71,8 @@
 | 2025-11-10 18:40 | Localization & Accessibility Audit | Localized condition transparency surfaces, added jsx-a11y linting with `npm run lint`, refreshed QA checklist, and documented multilingual accessibility verification. |
 | 2025-11-11 14:20 | Condition Transparency Data Exports Docs | Documented export pipeline integration patterns, webhook payloads, governance guardrails, and synced meeting outcomes with PO/architect expectations. |
 
+| 2025-11-12 15:00 | PO & Focus Group Sync | Met with PO, QA, narrative, and focus group reps to capture consent feedback, planned preset bundles, extension telemetry, recap catch-up prompts, and QA playtest artifacts for Tasks 58–63. |
+| 2025-11-13 16:00 | Transparency Task Review Retro | Cross-discipline review of Tasks 1–63 deliverables, identified documentation refresh needs, planned transparency dossier, component library reuse, AI prompt manifest, and onboarding knowledge transfer series. |
+| 2025-11-13 18:55 | Transparency Follow-Up Kickoff | Logged Tasks 64–68 (dossier, shared components, AI prompt manifest, knowledge transfer, consent KPI dashboard) and began dossier asset inventory plus QA regression tagging alignment. |
+
 > Update this log as features move from backlog to completion. Keep entries in UTC and 24-hour time.

--- a/TASK_PLAN.md
+++ b/TASK_PLAN.md
@@ -14,8 +14,20 @@
 - [ ] Task 61 – Condition Timer Share Expiry Stewardship (configurable expiry presets, lifecycle warnings, and lightweight extension controls in the manager UI).
 - [ ] Task 62 – Condition Timer Share Access Insights (trend dashboards for share usage, facilitator highlight panels, and export-ready datasets).
 - [ ] Task 63 – Condition Timer Share Guest Experience Polish (guest-facing narrative framing, responsive recap layouts, and regression coverage for refreshed copy).
+- [ ] Task 64 – Transparency Initiative Completion Dossier (stakeholder dossier compiling architecture, QA artifacts, telemetry dashboards, and narrative assets).
+- [ ] Task 65 – Shared Transparency Dashboard Components (extract reusable Inertia/shadcn UI components plus telemetry docs for future initiatives).
+- [ ] Task 66 – AI Mentor Prompt Localization Manifest (centralized manifest, workflow, and localization pilot for mentor briefing prompts).
+- [ ] Task 67 – Knowledge Transfer Series (two-session onboarding program with recordings, slides, and follow-up tracking).
+- [ ] Task 68 – Consent Audit KPI Dashboard (recurring Looker dashboard with consent/expiry KPIs and runbook integration).
 ## In Progress
-- _None_
+- Task 57 – Share Link & Consent Controls (finalizing review of consent-aware share UI and policies).
+- Task 58 – AI Mentor Briefings (moderation playback digest and guardrail review in flight).
+- Task 59 – End-to-End Transparency QA Suite (regression tagging, load scripts, and beta readiness reporting).
+- Task 60 – Condition Timer Share Access Trails (immutable access logging with telemetry feeds for insights).
+- Task 61 – Condition Timer Share Expiry Stewardship (preset bundles, extension workflows, and redaction guardrails).
+- Task 62 – Condition Timer Share Access Insights (trend dashboards correlating preset adoption and extension actors).
+- Task 63 – Condition Timer Share Guest Experience Polish (guest copy refresh, recap catch-up prompts, and responsive layout tuning).
+- Task 64 – Transparency Initiative Completion Dossier (asset inventory and stakeholder sign-off circulation).
 
 ## Completed
 - Initial architectural plan updated for multi-group, turn-based world.

--- a/Tasks/Week 7/Task 58 - AI Mentor Briefings.md
+++ b/Tasks/Week 7/Task 58 - AI Mentor Briefings.md
@@ -12,14 +12,16 @@ Leverage existing AI services to generate spoiler-safe mentor briefings that exp
 - [x] Draft prompt templates with narrative guardrails and spoiler filters, including localized variants.
 - [x] Implement AI request pipeline with caching, redaction of GM-only data, and human override controls.
 - [x] Surface briefings within digests, notifications, and facilitator dashboards with clear labeling.
-- [ ] Add moderation review queue for AI outputs with approval/feedback loops.
+- [ ] Add moderation review queue for AI outputs with approval/feedback loops plus facilitator playback digest for suppressed messages.
 - [x] Cover AI error handling and fallback messaging with automated tests.
 
 ## Notes
 - Provide toggles for groups that prefer purely human narration.
 - Work with focus group to validate tone—mentor voice should feel like a seasoned adventurer, not a lecture.
 - Ensure analytics capture uptake and satisfaction to inform future iterations.
+- Coordinate with Task 63 catch-up prompts so moderated briefings appear in recap feed digests when released.
 
 ## Log
 - 2025-11-05 17:08 UTC – Introduced after veteran players asked for contextual mentor tips during meeting.
 - 2025-11-09 15:50 UTC – Delivered mentor briefing service with cached AI responses, dashboard panel toggles, and Pest unit coverage validating caching toggles and focus extraction.
+- 2025-11-12 15:20 UTC – Added playback digest requirement for moderated briefings per PO & focus group sync feedback.

--- a/Tasks/Week 7/Task 59 - End-to-End Transparency QA Suite.md
+++ b/Tasks/Week 7/Task 59 - End-to-End Transparency QA Suite.md
@@ -8,18 +8,22 @@
 Establish a comprehensive QA suite and beta acceptance checklist covering guest share links, notifications, digests, analytics, and offline recovery so the transparency initiative can graduate from beta with confidence.
 
 ## Subtasks
-- [ ] Expand automated regression journeys simulating guest access, acknowledgement loops, and expired share scenarios.
-- [ ] Add load/performance scripts for notification dispatch, digest generation, and export queues.
-- [ ] Document manual QA checklist with accessibility, localization, and privacy verification steps.
-- [ ] Integrate synthetic monitoring for share links and notification endpoints with alerting thresholds.
-- [ ] Coordinate with focus group for structured beta acceptance playtest, capturing qualitative feedback.
-- [ ] Produce release readiness report summarizing coverage, open risks, and mitigation plans.
+- [ ] Expand automated regression journeys simulating guest access, acknowledgement loops, expired share scenarios, and recap-feed catch-up prompts for missed mentor briefings.
+- [ ] Add load/performance scripts for notification dispatch, digest generation, and export queues that replay focus group encounter pacing logs.
+- [ ] Document manual QA checklist with accessibility, localization, privacy verification steps, and AI moderation queue review workflow.
+- [ ] Normalize reusable scenario library with regression tagging guidance for dossiers, dashboards, and onboarding references.
+- [ ] Integrate synthetic monitoring for share links and notification endpoints with alerting thresholds tuned to focus group cadence.
+- [ ] Coordinate with focus group for structured beta acceptance playtest, capturing qualitative feedback and signed commitment forms.
+- [ ] Produce release readiness report summarizing coverage, open risks, mitigation plans, and consent auditor sign-off on extension trails.
 
 ## Notes
 - Ensure QA artifacts align with compliance expectations and audit requirements.
 - Reproduce previously reported guest acknowledgement count bug to validate fix.
 - Provide timeline for regression suite execution in CI/CD to prevent drift.
+- Leverage Task 61 preset bundle definitions to seed scenario matrices for expiry + visibility permutations.
 
 ## Log
 - 2025-11-05 17:10 UTC – Logged to address QA critique about stale counts on guest share links and finalize beta graduation.
 - 2025-11-07 10:40 UTC – Added condition transparency beta readiness checklist, synthetic ping command, and feature coverage for share access trails.
+- 2025-11-12 15:45 UTC – Updated scope after PO & focus group sync to incorporate encounter-paced load scripts, recap catch-up verification, and formal beta sign-off artifacts.
+- 2025-11-13 18:55 UTC – Captured retro action item to formalize regression tag legend and reusable scenario library for dossier handoff.

--- a/Tasks/Week 7/Task 60 - Condition Timer Share Access Trails.md
+++ b/Tasks/Week 7/Task 60 - Condition Timer Share Access Trails.md
@@ -12,13 +12,16 @@ Give facilitators visibility into how condition outlook links are opened so they
 - [ ] Instrument the share controller/service so every view records an immutable access entry, capturing optional signed-in user context and quiet-hour suppression state.
 - [ ] Emit structured logs/metrics for share views that integrate with current telemetry channels and feed Tasks 62 and 56.
 - [ ] Update facilitator exports to include access trails, respecting consent toggles and masking rules from Tasks 57 and 55.
+- [ ] Capture extension/revocation actor metadata in access events so Task 62 can correlate insights with preset bundle usage.
 
 ## Notes
 - Reuse the existing projection cache—only store share metadata required for auditing to avoid leaking timer payloads.
 - Access trails should exclude full IP storage; rely on salted hashes and region inference aligned with privacy commitments.
 - Coordinate with security to ensure masked data retention aligns with broader governance policies.
+- Surface actor metadata in a dedicated audit projection to keep facilitator dashboards fast while enabling deep dives in Task 62.
 
 ## Log
 - 2025-11-05 09:10 UTC – Scoped access trail modeling alongside Task 49 rollout to answer focus group concerns about stale link rotation.
 - 2025-11-05 16:30 UTC – Captured requirement to surface access trails in exports after facilitator council review.
 - 2025-11-07 10:50 UTC – Implemented hashed access log table, trend aggregation, and export payloads with masked identifiers.
+- 2025-11-12 16:05 UTC – Added actor metadata requirement post focus group sync so extension telemetry can flow into the insights dashboard workstream.

--- a/Tasks/Week 7/Task 61 - Condition Timer Share Expiry Stewardship.md
+++ b/Tasks/Week 7/Task 61 - Condition Timer Share Expiry Stewardship.md
@@ -9,16 +9,19 @@ Give facilitators finer control over share link lifetimes so risky outlooks expi
 
 ## Subtasks
 - [ ] Surface configurable expiry inputs when minting or editing a share link, including recommended presets and custom UTC durations.
+- [ ] Introduce preset bundles that pair expiry, visibility, and consent defaults (e.g., "one-shot preview", "extended ally access") with preview confirmation modal.
 - [ ] Display upcoming expiry state (active, expiring soon, expired) with color-coded messaging in both the manager controls and guest share summaries.
-- [ ] Provide a manager action to extend the existing share without issuing a new token, logging the change in access trails.
+- [ ] Provide a manager action to extend the existing share without issuing a new token, logging the change in access trails and preset usage metrics.
 - [ ] Ensure expired links older than 48 hours automatically redact timer payloads until re-enabled or cloned.
 
 ## Notes
 - Continue using UTC for all lifecycle calculations and align with quiet-hour suppression logic from Task 50.
 - Treat extensions as idempotent updates—only adjust expiry timestamps when explicitly requested.
 - Coordinate with localization to mirror new status copy in all supported locales.
+- Bundle definitions should be shareable with QA (Task 59) for scenario scripts and analytics teams (Task 62) for preset adoption tracking.
 
 ## Log
 - 2025-11-05 09:10 UTC – Scoped expiry stewardship objectives while addressing focus group requests for longer-lived expedition briefings.
 - 2025-11-05 13:45 UTC – Logged need for extension affordances after QA flagged manual DB edits during Task 49 testing.
 - 2025-11-07 10:55 UTC – Delivered share extension controls, evergreen preset, and 48-hour redaction guardrails on expired links.
+- 2025-11-12 16:15 UTC – Expanded scope per PO & focus group sync to add preset bundles, confirmation preview, and preset telemetry hooks.

--- a/Tasks/Week 7/Task 62 - Condition Timer Share Access Insights.md
+++ b/Tasks/Week 7/Task 62 - Condition Timer Share Access Insights.md
@@ -5,20 +5,23 @@
 **Dependencies:** Tasks 49, 60
 
 ## Intent
-Augment share analytics with trend data so facilitators can understand how often guests return to outlook summaries. Deliver rolling seven-day view counts inside the manager controls and export-ready highlight summaries for narrative teams.
+Augment share analytics with trend data so facilitators can understand how often guests return to outlook summaries. Deliver rolling seven-day view counts, extension actor callouts, and preset bundle adoption summaries inside the manager controls plus export-ready highlights for narrative teams.
 
 ## Subtasks
 - [ ] Aggregate share access logs by day for trailing week slices, respecting UTC boundaries and zero-visit days.
-- [ ] Render trend data inside the share controls UI with clear copy highlighting spikes or lulls.
+- [ ] Correlate access spikes with preset bundle selections and extension actors, surfacing anonymized attributions in the dashboard.
+- [ ] Render trend data inside the share controls UI with clear copy highlighting spikes, lulls, and extension-triggered resurfaces.
 - [ ] Extend exports and regression dashboards to include the new insight payloads and surface filter options.
-- [ ] Publish lightweight API endpoints for in-app widgets referenced by Tasks 58 and 59.
+- [ ] Publish lightweight API endpoints for in-app widgets referenced by Tasks 58 (mentor briefings) and 59 (QA dashboards).
 
 ## Notes
 - Ensure aggregation respects localization needs and masks sensitive data before surfacing counts.
 - Keep UI lightweight—text-based summaries are sufficient for now while design iterates on chart treatments.
 - Partner with narrative to craft "sending stone"-style copy for high activity callouts.
+- Work with compliance to confirm extension actor labeling meets consent auditors’ readability expectations.
 
 ## Log
 - 2025-11-05 09:15 UTC – Planned access insight rollup during documentation touchpoints.
 - 2025-11-05 13:45 UTC – Delivered seven-day trend requirements after facilitator recap workshop, export templates drafted.
 - 2025-11-07 11:00 UTC – Shipped seven-night access trend widget with copy, export surfacing, and QA hooks for regression dashboards.
+- 2025-11-12 16:25 UTC – Updated brief post focus group sync to track extension actors, preset adoption, and mentor widget API needs.

--- a/Tasks/Week 7/Task 63 - Condition Timer Share Guest Experience Polish.md
+++ b/Tasks/Week 7/Task 63 - Condition Timer Share Guest Experience Polish.md
@@ -11,14 +11,17 @@ Refresh the guest-facing share page with narrative framing, staleness cues, and 
 - [ ] Reframe hero messaging with last-updated callouts, facilitator contact hints, and a clear share etiquette reminder.
 - [ ] Ensure layout adapts gracefully across mobile/desktop with recap widget ordering that prioritizes urgent timers.
 - [ ] Reflect guest copy improvements inside spoiler-safe recap mode and ensure digest emails reuse the refreshed language.
-- [ ] Run regression coverage on share recap rendering to guard against layout regressions introduced by new copy blocks.
+- [ ] Add recap-feed catch-up prompts for mentor briefings that triggered while a guest was offline, respecting notification opt-outs.
+- [ ] Run regression coverage on share recap rendering to guard against layout regressions introduced by new copy blocks and catch-up prompts.
 
 ## Notes
 - Reuse existing summary metadata where possible to avoid redundant queries and keep the page lightweight.
 - Provide guest copy in immersive but spoiler-safe tone, consistent with Task 43 narrative standards.
 - Schedule a quick focus group review once copy is in staging to validate clarity for new players.
+- Coordinate with Task 58’s moderation queue so suppressed mentor briefings appear in the catch-up digest with facilitator notes.
 
 ## Log
 - 2025-11-05 09:20 UTC – Outlined guest experience improvements and messaging goals.
 - 2025-11-05 13:50 UTC – Logged narrative, visual, and QA touchpoints after focus group review surfaced guidance gaps.
 - 2025-11-07 11:05 UTC – Refreshed guest outlook copy with staleness cues, redaction messaging, and responsive layout tweaks.
+- 2025-11-12 16:35 UTC – Extended scope per focus group sync to add mentor catch-up prompts and moderation-aligned digest states.

--- a/Tasks/Week 8/Task 64 - Transparency Initiative Completion Dossier.md
+++ b/Tasks/Week 8/Task 64 - Transparency Initiative Completion Dossier.md
@@ -1,0 +1,24 @@
+# Task 64 – Transparency Initiative Completion Dossier
+
+**Status:** In Progress
+**Owner:** Engineering Lead
+**Dependencies:** Tasks 38–63, Meetings/2025-11-13-transparency-task-retro.md
+
+## Intent
+Assemble a stakeholder-ready dossier that curates the transparency initiative's architecture, QA assets, telemetry dashboards, and narrative collateral so executive sponsors and new contributors can grasp the full scope without hunting across disparate docs.
+
+## Subtasks
+- [ ] Inventory final architecture diagrams, service docs, and cache/telemetry references from Tasks 38–63 into a shared outline.
+- [ ] Collect QA artifacts (automation indices, regression tags, manual scripts) and summarize verification coverage per surface.
+- [ ] Curate telemetry dashboard screenshots, KPI definitions, and consent audit summaries into the dossier narrative.
+- [ ] Embed links to narrative assets (copy decks, mentor prompts, localization guidelines) and annotate ownership for upkeep.
+- [ ] Publish dossier in `Docs/transparency-completion-dossier.md` with executive summary, table of contents, and maintenance playbook.
+- [ ] Circulate draft for PO/QA/Narrative sign-off and track feedback resolutions in the log.
+
+## Notes
+- Treat TASK_PLAN.md as the authoritative index; link to existing documents rather than duplicating large sections.
+- Ensure timestamps follow UTC conventions and redacted assets remove personally identifiable player data.
+- Coordinate with QA to surface regression tag legend introduced during the 2025-11-13 retro.
+
+## Log
+- 2025-11-13 18:10 UTC – Kickoff following retro action item; dossier outline scaffolded and asset inventory checklist drafted.

--- a/Tasks/Week 8/Task 65 - Shared Transparency Dashboard Components.md
+++ b/Tasks/Week 8/Task 65 - Shared Transparency Dashboard Components.md
@@ -1,0 +1,23 @@
+# Task 65 – Shared Transparency Dashboard Components
+
+**Status:** Not Started
+**Owner:** Frontend Guild
+**Dependencies:** Tasks 34, 35, 52, 62
+
+## Intent
+Generalize the transparency dashboards and widgets into an Inertia + shadcn/ui component library so future initiatives can reuse the condition timer insights without rebuilding layout, accessibility, or telemetry wiring.
+
+## Subtasks
+- [ ] Audit existing transparency dashboards to identify reusable cards, list patterns, filters, and alert treatments.
+- [ ] Extract components into `backend/resources/js/Components/transparency/` with Storybook-style usage docs and TypeScript props.
+- [ ] Provide Tailwind theming tokens and CSS variables so themes beyond transparency can restyle components quickly.
+- [ ] Document expected telemetry events and props contract for each component, referencing analytics helpers from Task 44.
+- [ ] Publish integration guide in `Docs/frontend-components.md` and link from TASK_PLAN.md and the dossier (Task 64).
+
+## Notes
+- Maintain accessibility cues (ARIA labels, focus management) proven during transparency rollout.
+- Keep copy variants externalized so localization manifest work (Task 66) can reuse the same keys.
+- Coordinate with QA to ensure visual regression snapshots reflect the shared library outputs.
+
+## Log
+- 2025-11-13 18:20 UTC – Logged after retro decision to accelerate reuse of transparency insights across upcoming initiatives.

--- a/Tasks/Week 8/Task 66 - AI Mentor Prompt Localization Manifest.md
+++ b/Tasks/Week 8/Task 66 - AI Mentor Prompt Localization Manifest.md
@@ -1,0 +1,24 @@
+# Task 66 – AI Mentor Prompt Localization Manifest
+
+**Status:** Not Started
+**Owner:** Narrative & AI Lead
+**Dependencies:** Tasks 13, 43, 58
+
+## Intent
+Centralize mentor briefing prompt variants, tone guidelines, and localization keys into a single manifest so translation teams can review, approve, and maintain AI copy across languages without losing the approved D&D flavor.
+
+## Subtasks
+- [ ] Audit existing mentor prompts, moderation fallbacks, and recap catch-up copy to catalog all AI-facing strings.
+- [ ] Define manifest schema (tone tags, locale keys, narrative notes, moderation guidance) and store under `backend/resources/lang/en/transparency-ai.json`.
+- [ ] Populate manifest with current English content, ensuring spoiler filters and consent-sensitive phrasing are preserved.
+- [ ] Document contribution workflow (review checklist, PR template updates, approval routing) in `Docs/ai-mentor-prompts.md`.
+- [ ] Coordinate with localization vendors to pilot at least one additional language entry and capture feedback.
+- [ ] Wire Task 58 briefing pipeline to read from the manifest, providing migration notes and fallback behavior.
+
+## Notes
+- Align with PO expectations for tone (seasoned adventurer mentor) and maintain compliance review trail for sensitive wording.
+- Ensure manifest changes trigger QA tasks for translation accuracy and narrative sign-off.
+- Provide sample Jest/Pest fixtures for AI pipelines to validate manifest consumption.
+
+## Log
+- 2025-11-13 18:30 UTC – Created per retro decision; schema brainstorming scheduled with narrative and localization partners.

--- a/Tasks/Week 8/Task 67 - Knowledge Transfer Series.md
+++ b/Tasks/Week 8/Task 67 - Knowledge Transfer Series.md
@@ -1,0 +1,24 @@
+# Task 67 – Knowledge Transfer Series
+
+**Status:** Not Started
+**Owner:** Product Owner & Engineering Lead
+**Dependencies:** Task 64, Meetings/2025-11-13-transparency-task-retro.md
+
+## Intent
+Host a two-part knowledge transfer program that onboards incoming engineers to the transparency initiative's architecture, governance, telemetry, and narrative principles so they can contribute without rehashing historical decisions.
+
+## Subtasks
+- [ ] Draft agendas for two 60-minute sessions covering architecture/service overview and governance/telemetry workflows.
+- [ ] Coordinate scheduling with new engineer cohort, ensuring recordings and slides are planned for archival.
+- [ ] Prepare presentation materials leveraging the dossier (Task 64) and component/prompt work (Tasks 65–66).
+- [ ] Conduct sessions, capture Q&A, and collect attendee feedback surveys for continuous improvement.
+- [ ] Archive recordings, slides, and notes under `Meetings/` with cross-links in PROGRESS_LOG.md and TASK_PLAN.md.
+- [ ] Summarize follow-up action items and assign owners for any gaps discovered during sessions.
+
+## Notes
+- Ensure confidentiality guidelines are reiterated before sharing telemetry or compliance-sensitive details.
+- Provide hands-on demos referencing the transparency dashboards and AI mentor tooling.
+- Invite QA and Narrative leads to co-present on their respective workflows.
+
+## Log
+- 2025-11-13 18:40 UTC – Scheduled per retro action item; initial agenda draft started with PO/Engineering alignment.

--- a/Tasks/Week 8/Task 68 - Consent Audit KPI Dashboard.md
+++ b/Tasks/Week 8/Task 68 - Consent Audit KPI Dashboard.md
@@ -1,0 +1,24 @@
+# Task 68 – Consent Audit KPI Dashboard
+
+**Status:** Not Started
+**Owner:** Data & Telemetry Lead
+**Dependencies:** Tasks 44, 56, 62
+
+## Intent
+Deliver a recurring Looker dashboard that surfaces consent audit KPIs for transparency share links, ensuring compliance teams can monitor acknowledgement integrity, expiry stewardship, and extension usage without manual exports.
+
+## Subtasks
+- [ ] Define KPI list (acknowledgement freshness, expiry overrides, extension actor share rates, consent revocations) with compliance.
+- [ ] Model required datasets and views in analytics warehouse, ensuring privacy filters mask player-identifiable fields.
+- [ ] Build Looker dashboards with scheduled refresh windows and document access controls for stakeholders.
+- [ ] Update Task 62 insights brief with dashboard linkage and interpretation guide.
+- [ ] Provide runbook for incident response when KPIs breach thresholds, including telemetry alert hooks.
+- [ ] Announce availability via PROGRESS_LOG.md and share embed links for facilitator dashboards if approved.
+
+## Notes
+- Batch queries to avoid telemetry load spikes noted during retro risk review.
+- Align metric naming with existing transparency analytics to prevent duplicate definitions.
+- Coordinate with legal/compliance to vet shareability of metrics outside the core team.
+
+## Log
+- 2025-11-13 18:50 UTC – Created following retro action item; KPI scoping session booked with compliance partner.


### PR DESCRIPTION
## Summary
- log new transparency follow-up work items (Tasks 64–68) covering dossier, shared components, localization manifest, knowledge transfer, and consent KPIs
- update Task 59 with regression tagging requirements from the retro and mark ongoing work in TASK_PLAN
- capture the follow-up kickoff in the progress log and start the dossier task

## Testing
- not run (documentation updates)

------
https://chatgpt.com/codex/tasks/task_e_68f282539ca4833286d742f180c0f4bd