### PR TITLE
Fix session rewards migration foreign keys

### DIFF
--- a/backend/database/migrations/2025_10_24_084500_create_session_rewards_table.php
+++ b/backend/database/migrations/2025_10_24_084500_create_session_rewards_table.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Models\Campaign;
+use App\Models\CampaignSession;
+use App\Models\User;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -10,9 +13,9 @@ return new class extends Migration
     {
         Schema::create('session_rewards', function (Blueprint $table) {
             $table->uuid('id')->primary();
-            $table->uuid('campaign_id');
-            $table->uuid('campaign_session_id');
-            $table->uuid('recorded_by');
+            $table->foreignIdFor(Campaign::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(CampaignSession::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(User::class, 'recorded_by')->constrained('users')->cascadeOnDelete();
             $table->string('reward_type', 32);
             $table->string('title');
             $table->unsignedInteger('quantity')->nullable();
@@ -20,11 +23,7 @@ return new class extends Migration
             $table->text('notes')->nullable();
             $table->timestamps();
 
-            $table->foreign('campaign_id')->references('id')->on('campaigns')->cascadeOnDelete();
-            $table->foreign('campaign_session_id')->references('id')->on('campaign_sessions')->cascadeOnDelete();
-            $table->foreign('recorded_by')->references('id')->on('users')->cascadeOnDelete();
             $table->index(['campaign_session_id', 'reward_type']);
-            $table->index('campaign_id');
         });
     }
 


### PR DESCRIPTION
## Summary
- update the session rewards migration to reference campaign, session, and user IDs using foreignIdFor
- align foreign key definitions with existing bigint identifiers to avoid datatype mismatches during migration

## Testing
- php artisan migrate --pretend --path=database/migrations/2025_10_24_084500_create_session_rewards_table.php *(fails: missing vendor/autoload.php in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f388156d7c83328c42f6686f33af09