### PR TITLE
Add AI assistance across campaign tools and admin role management

### DIFF
--- a/backend/app/Http/Controllers/Admin/UserRoleController.php
+++ b/backend/app/Http/Controllers/Admin/UserRoleController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\UserRoleUpdateRequest;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class UserRoleController extends Controller
+{
+    public function index(): Response
+    {
+        $this->authorizeSupportAdmin();
+
+        $users = User::query()
+            ->orderBy('name')
+            ->get(['id', 'name', 'email', 'is_support_admin', 'created_at']);
+
+        return Inertia::render('Admin/Users/Index', [
+            'users' => $users->map(fn (User $user) => [
+                'id' => $user->id,
+                'name' => $user->name,
+                'email' => $user->email,
+                'is_support_admin' => (bool) $user->is_support_admin,
+                'created_at' => $user->created_at?->toIso8601String(),
+            ]),
+        ]);
+    }
+
+    public function update(UserRoleUpdateRequest $request, User $user): RedirectResponse
+    {
+        $this->authorizeSupportAdmin();
+
+        $validated = $request->validated();
+
+        $user->forceFill([
+            'is_support_admin' => $validated['is_support_admin'],
+        ])->save();
+
+        return redirect()
+            ->back()
+            ->with('success', sprintf('Updated support access for %s.', $user->name));
+    }
+
+    protected function authorizeSupportAdmin(): void
+    {
+        abort_unless($requestUser = request()->user(), 403);
+        abort_unless($requestUser->is_support_admin, 403);
+    }
+}

--- a/backend/app/Http/Controllers/AiCreativeController.php
+++ b/backend/app/Http/Controllers/AiCreativeController.php
@@ -1,0 +1,279 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\AiCreativeRequest;
+use App\Services\AiContentService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Arr;
+
+class AiCreativeController extends Controller
+{
+    public function __invoke(AiCreativeRequest $request, AiContentService $ai): JsonResponse
+    {
+        $data = $request->validated();
+        $domain = $data['domain'];
+        $userPrompt = trim((string) ($data['prompt'] ?? ''));
+        $context = $data['context'] ?? [];
+
+        $config = (array) config("ai.prompts.creative.$domain");
+        abort_unless($config !== [], 422, 'Unsupported creative domain.');
+
+        $systemPrompt = (string) Arr::get($config, 'system', '');
+        $requestType = (string) Arr::get($config, 'request_type', 'creative_'.$domain);
+
+        $prompt = $this->buildPrompt($domain, $userPrompt, $context);
+
+        /** @var \App\Models\User $actor */
+        $actor = $request->user();
+
+        $result = $ai->creativeIdea(
+            $actor,
+            $requestType,
+            $prompt,
+            $systemPrompt,
+            [
+                'domain' => $domain,
+                'context' => $context,
+                'user_prompt' => $userPrompt,
+            ],
+            $actor,
+        );
+
+        $structured = $this->decodeStructured($result['content']);
+
+        return response()->json([
+            'idea' => $result['content'],
+            'structured' => $structured,
+        ]);
+    }
+
+    protected function buildPrompt(string $domain, string $userPrompt, array $context): string
+    {
+        return match ($domain) {
+            'world' => $this->worldPrompt($userPrompt, $context),
+            'region' => $this->regionPrompt($userPrompt, $context),
+            'tile_template' => $this->tileTemplatePrompt($userPrompt, $context),
+            'region_map' => $this->regionMapPrompt($userPrompt, $context),
+            'campaign_tasks' => $this->campaignTaskPrompt($userPrompt, $context),
+            'lore' => $this->lorePrompt($userPrompt, $context),
+            'quest' => $this->questPrompt($userPrompt, $context),
+            default => trim($userPrompt),
+        };
+    }
+
+    protected function worldPrompt(string $userPrompt, array $context): string
+    {
+        $lines = [];
+        $group = Arr::get($context, 'group_name');
+        $name = Arr::get($context, 'name');
+        $summary = Arr::get($context, 'summary');
+        $description = Arr::get($context, 'description');
+        $turnCadence = Arr::get($context, 'turn_duration');
+
+        $lines[] = 'Draft a collaborative world concept for a shared campaign.';
+        if ($group) {
+            $lines[] = "Group: $group";
+        }
+        if ($name) {
+            $lines[] = "Working title: $name";
+        }
+        if ($summary) {
+            $lines[] = "Existing summary: $summary";
+        }
+        if ($description) {
+            $lines[] = "Existing notes: $description";
+        }
+        if ($turnCadence) {
+            $lines[] = "Preferred turn cadence: $turnCadence hours";
+        }
+        if ($userPrompt !== '') {
+            $lines[] = "Player prompt: $userPrompt";
+        }
+        $lines[] = 'Blend high-level lore, recurring beats, and an evocative image prompt that could be sent to a1111 for a 512x512 tile.';
+
+        return implode("\n", $lines);
+    }
+
+    protected function regionPrompt(string $userPrompt, array $context): string
+    {
+        $lines = [];
+        if ($world = Arr::get($context, 'world_name')) {
+            $lines[] = "Parent world: $world";
+        }
+        if ($region = Arr::get($context, 'name')) {
+            $lines[] = "Region name: $region";
+        }
+        if ($summary = Arr::get($context, 'summary')) {
+            $lines[] = "Existing summary: $summary";
+        }
+        if ($description = Arr::get($context, 'description')) {
+            $lines[] = "Existing notes: $description";
+        }
+        if ($dm = Arr::get($context, 'dungeon_master')) {
+            $lines[] = "Dungeon master focus: $dm";
+        }
+        if ($userPrompt !== '') {
+            $lines[] = "Player or facilitator ask: $userPrompt";
+        }
+        $lines[] = 'Outline hazards, story threads, and an image prompt useful for stable diffusion.';
+
+        return implode("\n", $lines);
+    }
+
+    protected function tileTemplatePrompt(string $userPrompt, array $context): string
+    {
+        $lines = [];
+        $group = Arr::get($context, 'group_name');
+        $world = Arr::get($context, 'world_name');
+        $terrain = Arr::get($context, 'terrain_type');
+        $movement = Arr::get($context, 'movement_cost');
+        $defense = Arr::get($context, 'defense_bonus');
+        $description = Arr::get($context, 'description');
+
+        $lines[] = 'Design a tactical map tile template for our digital library.';
+        if ($group) {
+            $lines[] = "Group: $group";
+        }
+        if ($world) {
+            $lines[] = "World: $world";
+        }
+        if ($terrain) {
+            $lines[] = "Existing terrain type: $terrain";
+        }
+        if ($movement !== null) {
+            $lines[] = "Current movement cost: $movement";
+        }
+        if ($defense !== null) {
+            $lines[] = "Current defense bonus: $defense";
+        }
+        if ($description) {
+            $lines[] = "Notes: $description";
+        }
+        if ($userPrompt !== '') {
+            $lines[] = "Facilitator request: $userPrompt";
+        }
+        $lines[] = 'Suggest edge connections and a 512x512 a1111 prompt to render the tile art.';
+
+        return implode("\n", $lines);
+    }
+
+    protected function regionMapPrompt(string $userPrompt, array $context): string
+    {
+        $lines = [];
+        if ($title = Arr::get($context, 'title')) {
+            $lines[] = "Map title: $title";
+        }
+        if ($base = Arr::get($context, 'base_layer')) {
+            $lines[] = "Base layer: $base";
+        }
+        if ($orientation = Arr::get($context, 'orientation')) {
+            $lines[] = "Orientation: $orientation";
+        }
+        if ($fog = Arr::get($context, 'fog_data')) {
+            $lines[] = 'Current fog data: '.json_encode($fog);
+        }
+        if ($userPrompt !== '') {
+            $lines[] = "Facilitator ask: $userPrompt";
+        }
+        $lines[] = 'Provide layout notes, exploration hooks, suggested fog defaults, and an a1111-friendly prompt.';
+
+        return implode("\n", $lines);
+    }
+
+    protected function campaignTaskPrompt(string $userPrompt, array $context): string
+    {
+        $lines = [];
+        if ($campaign = Arr::get($context, 'campaign_title')) {
+            $lines[] = "Campaign: $campaign";
+        }
+        if ($turn = Arr::get($context, 'current_turn')) {
+            $lines[] = "Current turn: $turn";
+        }
+        if ($status = Arr::get($context, 'statuses')) {
+            $lines[] = 'Available statuses: '.implode(', ', (array) $status);
+        }
+        if ($existing = Arr::get($context, 'existing_tasks')) {
+            $lines[] = 'Existing tasks: '.json_encode($existing);
+        }
+        if ($userPrompt !== '') {
+            $lines[] = "GM prompt: $userPrompt";
+        }
+        $lines[] = 'Return backlog suggestions and note how they align to turns.';
+
+        return implode("\n", $lines);
+    }
+
+    protected function lorePrompt(string $userPrompt, array $context): string
+    {
+        $lines = [];
+        if ($name = Arr::get($context, 'name')) {
+            $lines[] = "Lore subject: $name";
+        }
+        if ($type = Arr::get($context, 'type')) {
+            $lines[] = "Type: $type";
+        }
+        if ($tags = Arr::get($context, 'tags')) {
+            $lines[] = 'Existing tags: '.implode(', ', (array) $tags);
+        }
+        if ($summary = Arr::get($context, 'summary')) {
+            $lines[] = "Existing summary: $summary";
+        }
+        if ($userPrompt !== '') {
+            $lines[] = "GM prompt: $userPrompt";
+        }
+        $lines[] = 'Offer secrets that are safe for collaborative play and an image prompt for a1111.';
+
+        return implode("\n", $lines);
+    }
+
+    protected function questPrompt(string $userPrompt, array $context): string
+    {
+        $lines = [];
+        if ($campaign = Arr::get($context, 'campaign_title')) {
+            $lines[] = "Campaign: $campaign";
+        }
+        if ($quest = Arr::get($context, 'title')) {
+            $lines[] = "Quest title: $quest";
+        }
+        if ($region = Arr::get($context, 'region')) {
+            $lines[] = "Region focus: $region";
+        }
+        if ($status = Arr::get($context, 'status')) {
+            $lines[] = "Quest status: $status";
+        }
+        if ($userPrompt !== '') {
+            $lines[] = "GM or player request: $userPrompt";
+        }
+        $lines[] = 'Outline objectives, complications, rewards, and an evocative a1111 prompt.';
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    protected function decodeStructured(string $content): ?array
+    {
+        $content = trim($content);
+        if ($content === '') {
+            return null;
+        }
+
+        $decoded = json_decode($content, true);
+
+        if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+            return $decoded;
+        }
+
+        // Attempt to extract JSON substring if wrappers exist
+        if (preg_match('/\{.*\}/s', $content, $matches) === 1) {
+            $second = json_decode($matches[0], true);
+            if (json_last_error() === JSON_ERROR_NONE && is_array($second)) {
+                return $second;
+            }
+        }
+
+        return null;
+    }
+}

--- a/backend/app/Http/Controllers/TileTemplateController.php
+++ b/backend/app/Http/Controllers/TileTemplateController.php
@@ -35,6 +35,12 @@ class TileTemplateController extends Controller
 
         $edgeProfile = $this->decodeJsonField($validated['edge_profile'] ?? null);
 
+        $imagePath = Arr::get($validated, 'image_path');
+
+        if ($request->hasFile('image_upload')) {
+            $imagePath = $request->file('image_upload')->store('tile-templates/'.$group->id, 'public');
+        }
+
         $group->tileTemplates()->create([
             'world_id' => $validated['world_id'] ?? null,
             'created_by' => $request->user()?->getAuthIdentifier(),
@@ -43,7 +49,7 @@ class TileTemplateController extends Controller
             'terrain_type' => $validated['terrain_type'],
             'movement_cost' => $validated['movement_cost'],
             'defense_bonus' => $validated['defense_bonus'],
-            'image_path' => Arr::get($validated, 'image_path'),
+            'image_path' => $imagePath,
             'edge_profile' => $edgeProfile,
         ]);
 
@@ -86,6 +92,12 @@ class TileTemplateController extends Controller
 
         $edgeProfile = $this->decodeJsonField($validated['edge_profile'] ?? null);
 
+        $imagePath = Arr::get($validated, 'image_path', $tileTemplate->image_path);
+
+        if ($request->hasFile('image_upload')) {
+            $imagePath = $request->file('image_upload')->store('tile-templates/'.$group->id, 'public');
+        }
+
         $tileTemplate->update([
             'world_id' => $validated['world_id'] ?? null,
             'key' => Arr::get($validated, 'key'),
@@ -93,7 +105,7 @@ class TileTemplateController extends Controller
             'terrain_type' => $validated['terrain_type'],
             'movement_cost' => $validated['movement_cost'],
             'defense_bonus' => $validated['defense_bonus'],
-            'image_path' => Arr::get($validated, 'image_path'),
+            'image_path' => $imagePath,
             'edge_profile' => $edgeProfile,
         ]);
 

--- a/backend/app/Http/Middleware/HandleInertiaRequests.php
+++ b/backend/app/Http/Middleware/HandleInertiaRequests.php
@@ -42,6 +42,7 @@ class HandleInertiaRequests extends Middleware
                     'theme',
                     'high_contrast',
                     'font_scale',
+                    'is_support_admin',
                 ]),
             ],
             'flash' => [

--- a/backend/app/Http/Requests/Admin/UserRoleUpdateRequest.php
+++ b/backend/app/Http/Requests/Admin/UserRoleUpdateRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use App\Models\User;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UserRoleUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        /** @var User|null $actor */
+        $actor = $this->user();
+
+        return (bool) ($actor?->is_support_admin);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'is_support_admin' => ['required', 'boolean'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/AiCreativeRequest.php
+++ b/backend/app/Http/Requests/AiCreativeRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class AiCreativeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    public function rules(): array
+    {
+        $domains = array_keys((array) config('ai.prompts.creative'));
+
+        return [
+            'domain' => ['required', 'string', Rule::in($domains)],
+            'prompt' => ['nullable', 'string', 'max:2000'],
+            'context' => ['nullable', 'array'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/TileTemplateStoreRequest.php
+++ b/backend/app/Http/Requests/TileTemplateStoreRequest.php
@@ -43,6 +43,7 @@ class TileTemplateStoreRequest extends FormRequest
             'movement_cost' => ['required', 'integer', 'min:0', 'max:20'],
             'defense_bonus' => ['required', 'integer', 'min:0', 'max:20'],
             'image_path' => ['nullable', 'string', 'max:255'],
+            'image_upload' => ['nullable', 'image', 'max:5120'],
             'edge_profile' => ['nullable', 'json'],
             'world_id' => [
                 'nullable',

--- a/backend/app/Http/Requests/TileTemplateUpdateRequest.php
+++ b/backend/app/Http/Requests/TileTemplateUpdateRequest.php
@@ -47,6 +47,7 @@ class TileTemplateUpdateRequest extends FormRequest
             'movement_cost' => ['required', 'integer', 'min:0', 'max:20'],
             'defense_bonus' => ['required', 'integer', 'min:0', 'max:20'],
             'image_path' => ['nullable', 'string', 'max:255'],
+            'image_upload' => ['nullable', 'image', 'max:5120'],
             'edge_profile' => ['nullable', 'json'],
             'world_id' => [
                 'nullable',

--- a/backend/app/Services/AiContentService.php
+++ b/backend/app/Services/AiContentService.php
@@ -113,6 +113,35 @@ class AiContentService
         ];
     }
 
+    /**
+     * Generic creative helper hook that stores and dispatches custom prompts.
+     *
+     * @param  array<string, mixed>  $meta
+     */
+    public function creativeIdea(
+        Model $context,
+        string $requestType,
+        string $prompt,
+        string $systemPrompt,
+        array $meta = [],
+        ?User $requestedBy = null
+    ): array {
+        $request = $this->storeRequest(
+            requestType: $requestType,
+            context: $context,
+            prompt: $prompt,
+            meta: $meta,
+            requestedBy: $requestedBy,
+        );
+
+        $response = $this->dispatch($request, $prompt, $systemPrompt);
+
+        return [
+            'request' => $request->fresh(),
+            'content' => $response,
+        ];
+    }
+
     protected function dispatch(AiRequest $request, string $prompt, ?string $systemPrompt = null): string
     {
         try {

--- a/backend/config/ai.php
+++ b/backend/config/ai.php
@@ -22,6 +22,36 @@ return [
         'mentor_briefing' => [
             'system' => 'You are an encouraging veteran adventurer offering spoiler-safe tips about ongoing conditions. Celebrate progress, warn about risks, and suggest countermeasures without revealing hidden GM secrets. Keep it supportive and under 140 words.',
         ],
+        'creative' => [
+            'world' => [
+                'request_type' => 'creative_world',
+                'system' => 'You are a collaborative Dungeons & Dragons world-building assistant. Respond with valid minified JSON containing keys: summary (string under 60 words), description (string under 220 words), turn_hooks (array of 3 short strings highlighting recurring beats), and image_prompt (string describing a 512x512 map tile scene suitable for stable diffusion / a1111). Do not include extra commentary.',
+            ],
+            'region' => [
+                'request_type' => 'creative_region',
+                'system' => 'You help facilitators outline regions inside a shared world. Respond with JSON containing: summary (under 60 words), description (under 220 words), hazards (array of 3 short entries), plot_threads (array of 3 short entries), and image_prompt (string for a 512x512 regional illustration). Return valid JSON only.',
+            ],
+            'tile_template' => [
+                'request_type' => 'creative_tile_template',
+                'system' => 'You design tactical map tiles. Respond with JSON containing: terrain_type (string), movement_cost (number between 1-12), defense_bonus (number between 0-10), edge_profile (object with up to 4 keys north/south/east/west describing connection types), description (string under 120 words for tooltip), and image_prompt (string for a 512x512 tile illustration). Valid JSON only.',
+            ],
+            'region_map' => [
+                'request_type' => 'creative_region_map',
+                'system' => 'You assist dungeon masters in shaping region maps. Respond with JSON containing: layout_notes (array of 4 short strings about map structure and canvas guidance), fog_settings (object with keys mode, opacity, and notes), exploration_hooks (array of 3 short prompts), and image_prompt (string for a 512x512 overworld render). Only output valid JSON.',
+            ],
+            'campaign_tasks' => [
+                'request_type' => 'creative_campaign_tasks',
+                'system' => 'You act as an agile facilitator summarizing work for a D&D campaign board. Respond with JSON containing: overview (string under 80 words), tasks (array of objects with title, description, status), and turn_alignment (array of 3 strings). Provide valid JSON.',
+            ],
+            'lore' => [
+                'request_type' => 'creative_lore_entry',
+                'system' => 'You are a lore archivist expanding sparse notes. Respond with JSON containing: summary (string under 120 words), secrets (array of 2 spoiler-safe hints), tags (array of 3 tag strings), and image_prompt (string for a 512x512 character or location portrait). Valid JSON only.',
+            ],
+            'quest' => [
+                'request_type' => 'creative_quest',
+                'system' => 'You outline quests for a cooperative D&D group. Respond with JSON containing: title (string), summary (under 120 words), objectives (array of 3 short steps), complications (array of 2 twists), rewards (array of 2 ideas), and image_prompt (string for a 512x512 quest scene). Output valid JSON only.',
+            ],
+        ],
     ],
 
     'mocks' => [

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -16,6 +16,16 @@ class DatabaseSeeder extends Seeder
         // User::factory(10)->create();
 
         User::factory()->create([
+            'name' => 'Demo Support Admin',
+            'email' => 'admin@example.com',
+            'password' => 'password',
+            'locale' => 'en',
+            'timezone' => 'UTC',
+            'theme' => 'dark',
+            'is_support_admin' => true,
+        ]);
+
+        User::factory()->create([
             'name' => 'Demo GM',
             'email' => 'gm@example.com',
             'password' => 'password',

--- a/backend/resources/js/Layouts/AppLayout.tsx
+++ b/backend/resources/js/Layouts/AppLayout.tsx
@@ -18,7 +18,7 @@ export default function AppLayout({ children }: PropsWithChildren) {
     const { props } = usePage<{
         csrf_token?: string;
         flash?: { success?: string; error?: string };
-        auth?: { user?: { name: string } & PreferenceBag };
+        auth?: { user?: { name: string; is_support_admin?: boolean } & PreferenceBag };
         notifications?: { unread_count: number };
         preferences?: PreferenceBag;
     }>();
@@ -168,6 +168,14 @@ export default function AppLayout({ children }: PropsWithChildren) {
                                 )}
                             </Link>
                         )}
+                        {user?.is_support_admin && (
+                            <Link
+                                href={route('admin.users.index')}
+                                className={`${navLinkClass} focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400`}
+                            >
+                                Support console
+                            </Link>
+                        )}
                         {user && (
                             <Link
                                 href={route('settings.preferences.edit')}
@@ -180,7 +188,12 @@ export default function AppLayout({ children }: PropsWithChildren) {
                     <div className="flex items-center gap-3 text-sm">
                         {user && (
                             <span className={isDarkMode ? 'text-zinc-400' : 'text-slate-600'} aria-live="polite">
-                                {user.name}
+                                <span className="font-medium">{user.name}</span>
+                                {user.is_support_admin && (
+                                    <span className="ml-2 rounded-full bg-indigo-500/20 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-indigo-100">
+                                        Support admin
+                                    </span>
+                                )}
                             </span>
                         )}
                         <form method="post" action={route('logout')}>

--- a/backend/resources/js/Pages/Admin/Users/Index.tsx
+++ b/backend/resources/js/Pages/Admin/Users/Index.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+
+import { Head, Link, router, usePage } from '@inertiajs/react';
+
+import AppLayout from '@/Layouts/AppLayout';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Badge } from '@/components/ui/badge';
+import { formatTimestamp } from '@/lib/utils';
+
+type UserSummary = {
+    id: number;
+    name: string;
+    email: string;
+    is_support_admin: boolean;
+    created_at: string | null;
+};
+
+type PageProps = {
+    users: UserSummary[];
+};
+
+export default function AdminUserIndex() {
+    const { users } = usePage<PageProps>().props;
+    const [updating, setUpdating] = useState<number | null>(null);
+
+    const handleToggle = (user: UserSummary, next: boolean) => {
+        setUpdating(user.id);
+
+        router.patch(
+            route('admin.users.update', user.id),
+            { is_support_admin: next },
+            {
+                preserveScroll: true,
+                onFinish: () => setUpdating(null),
+            }
+        );
+    };
+
+    return (
+        <AppLayout>
+            <Head title="Support administration" />
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <h1 className="text-3xl font-semibold text-zinc-100">Support administration</h1>
+                    <p className="text-sm text-zinc-400">
+                        Promote facilitators into support admins so they can triage bug reports and moderate AI outputs.
+                    </p>
+                </div>
+                <Button asChild variant="outline" className="border-zinc-700 text-sm">
+                    <Link href={route('admin.bug-reports.index')}>Bug reports</Link>
+                </Button>
+            </div>
+
+            <section className="mt-8 space-y-4 rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/40">
+                <header>
+                    <h2 className="text-lg font-semibold text-zinc-100">User roster</h2>
+                    <p className="text-sm text-zinc-500">
+                        Mark at least one support admin so the platform always has someone who can respond to feedback.
+                    </p>
+                </header>
+
+                <div className="space-y-3">
+                    {users.map((user) => (
+                        <article
+                            key={user.id}
+                            className="flex flex-col gap-3 rounded-lg border border-zinc-800/60 bg-zinc-950/80 p-4 sm:flex-row sm:items-center sm:justify-between"
+                        >
+                            <div>
+                                <div className="flex items-center gap-3">
+                                    <h3 className="text-base font-semibold text-zinc-100">{user.name}</h3>
+                                    {user.is_support_admin && <Badge variant="secondary">Support admin</Badge>}
+                                </div>
+                                <p className="text-sm text-zinc-400">{user.email}</p>
+                                {user.created_at && (
+                                    <p className="text-xs text-zinc-500">Joined {formatTimestamp(user.created_at)}</p>
+                                )}
+                            </div>
+                            <div className="flex items-center gap-3">
+                                <Checkbox
+                                    id={`support-${user.id}`}
+                                    checked={user.is_support_admin}
+                                    disabled={updating === user.id}
+                                    onCheckedChange={(checked) => handleToggle(user, checked === true)}
+                                />
+                                <label htmlFor={`support-${user.id}`} className="text-sm text-zinc-300">
+                                    {updating === user.id
+                                        ? 'Updating access…'
+                                        : user.is_support_admin
+                                          ? 'Remove support access'
+                                          : 'Grant support access'}
+                                </label>
+                            </div>
+                        </article>
+                    ))}
+                </div>
+            </section>
+        </AppLayout>
+    );
+}

--- a/backend/resources/js/Pages/CampaignEntities/Create.tsx
+++ b/backend/resources/js/Pages/CampaignEntities/Create.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input';
 import { InputError } from '@/components/InputError';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import AiIdeaPanel, { AiIdeaResult } from '@/components/ai/AiIdeaPanel';
 
 type CampaignSummary = {
     id: number;
@@ -148,299 +149,296 @@ export default function CampaignEntityCreate({
                 </Button>
             </div>
 
-            <form onSubmit={submit} className="mt-6 space-y-8">
-                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
-                    <h2 className="text-lg font-semibold text-zinc-100">Essentials</h2>
-                    <p className="text-sm text-zinc-500">
-                        Provide a name and optional epithets so storytellers can reference this entity during play.
-                    </p>
+            <div className="mt-6 grid gap-8 xl:grid-cols-[2fr_1fr]">
+                <form onSubmit={submit} className="space-y-8">
+                    <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
+                        <h2 className="text-lg font-semibold text-zinc-100">Essentials</h2>
+                        <p className="text-sm text-zinc-500">
+                            Provide a name and optional epithets so storytellers can reference this entity during play.
+                        </p>
 
-                    <div className="mt-4 grid gap-4 md:grid-cols-2">
-                        <div>
-                            <Label htmlFor="name">Name</Label>
-                            <Input
-                                id="name"
-                                value={data.name}
-                                onChange={(event) => setData('name', event.target.value)}
-                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
-                                required
+                        <div className="mt-4 grid gap-4 md:grid-cols-2">
+                            <div>
+                                <Label htmlFor="name">Name</Label>
+                                <Input
+                                    id="name"
+                                    value={data.name}
+                                    onChange={(event) => setData('name', event.target.value)}
+                                    className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                                    required
+                                />
+                                <InputError message={errors.name} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="alias">Alias / epithet</Label>
+                                <Input
+                                    id="alias"
+                                    value={data.alias}
+                                    onChange={(event) => setData('alias', event.target.value)}
+                                    placeholder="e.g., The Whispered Blade"
+                                    className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                                />
+                                <InputError message={errors.alias} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="pronunciation">Pronunciation</Label>
+                                <Input
+                                    id="pronunciation"
+                                    value={data.pronunciation}
+                                    onChange={(event) => setData('pronunciation', event.target.value)}
+                                    placeholder="Optional pronunciation guide"
+                                    className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                                />
+                                <InputError message={errors.pronunciation} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="entity_type">Entity type</Label>
+                                <select
+                                    id="entity_type"
+                                    value={data.entity_type}
+                                    onChange={(event) => setData('entity_type', event.target.value)}
+                                    className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none"
+                                >
+                                    {available_types.map((value) => (
+                                        <option key={value} value={value}>
+                                            {typeLabels[value] ?? value}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={errors.entity_type} className="mt-2" />
+                            </div>
+                        </div>
+                    </section>
+
+                    <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
+                        <h2 className="text-lg font-semibold text-zinc-100">Visibility & assignment</h2>
+                        <p className="text-sm text-zinc-500">Determine who can see and maintain this entry.</p>
+
+                        <div className="mt-4 grid gap-4 md:grid-cols-2">
+                            <div>
+                                <Label htmlFor="visibility">Visibility</Label>
+                                <select
+                                    id="visibility"
+                                    value={data.visibility}
+                                    onChange={(event) => setData('visibility', event.target.value)}
+                                    className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none"
+                                >
+                                    {visibility_options.map((value) => (
+                                        <option key={value} value={value}>
+                                            {visibilityLabels[value] ?? value}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={errors.visibility} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="group_id">Group (optional)</Label>
+                                <select
+                                    id="group_id"
+                                    value={data.group_id}
+                                    onChange={(event) => setData('group_id', event.target.value)}
+                                    className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none"
+                                >
+                                    <option value="">Unassigned</option>
+                                    <option value={String(group.id)}>{group.name}</option>
+                                </select>
+                                <InputError message={errors.group_id} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="owner_id">Owner (optional)</Label>
+                                <select
+                                    id="owner_id"
+                                    value={data.owner_id}
+                                    onChange={(event) => setData('owner_id', event.target.value)}
+                                    className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none"
+                                >
+                                    <option value="">Unassigned</option>
+                                    {members.map((member) => (
+                                        <option key={member.id} value={member.id}>
+                                            {member.name}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={errors.owner_id} className="mt-2" />
+                            </div>
+                        </div>
+
+                        <div className="mt-4 flex items-center gap-3">
+                            <Checkbox
+                                id="ai_controlled"
+                                checked={data.ai_controlled}
+                                onCheckedChange={(checked) => setData('ai_controlled', checked === true)}
                             />
-                            <InputError message={errors.name} className="mt-2" />
+                            <Label htmlFor="ai_controlled" className="text-sm text-zinc-300">
+                                Allow AI to improvise updates
+                            </Label>
                         </div>
+                    </section>
 
-                        <div>
-                            <Label htmlFor="alias">Alias / epithet</Label>
-                            <Input
-                                id="alias"
-                                value={data.alias}
-                                onChange={(event) => setData('alias', event.target.value)}
-                                placeholder="e.g., The Whispered Blade"
-                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
-                            />
-                            <InputError message={errors.alias} className="mt-2" />
-                        </div>
+                    <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
+                        <h2 className="text-lg font-semibold text-zinc-100">Lore & stats</h2>
+                        <p className="text-sm text-zinc-500">
+                            Describe the entity and track quick-reference stats or aspects.
+                        </p>
 
-                        <div>
-                            <Label htmlFor="pronunciation">Pronunciation</Label>
-                            <Input
-                                id="pronunciation"
-                                value={data.pronunciation}
-                                onChange={(event) => setData('pronunciation', event.target.value)}
-                                placeholder="Optional pronunciation guide"
-                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
-                            />
-                            <InputError message={errors.pronunciation} className="mt-2" />
-                        </div>
+                        <div className="mt-4 space-y-4">
+                            <div>
+                                <Label htmlFor="description">Description</Label>
+                                <Textarea
+                                    id="description"
+                                    value={data.description}
+                                    onChange={(event) => setData('description', event.target.value)}
+                                    className="mt-1 h-32 border-zinc-700 bg-zinc-900/60 text-sm text-zinc-100"
+                                />
+                                <InputError message={errors.description} className="mt-2" />
+                            </div>
 
-                        <div>
-                            <Label htmlFor="entity_type">Entity type</Label>
-                            <select
-                                id="entity_type"
-                                value={data.entity_type}
-                                onChange={(event) => setData('entity_type', event.target.value)}
-                                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100"
-                            >
-                                {available_types.map((type) => (
-                                    <option key={type} value={type}>
-                                        {typeLabels[type] ?? type}
-                                    </option>
-                                ))}
-                            </select>
-                            <InputError message={errors.entity_type} className="mt-2" />
-                        </div>
-                    </div>
-                </section>
-
-                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
-                    <h2 className="text-lg font-semibold text-zinc-100">Lore & stewardship</h2>
-                    <p className="text-sm text-zinc-500">
-                        Note who tends this entry and how visible it is to the party.
-                    </p>
-
-                    <div className="mt-4 grid gap-4 md:grid-cols-2">
-                        <div>
-                            <Label htmlFor="visibility">Visibility</Label>
-                            <select
-                                id="visibility"
-                                value={data.visibility}
-                                onChange={(event) => setData('visibility', event.target.value)}
-                                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100"
-                            >
-                                {visibility_options.map((visibility) => (
-                                    <option key={visibility} value={visibility}>
-                                        {visibilityLabels[visibility] ?? visibility}
-                                    </option>
-                                ))}
-                            </select>
-                            <InputError message={errors.visibility} className="mt-2" />
-                        </div>
-
-                        <div>
-                            <Label htmlFor="owner_id">Steward</Label>
-                            <select
-                                id="owner_id"
-                                value={data.owner_id}
-                                onChange={(event) => setData('owner_id', event.target.value)}
-                                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100"
-                            >
-                                <option value="">Unassigned</option>
-                                {members.map((member) => (
-                                    <option key={member.id} value={member.id}>
-                                        {member.name}
-                                    </option>
-                                ))}
-                            </select>
-                            <InputError message={errors.owner_id} className="mt-2" />
-                        </div>
-
-                        <div>
-                            <Label htmlFor="group_id">Group alignment</Label>
-                            <select
-                                id="group_id"
-                                value={data.group_id}
-                                onChange={(event) => setData('group_id', event.target.value)}
-                                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100"
-                            >
-                                <option value="">No dedicated group</option>
-                                <option value={group.id}>{group.name}</option>
-                            </select>
-                            <InputError message={errors.group_id} className="mt-2" />
-                        </div>
-
-                        <div>
-                            <Label htmlFor="initiative_default">Initiative default</Label>
-                            <Input
-                                id="initiative_default"
-                                type="number"
-                                min={0}
-                                max={40}
-                                value={data.initiative_default}
-                                onChange={(event) => setData('initiative_default', event.target.value)}
-                                placeholder="Optional initiative baseline"
-                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
-                            />
-                            <InputError message={errors.initiative_default} className="mt-2" />
-                        </div>
-                    </div>
-
-                    <div className="mt-4 flex items-center gap-2">
-                        <Checkbox
-                            id="ai_controlled"
-                            checked={data.ai_controlled}
-                            onCheckedChange={(checked) => setData('ai_controlled', checked === true)}
-                        />
-                        <Label htmlFor="ai_controlled" className="text-sm text-zinc-300">
-                            AI stewarded lore entry
-                        </Label>
-                        <InputError message={errors.ai_controlled} className="ml-2" />
-                    </div>
-
-                    <div className="mt-4">
-                        <Label htmlFor="description">Lore summary</Label>
-                        <Textarea
-                            id="description"
-                            value={data.description}
-                            onChange={(event) => setData('description', event.target.value)}
-                            placeholder="Describe their history, motives, or significance. Markdown supported."
-                            className="mt-1 min-h-[160px] border-zinc-700 bg-zinc-900/60 text-sm text-zinc-100"
-                        />
-                        <InputError message={errors.description} className="mt-2" />
-                    </div>
-                </section>
-
-                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
-                    <h2 className="text-lg font-semibold text-zinc-100">Stat blocks</h2>
-                    <p className="text-sm text-zinc-500">
-                        Track notable traits or mechanics (AC, HP, key abilities) for quick reference.
-                    </p>
-
-                    <div className="mt-4 space-y-4">
-                        {data.stats.map((stat, index) => (
-                            <div key={index} className="flex flex-col gap-2 rounded-lg border border-zinc-800/80 p-4 md:flex-row">
-                                <div className="md:w-1/3">
-                                    <Label>Label</Label>
-                                    <Input
-                                        value={stat.label}
-                                        onChange={(event) => updateStat(index, 'label', event.target.value)}
-                                        placeholder="e.g., Armor Class"
-                                        className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
-                                    />
-                                </div>
-                                <div className="md:w-1/3">
-                                    <Label>Value</Label>
-                                    <Input
-                                        value={stat.value}
-                                        onChange={(event) => updateStat(index, 'value', event.target.value)}
-                                        placeholder="e.g., 16 (chain mail)"
-                                        className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
-                                    />
-                                </div>
-                                <div className="flex items-end justify-end md:w-1/3">
-                                    <Button
-                                        type="button"
-                                        variant="outline"
-                                        onClick={() => removeStatRow(index)}
-                                        className="border-rose-700/60 text-sm text-rose-200 hover:bg-rose-900/40"
-                                    >
-                                        Remove
+                            <div className="space-y-3">
+                                <div className="flex items-center justify-between">
+                                    <Label>Stats</Label>
+                                    <Button type="button" variant="outline" size="sm" onClick={addStatRow}>
+                                        Add stat
                                     </Button>
                                 </div>
+
+                                <div className="space-y-2">
+                                    {data.stats.map((stat, index) => (
+                                        <div key={`stat-${index}`} className="grid gap-2 sm:grid-cols-[1fr_1fr_auto]">
+                                            <Input
+                                                value={stat.label}
+                                                onChange={(event) => updateStat(index, 'label', event.target.value)}
+                                                placeholder="Attribute"
+                                                className="border-zinc-700 bg-zinc-900/60"
+                                            />
+                                            <Input
+                                                value={stat.value}
+                                                onChange={(event) => updateStat(index, 'value', event.target.value)}
+                                                placeholder="Value"
+                                                className="border-zinc-700 bg-zinc-900/60"
+                                            />
+                                            <Button
+                                                type="button"
+                                                variant="ghost"
+                                                onClick={() => removeStatRow(index)}
+                                                className="justify-self-end text-sm text-rose-300 hover:text-rose-200"
+                                            >
+                                                Remove
+                                            </Button>
+                                        </div>
+                                    ))}
+                                </div>
+                                <InputError message={errors.stats} className="mt-2" />
                             </div>
-                        ))}
 
-                        <Button
-                            type="button"
-                            onClick={addStatRow}
-                            className="w-full bg-indigo-500/20 text-indigo-200 hover:bg-indigo-500/30"
-                        >
-                            Add another stat
-                        </Button>
-                        <InputError message={errors.stats} />
-                    </div>
-                </section>
+                            <div>
+                                <Label className="block">Tags</Label>
+                                <div className="mt-2 flex flex-wrap gap-2">
+                                    {data.tags.map((tag) => (
+                                        <span
+                                            key={tag}
+                                            className="inline-flex items-center gap-1 rounded-full border border-zinc-700 bg-zinc-900/60 px-3 py-1 text-xs text-zinc-200"
+                                        >
+                                            {tag}
+                                            <button
+                                                type="button"
+                                                className="text-rose-300 hover:text-rose-200"
+                                                onClick={() => toggleTag(tag)}
+                                            >
+                                                ×
+                                            </button>
+                                        </span>
+                                    ))}
+                                </div>
+                                <div className="mt-3 flex gap-2">
+                                    <Input
+                                        value={tagDraft}
+                                        onChange={(event) => setTagDraft(event.target.value)}
+                                        placeholder="Add custom tag"
+                                        className="border-zinc-700 bg-zinc-900/60"
+                                    />
+                                    <Button type="button" variant="outline" onClick={addTagDraft}>
+                                        Add tag
+                                    </Button>
+                                </div>
 
-                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
-                    <h2 className="text-lg font-semibold text-zinc-100">Tags & themes</h2>
-                    <p className="text-sm text-zinc-500">
-                        Tag entries for quicker discovery during play (factions, arc names, mood cues).
-                    </p>
-
-                    <div className="mt-4 flex flex-wrap gap-2">
-                        {data.tags.length === 0 ? (
-                            <span className="text-xs text-zinc-500">No tags selected yet.</span>
-                        ) : (
-                            data.tags.map((tag) => (
-                                <span
-                                    key={tag}
-                                    className="flex items-center gap-2 rounded-full bg-amber-500/10 px-3 py-1 text-xs text-amber-100"
-                                >
-                                    {tag}
-                                    <button
-                                        type="button"
-                                        onClick={() => toggleTag(tag)}
-                                        className="rounded-full bg-amber-500/40 px-2 text-[10px] uppercase tracking-wide"
-                                    >
-                                        Remove
-                                    </button>
-                                </span>
-                            ))
-                        )}
-                    </div>
-
-                    <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end">
-                        <div className="sm:flex-1">
-                            <Label htmlFor="tagDraft">Add a new tag</Label>
-                            <Input
-                                id="tagDraft"
-                                value={tagDraft}
-                                onChange={(event) => setTagDraft(event.target.value)}
-                                placeholder="e.g., Shadow Court"
-                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
-                            />
-                        </div>
-                        <Button
-                            type="button"
-                            onClick={addTagDraft}
-                            className="sm:w-auto bg-emerald-500/20 text-emerald-200 hover:bg-emerald-500/30"
-                        >
-                            Add tag
-                        </Button>
-                    </div>
-
-                    {available_tags.length > 0 && (
-                        <div className="mt-4 space-y-2">
-                            <p className="text-xs uppercase tracking-wide text-zinc-500">Popular tags</p>
-                            <div className="flex flex-wrap gap-2">
-                                {available_tags.map((tag) => (
-                                    <button
-                                        type="button"
-                                        key={tag.slug}
-                                        onClick={() => toggleTag(tag.label)}
-                                        className={`rounded-full px-3 py-1 text-xs font-semibold transition ${
-                                            data.tags.includes(tag.label)
-                                                ? 'bg-emerald-500/30 text-emerald-100'
-                                                : 'bg-zinc-800/80 text-zinc-300 hover:bg-zinc-700'
-                                        }`}
-                                    >
-                                        {tag.label}
-                                    </button>
-                                ))}
+                                <div className="mt-4 flex flex-wrap gap-2">
+                                    {available_tags.map((tag) => (
+                                        <button
+                                            key={tag.id}
+                                            type="button"
+                                            onClick={() => toggleTag(tag.label)}
+                                            className={`rounded-full border px-3 py-1 text-xs ${
+                                                data.tags.includes(tag.label)
+                                                    ? 'border-indigo-500 bg-indigo-500/10 text-indigo-200'
+                                                    : 'border-zinc-700 bg-zinc-900/60 text-zinc-300 hover:border-indigo-500 hover:text-indigo-200'
+                                            }`}
+                                        >
+                                            {tag.label}
+                                        </button>
+                                    ))}
+                                </div>
+                                <InputError message={errors.tags} className="mt-2" />
                             </div>
                         </div>
-                    )}
+                    </section>
 
-                    <InputError message={errors.tags} className="mt-2" />
-                </section>
+                    <section className="flex items-center justify-between">
+                        <Button type="submit" disabled={processing}>
+                            Save lore entry
+                        </Button>
+                        <Button asChild variant="ghost">
+                            <Link href={route('campaigns.entities.index', campaign.id)}>Cancel</Link>
+                        </Button>
+                    </section>
+                </form>
 
-                <div className="flex items-center justify-end gap-3">
-                    <Button asChild variant="outline" className="border-zinc-700 text-sm text-zinc-300">
-                        <Link href={route('campaigns.entities.index', campaign.id)}>Cancel</Link>
-                    </Button>
-                    <Button type="submit" disabled={processing} className="bg-amber-500/30 text-amber-100">
-                        Save lore entry
-                    </Button>
-                </div>
-            </form>
+                <AiIdeaPanel
+                    domain="lore"
+                    title="Summon lore sparks"
+                    description="Turn a name or tag into vivid codex copy, spoiler-safe secrets, and art prompts."
+                    placeholder="Forgotten guardian of the Bramble Pass"
+                    context={{
+                        campaign: campaign.title,
+                        name: data.name,
+                        type: data.entity_type,
+                        tags: data.tags,
+                        summary: data.description,
+                    }}
+                    actions={[
+                        {
+                            label: 'Use as description',
+                            onApply: (result: AiIdeaResult) => {
+                                const summary = typeof result.structured?.summary === 'string' ? result.structured.summary : '';
+                                const secrets = Array.isArray(result.structured?.secrets)
+                                    ? result.structured.secrets.filter((entry): entry is string => typeof entry === 'string')
+                                    : [];
+                                const combined = [summary, secrets.length ? '' : null, ...secrets.map((secret) => `• ${secret}`)]
+                                    .filter((value): value is string => Boolean(value && value !== ''))
+                                    .join('\n');
+
+                                setData('description', combined !== '' ? combined : result.text);
+                            },
+                        },
+                        {
+                            label: 'Adopt tag suggestions',
+                            onApply: (result: AiIdeaResult) => {
+                                const tags = Array.isArray(result.structured?.tags)
+                                    ? result.structured.tags.filter((tag): tag is string => typeof tag === 'string')
+                                    : [];
+                                if (tags.length > 0) {
+                                    const merged = Array.from(new Set([...data.tags, ...tags]));
+                                    setData('tags', merged);
+                                }
+                            },
+                        },
+                    ]}
+                />
+            </div>
         </AppLayout>
     );
 }

--- a/backend/resources/js/Pages/CampaignEntities/Edit.tsx
+++ b/backend/resources/js/Pages/CampaignEntities/Edit.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input';
 import { InputError } from '@/components/InputError';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import AiIdeaPanel, { AiIdeaResult } from '@/components/ai/AiIdeaPanel';
 
 type CampaignSummary = {
     id: number;
@@ -189,299 +190,296 @@ export default function CampaignEntityEdit({
                 </div>
             </div>
 
-            <form onSubmit={submit} className="mt-6 space-y-8">
-                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
-                    <h2 className="text-lg font-semibold text-zinc-100">Essentials</h2>
-                    <p className="text-sm text-zinc-500">
-                        Provide a name and optional epithets so storytellers can reference this entity during play.
-                    </p>
+            <div className="mt-6 grid gap-8 xl:grid-cols-[2fr_1fr]">
+                <form onSubmit={submit} className="space-y-8">
+                    <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
+                        <h2 className="text-lg font-semibold text-zinc-100">Essentials</h2>
+                        <p className="text-sm text-zinc-500">
+                            Provide a name and optional epithets so storytellers can reference this entity during play.
+                        </p>
 
-                    <div className="mt-4 grid gap-4 md:grid-cols-2">
-                        <div>
-                            <Label htmlFor="name">Name</Label>
-                            <Input
-                                id="name"
-                                value={data.name}
-                                onChange={(event) => setData('name', event.target.value)}
-                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
-                                required
+                        <div className="mt-4 grid gap-4 md:grid-cols-2">
+                            <div>
+                                <Label htmlFor="name">Name</Label>
+                                <Input
+                                    id="name"
+                                    value={data.name}
+                                    onChange={(event) => setData('name', event.target.value)}
+                                    className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                                    required
+                                />
+                                <InputError message={errors.name} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="alias">Alias / epithet</Label>
+                                <Input
+                                    id="alias"
+                                    value={data.alias}
+                                    onChange={(event) => setData('alias', event.target.value)}
+                                    placeholder="e.g., The Whispered Blade"
+                                    className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                                />
+                                <InputError message={errors.alias} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="pronunciation">Pronunciation</Label>
+                                <Input
+                                    id="pronunciation"
+                                    value={data.pronunciation}
+                                    onChange={(event) => setData('pronunciation', event.target.value)}
+                                    placeholder="Optional pronunciation guide"
+                                    className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
+                                />
+                                <InputError message={errors.pronunciation} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="entity_type">Entity type</Label>
+                                <select
+                                    id="entity_type"
+                                    value={data.entity_type}
+                                    onChange={(event) => setData('entity_type', event.target.value)}
+                                    className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none"
+                                >
+                                    {available_types.map((value) => (
+                                        <option key={value} value={value}>
+                                            {typeLabels[value] ?? value}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={errors.entity_type} className="mt-2" />
+                            </div>
+                        </div>
+                    </section>
+
+                    <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
+                        <h2 className="text-lg font-semibold text-zinc-100">Visibility & assignment</h2>
+                        <p className="text-sm text-zinc-500">Determine who can see and maintain this entry.</p>
+
+                        <div className="mt-4 grid gap-4 md:grid-cols-2">
+                            <div>
+                                <Label htmlFor="visibility">Visibility</Label>
+                                <select
+                                    id="visibility"
+                                    value={data.visibility}
+                                    onChange={(event) => setData('visibility', event.target.value)}
+                                    className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none"
+                                >
+                                    {visibility_options.map((value) => (
+                                        <option key={value} value={value}>
+                                            {visibilityLabels[value] ?? value}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={errors.visibility} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="group_id">Group (optional)</Label>
+                                <select
+                                    id="group_id"
+                                    value={data.group_id}
+                                    onChange={(event) => setData('group_id', event.target.value)}
+                                    className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none"
+                                >
+                                    <option value="">Unassigned</option>
+                                    <option value={String(group.id)}>{group.name}</option>
+                                </select>
+                                <InputError message={errors.group_id} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="owner_id">Owner (optional)</Label>
+                                <select
+                                    id="owner_id"
+                                    value={data.owner_id}
+                                    onChange={(event) => setData('owner_id', event.target.value)}
+                                    className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none"
+                                >
+                                    <option value="">Unassigned</option>
+                                    {members.map((member) => (
+                                        <option key={member.id} value={member.id}>
+                                            {member.name}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={errors.owner_id} className="mt-2" />
+                            </div>
+                        </div>
+
+                        <div className="mt-4 flex items-center gap-3">
+                            <Checkbox
+                                id="ai_controlled"
+                                checked={data.ai_controlled}
+                                onCheckedChange={(checked) => setData('ai_controlled', checked === true)}
                             />
-                            <InputError message={errors.name} className="mt-2" />
+                            <Label htmlFor="ai_controlled" className="text-sm text-zinc-300">
+                                Allow AI to improvise updates
+                            </Label>
                         </div>
+                    </section>
 
-                        <div>
-                            <Label htmlFor="alias">Alias / epithet</Label>
-                            <Input
-                                id="alias"
-                                value={data.alias}
-                                onChange={(event) => setData('alias', event.target.value)}
-                                placeholder="e.g., The Whispered Blade"
-                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
-                            />
-                            <InputError message={errors.alias} className="mt-2" />
-                        </div>
+                    <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
+                        <h2 className="text-lg font-semibold text-zinc-100">Lore & stats</h2>
+                        <p className="text-sm text-zinc-500">
+                            Describe the entity and track quick-reference stats or aspects.
+                        </p>
 
-                        <div>
-                            <Label htmlFor="pronunciation">Pronunciation</Label>
-                            <Input
-                                id="pronunciation"
-                                value={data.pronunciation}
-                                onChange={(event) => setData('pronunciation', event.target.value)}
-                                placeholder="Optional pronunciation guide"
-                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
-                            />
-                            <InputError message={errors.pronunciation} className="mt-2" />
-                        </div>
+                        <div className="mt-4 space-y-4">
+                            <div>
+                                <Label htmlFor="description">Description</Label>
+                                <Textarea
+                                    id="description"
+                                    value={data.description}
+                                    onChange={(event) => setData('description', event.target.value)}
+                                    className="mt-1 h-32 border-zinc-700 bg-zinc-900/60 text-sm text-zinc-100"
+                                />
+                                <InputError message={errors.description} className="mt-2" />
+                            </div>
 
-                        <div>
-                            <Label htmlFor="entity_type">Entity type</Label>
-                            <select
-                                id="entity_type"
-                                value={data.entity_type}
-                                onChange={(event) => setData('entity_type', event.target.value)}
-                                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100"
-                            >
-                                {available_types.map((type) => (
-                                    <option key={type} value={type}>
-                                        {typeLabels[type] ?? type}
-                                    </option>
-                                ))}
-                            </select>
-                            <InputError message={errors.entity_type} className="mt-2" />
-                        </div>
-                    </div>
-                </section>
-
-                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
-                    <h2 className="text-lg font-semibold text-zinc-100">Lore & stewardship</h2>
-                    <p className="text-sm text-zinc-500">
-                        Note who tends this entry and how visible it is to the party.
-                    </p>
-
-                    <div className="mt-4 grid gap-4 md:grid-cols-2">
-                        <div>
-                            <Label htmlFor="visibility">Visibility</Label>
-                            <select
-                                id="visibility"
-                                value={data.visibility}
-                                onChange={(event) => setData('visibility', event.target.value)}
-                                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100"
-                            >
-                                {visibility_options.map((visibility) => (
-                                    <option key={visibility} value={visibility}>
-                                        {visibilityLabels[visibility] ?? visibility}
-                                    </option>
-                                ))}
-                            </select>
-                            <InputError message={errors.visibility} className="mt-2" />
-                        </div>
-
-                        <div>
-                            <Label htmlFor="owner_id">Steward</Label>
-                            <select
-                                id="owner_id"
-                                value={data.owner_id}
-                                onChange={(event) => setData('owner_id', event.target.value)}
-                                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100"
-                            >
-                                <option value="">Unassigned</option>
-                                {members.map((member) => (
-                                    <option key={member.id} value={member.id}>
-                                        {member.name}
-                                    </option>
-                                ))}
-                            </select>
-                            <InputError message={errors.owner_id} className="mt-2" />
-                        </div>
-
-                        <div>
-                            <Label htmlFor="group_id">Group alignment</Label>
-                            <select
-                                id="group_id"
-                                value={data.group_id}
-                                onChange={(event) => setData('group_id', event.target.value)}
-                                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-100"
-                            >
-                                <option value="">No dedicated group</option>
-                                <option value={group.id}>{group.name}</option>
-                            </select>
-                            <InputError message={errors.group_id} className="mt-2" />
-                        </div>
-
-                        <div>
-                            <Label htmlFor="initiative_default">Initiative default</Label>
-                            <Input
-                                id="initiative_default"
-                                type="number"
-                                min={0}
-                                max={40}
-                                value={data.initiative_default}
-                                onChange={(event) => setData('initiative_default', event.target.value)}
-                                placeholder="Optional initiative baseline"
-                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
-                            />
-                            <InputError message={errors.initiative_default} className="mt-2" />
-                        </div>
-                    </div>
-
-                    <div className="mt-4 flex items-center gap-2">
-                        <Checkbox
-                            id="ai_controlled"
-                            checked={data.ai_controlled}
-                            onCheckedChange={(checked) => setData('ai_controlled', checked === true)}
-                        />
-                        <Label htmlFor="ai_controlled" className="text-sm text-zinc-300">
-                            AI stewarded lore entry
-                        </Label>
-                        <InputError message={errors.ai_controlled} className="ml-2" />
-                    </div>
-
-                    <div className="mt-4">
-                        <Label htmlFor="description">Lore summary</Label>
-                        <Textarea
-                            id="description"
-                            value={data.description}
-                            onChange={(event) => setData('description', event.target.value)}
-                            placeholder="Describe their history, motives, or significance. Markdown supported."
-                            className="mt-1 min-h-[160px] border-zinc-700 bg-zinc-900/60 text-sm text-zinc-100"
-                        />
-                        <InputError message={errors.description} className="mt-2" />
-                    </div>
-                </section>
-
-                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
-                    <h2 className="text-lg font-semibold text-zinc-100">Stat blocks</h2>
-                    <p className="text-sm text-zinc-500">
-                        Track notable traits or mechanics (AC, HP, key abilities) for quick reference.
-                    </p>
-
-                    <div className="mt-4 space-y-4">
-                        {data.stats.map((stat, index) => (
-                            <div key={index} className="flex flex-col gap-2 rounded-lg border border-zinc-800/80 p-4 md:flex-row">
-                                <div className="md:w-1/3">
-                                    <Label>Label</Label>
-                                    <Input
-                                        value={stat.label}
-                                        onChange={(event) => updateStat(index, 'label', event.target.value)}
-                                        placeholder="e.g., Armor Class"
-                                        className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
-                                    />
-                                </div>
-                                <div className="md:w-1/3">
-                                    <Label>Value</Label>
-                                    <Input
-                                        value={stat.value}
-                                        onChange={(event) => updateStat(index, 'value', event.target.value)}
-                                        placeholder="e.g., 16 (chain mail)"
-                                        className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
-                                    />
-                                </div>
-                                <div className="flex items-end justify-end md:w-1/3">
-                                    <Button
-                                        type="button"
-                                        variant="outline"
-                                        onClick={() => removeStatRow(index)}
-                                        className="border-rose-700/60 text-sm text-rose-200 hover:bg-rose-900/40"
-                                    >
-                                        Remove
+                            <div className="space-y-3">
+                                <div className="flex items-center justify-between">
+                                    <Label>Stats</Label>
+                                    <Button type="button" variant="outline" size="sm" onClick={addStatRow}>
+                                        Add stat
                                     </Button>
                                 </div>
+
+                                <div className="space-y-2">
+                                    {data.stats.map((stat, index) => (
+                                        <div key={`stat-${index}`} className="grid gap-2 sm:grid-cols-[1fr_1fr_auto]">
+                                            <Input
+                                                value={stat.label}
+                                                onChange={(event) => updateStat(index, 'label', event.target.value)}
+                                                placeholder="Attribute"
+                                                className="border-zinc-700 bg-zinc-900/60"
+                                            />
+                                            <Input
+                                                value={stat.value}
+                                                onChange={(event) => updateStat(index, 'value', event.target.value)}
+                                                placeholder="Value"
+                                                className="border-zinc-700 bg-zinc-900/60"
+                                            />
+                                            <Button
+                                                type="button"
+                                                variant="ghost"
+                                                onClick={() => removeStatRow(index)}
+                                                className="justify-self-end text-sm text-rose-300 hover:text-rose-200"
+                                            >
+                                                Remove
+                                            </Button>
+                                        </div>
+                                    ))}
+                                </div>
+                                <InputError message={errors.stats} className="mt-2" />
                             </div>
-                        ))}
 
-                        <Button
-                            type="button"
-                            onClick={addStatRow}
-                            className="w-full bg-indigo-500/20 text-indigo-200 hover:bg-indigo-500/30"
-                        >
-                            Add another stat
-                        </Button>
-                        <InputError message={errors.stats} />
-                    </div>
-                </section>
+                            <div>
+                                <Label className="block">Tags</Label>
+                                <div className="mt-2 flex flex-wrap gap-2">
+                                    {data.tags.map((tag) => (
+                                        <span
+                                            key={tag}
+                                            className="inline-flex items-center gap-1 rounded-full border border-zinc-700 bg-zinc-900/60 px-3 py-1 text-xs text-zinc-200"
+                                        >
+                                            {tag}
+                                            <button
+                                                type="button"
+                                                className="text-rose-300 hover:text-rose-200"
+                                                onClick={() => toggleTag(tag)}
+                                            >
+                                                ×
+                                            </button>
+                                        </span>
+                                    ))}
+                                </div>
+                                <div className="mt-3 flex gap-2">
+                                    <Input
+                                        value={tagDraft}
+                                        onChange={(event) => setTagDraft(event.target.value)}
+                                        placeholder="Add custom tag"
+                                        className="border-zinc-700 bg-zinc-900/60"
+                                    />
+                                    <Button type="button" variant="outline" onClick={addTagDraft}>
+                                        Add tag
+                                    </Button>
+                                </div>
 
-                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/30">
-                    <h2 className="text-lg font-semibold text-zinc-100">Tags & themes</h2>
-                    <p className="text-sm text-zinc-500">
-                        Tag entries for quicker discovery during play (factions, arc names, mood cues).
-                    </p>
-
-                    <div className="mt-4 flex flex-wrap gap-2">
-                        {data.tags.length === 0 ? (
-                            <span className="text-xs text-zinc-500">No tags selected yet.</span>
-                        ) : (
-                            data.tags.map((tag) => (
-                                <span
-                                    key={tag}
-                                    className="flex items-center gap-2 rounded-full bg-amber-500/10 px-3 py-1 text-xs text-amber-100"
-                                >
-                                    {tag}
-                                    <button
-                                        type="button"
-                                        onClick={() => toggleTag(tag)}
-                                        className="rounded-full bg-amber-500/40 px-2 text-[10px] uppercase tracking-wide"
-                                    >
-                                        Remove
-                                    </button>
-                                </span>
-                            ))
-                        )}
-                    </div>
-
-                    <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end">
-                        <div className="sm:flex-1">
-                            <Label htmlFor="tagDraft">Add a new tag</Label>
-                            <Input
-                                id="tagDraft"
-                                value={tagDraft}
-                                onChange={(event) => setTagDraft(event.target.value)}
-                                placeholder="e.g., Shadow Court"
-                                className="mt-1 border-zinc-700 bg-zinc-900/60 text-zinc-100"
-                            />
-                        </div>
-                        <Button
-                            type="button"
-                            onClick={addTagDraft}
-                            className="sm:w-auto bg-emerald-500/20 text-emerald-200 hover:bg-emerald-500/30"
-                        >
-                            Add tag
-                        </Button>
-                    </div>
-
-                    {available_tags.length > 0 && (
-                        <div className="mt-4 space-y-2">
-                            <p className="text-xs uppercase tracking-wide text-zinc-500">Popular tags</p>
-                            <div className="flex flex-wrap gap-2">
-                                {available_tags.map((tag) => (
-                                    <button
-                                        type="button"
-                                        key={tag.slug}
-                                        onClick={() => toggleTag(tag.label)}
-                                        className={`rounded-full px-3 py-1 text-xs font-semibold transition ${
-                                            data.tags.includes(tag.label)
-                                                ? 'bg-emerald-500/30 text-emerald-100'
-                                                : 'bg-zinc-800/80 text-zinc-300 hover:bg-zinc-700'
-                                        }`}
-                                    >
-                                        {tag.label}
-                                    </button>
-                                ))}
+                                <div className="mt-4 flex flex-wrap gap-2">
+                                    {available_tags.map((tag) => (
+                                        <button
+                                            key={tag.id}
+                                            type="button"
+                                            onClick={() => toggleTag(tag.label)}
+                                            className={`rounded-full border px-3 py-1 text-xs ${
+                                                data.tags.includes(tag.label)
+                                                    ? 'border-indigo-500 bg-indigo-500/10 text-indigo-200'
+                                                    : 'border-zinc-700 bg-zinc-900/60 text-zinc-300 hover:border-indigo-500 hover:text-indigo-200'
+                                            }`}
+                                        >
+                                            {tag.label}
+                                        </button>
+                                    ))}
+                                </div>
+                                <InputError message={errors.tags} className="mt-2" />
                             </div>
                         </div>
-                    )}
+                    </section>
 
-                    <InputError message={errors.tags} className="mt-2" />
-                </section>
+                    <section className="flex items-center justify-between">
+                        <Button type="submit" disabled={processing}>
+                            Save changes
+                        </Button>
+                        <Button asChild variant="ghost">
+                            <Link href={route('campaigns.entities.show', [campaign.id, entity.id])}>Cancel</Link>
+                        </Button>
+                    </section>
+                </form>
 
-                <div className="flex items-center justify-end gap-3">
-                    <Button asChild variant="outline" className="border-zinc-700 text-sm text-zinc-300">
-                        <Link href={route('campaigns.entities.show', [campaign.id, entity.id])}>Cancel</Link>
-                    </Button>
-                    <Button type="submit" disabled={processing} className="bg-amber-500/30 text-amber-100">
-                        Update lore entry
-                    </Button>
-                </div>
-            </form>
+                <AiIdeaPanel
+                    domain="lore"
+                    title="Refresh lore with AI"
+                    description="Surface new secrets, update summaries, or pull an art prompt as the campaign shifts."
+                    placeholder={`Reveal complications for ${entity.name}`}
+                    context={{
+                        campaign: campaign.title,
+                        name: data.name,
+                        type: data.entity_type,
+                        tags: data.tags,
+                        summary: data.description,
+                    }}
+                    actions={[
+                        {
+                            label: 'Update description',
+                            onApply: (result: AiIdeaResult) => {
+                                const summary = typeof result.structured?.summary === 'string' ? result.structured.summary : '';
+                                const secrets = Array.isArray(result.structured?.secrets)
+                                    ? result.structured.secrets.filter((entry): entry is string => typeof entry === 'string')
+                                    : [];
+                                const combined = [summary, secrets.length ? '' : null, ...secrets.map((secret) => `• ${secret}`)]
+                                    .filter((value): value is string => Boolean(value && value !== ''))
+                                    .join('\n');
+
+                                setData('description', combined !== '' ? combined : result.text);
+                            },
+                        },
+                        {
+                            label: 'Merge tag ideas',
+                            onApply: (result: AiIdeaResult) => {
+                                const tags = Array.isArray(result.structured?.tags)
+                                    ? result.structured.tags.filter((tag): tag is string => typeof tag === 'string')
+                                    : [];
+                                if (tags.length > 0) {
+                                    const merged = Array.from(new Set([...data.tags, ...tags]));
+                                    setData('tags', merged);
+                                }
+                            },
+                        },
+                    ]}
+                />
+            </div>
         </AppLayout>
     );
 }

--- a/backend/resources/js/Pages/CampaignQuests/Create.tsx
+++ b/backend/resources/js/Pages/CampaignQuests/Create.tsx
@@ -1,4 +1,4 @@
-import { FormEventHandler } from 'react';
+import { FormEventHandler, useMemo } from 'react';
 
 import { Head, Link, useForm } from '@inertiajs/react';
 
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { InputError } from '@/components/InputError';
+import AiIdeaPanel, { AiIdeaResult } from '@/components/ai/AiIdeaPanel';
 
 type RegionOption = {
     id: number;
@@ -35,6 +36,18 @@ const priorityLabels: Record<string, string> = {
     low: 'Low',
 };
 
+type StructuredQuest = {
+    title?: string;
+    summary?: string;
+    status?: string;
+    objectives?: string[];
+    complications?: string[];
+    rewards?: string[];
+};
+
+const isStructuredQuest = (value: unknown): value is StructuredQuest =>
+    typeof value === 'object' && value !== null;
+
 export default function CampaignQuestCreate({ campaign, available_statuses, available_priorities, regions }: CampaignQuestCreateProps) {
     const { data, setData, post, processing, errors } = useForm({
         title: '',
@@ -48,10 +61,27 @@ export default function CampaignQuestCreate({ campaign, available_statuses, avai
         completed_at: '',
     });
 
+    const regionLookup = useMemo(() => Object.fromEntries(regions.map((region) => [String(region.id), region.name])), [regions]);
+
     const submit: FormEventHandler<HTMLFormElement> = (event) => {
         event.preventDefault();
 
         post(route('campaigns.quests.store', campaign.id));
+    };
+
+    const matchStatus = (value?: string): string | null => {
+        if (!value) {
+            return null;
+        }
+
+        const lower = value.toLowerCase();
+        const direct = available_statuses.find((status) => status.toLowerCase() === lower);
+        if (direct) {
+            return direct;
+        }
+
+        const byLabel = available_statuses.find((status) => (statusLabels[status] ?? status).toLowerCase() === lower);
+        return byLabel ?? null;
     };
 
     return (
@@ -71,177 +101,239 @@ export default function CampaignQuestCreate({ campaign, available_statuses, avai
                 </Button>
             </div>
 
-            <form onSubmit={submit} className="mt-6 space-y-6">
-                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/40">
-                    <h2 className="text-lg font-semibold text-zinc-100">Quest details</h2>
+            <div className="mt-6 grid gap-8 xl:grid-cols-[2fr_1fr]">
+                <form onSubmit={submit} className="space-y-6">
+                    <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/40">
+                        <h2 className="text-lg font-semibold text-zinc-100">Quest details</h2>
 
-                    <div className="mt-4 grid gap-5 md:grid-cols-2">
-                        <div>
-                            <Label htmlFor="title" className="text-xs uppercase tracking-wide text-zinc-500">
-                                Title
+                        <div className="mt-4 grid gap-5 md:grid-cols-2">
+                            <div>
+                                <Label htmlFor="title" className="text-xs uppercase tracking-wide text-zinc-500">
+                                    Title
+                                </Label>
+                                <Input
+                                    id="title"
+                                    value={data.title}
+                                    onChange={(event) => setData('title', event.target.value)}
+                                    placeholder="Quest name"
+                                    className="mt-1 bg-zinc-900/60"
+                                />
+                                <InputError message={errors.title} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="region_id" className="text-xs uppercase tracking-wide text-zinc-500">
+                                    Region
+                                </Label>
+                                <select
+                                    id="region_id"
+                                    value={data.region_id}
+                                    onChange={(event) => setData('region_id', event.target.value)}
+                                    className="mt-1 w-full rounded-lg border border-zinc-800 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-200 focus:border-amber-500 focus:outline-none"
+                                >
+                                    <option value="">Unassigned</option>
+                                    {regions.map((region) => (
+                                        <option key={region.id} value={String(region.id)}>
+                                            {region.name}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={errors.region_id} className="mt-2" />
+                            </div>
+                        </div>
+
+                        <div className="mt-4">
+                            <Label htmlFor="summary" className="text-xs uppercase tracking-wide text-zinc-500">
+                                Summary
                             </Label>
-                            <Input
-                                id="title"
-                                value={data.title}
-                                onChange={(event) => setData('title', event.target.value)}
-                                placeholder="Quest name"
-                                className="mt-1 bg-zinc-900/60"
+                            <Textarea
+                                id="summary"
+                                value={data.summary}
+                                onChange={(event) => setData('summary', event.target.value)}
+                                placeholder="High-level goal, stakes, or rumors"
+                                className="mt-1 h-32 bg-zinc-900/60"
                             />
-                            <InputError message={errors.title} className="mt-2" />
+                            <InputError message={errors.summary} className="mt-2" />
                         </div>
 
-                        <div>
-                            <Label htmlFor="region_id" className="text-xs uppercase tracking-wide text-zinc-500">
-                                Region
+                        <div className="mt-4">
+                            <Label htmlFor="details" className="text-xs uppercase tracking-wide text-zinc-500">
+                                Details
                             </Label>
-                            <select
-                                id="region_id"
-                                value={data.region_id}
-                                onChange={(event) => setData('region_id', event.target.value)}
-                                className="mt-1 w-full rounded-lg border border-zinc-800 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-200 focus:border-amber-500 focus:outline-none"
-                            >
-                                <option value="">Unassigned</option>
-                                {regions.map((region) => (
-                                    <option key={region.id} value={String(region.id)}>
-                                        {region.name}
-                                    </option>
-                                ))}
-                            </select>
-                            <InputError message={errors.region_id} className="mt-2" />
-                        </div>
-                    </div>
-
-                    <div className="mt-4">
-                        <Label htmlFor="summary" className="text-xs uppercase tracking-wide text-zinc-500">
-                            Summary
-                        </Label>
-                        <Textarea
-                            id="summary"
-                            value={data.summary}
-                            onChange={(event) => setData('summary', event.target.value)}
-                            placeholder="High-level goal, stakes, or rumors"
-                            className="mt-1 h-32 bg-zinc-900/60"
-                        />
-                        <InputError message={errors.summary} className="mt-2" />
-                    </div>
-
-                    <div className="mt-4">
-                        <Label htmlFor="details" className="text-xs uppercase tracking-wide text-zinc-500">
-                            Details
-                        </Label>
-                        <Textarea
-                            id="details"
-                            value={data.details}
-                            onChange={(event) => setData('details', event.target.value)}
-                            placeholder="Clues, leads, rewards, NPC ties, or twists"
-                            className="mt-1 h-40 bg-zinc-900/60"
-                        />
-                        <InputError message={errors.details} className="mt-2" />
-                    </div>
-                </section>
-
-                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/40">
-                    <h2 className="text-lg font-semibold text-zinc-100">Cadence & priority</h2>
-
-                    <div className="mt-4 grid gap-5 md:grid-cols-2">
-                        <div>
-                            <Label htmlFor="status" className="text-xs uppercase tracking-wide text-zinc-500">
-                                Status
-                            </Label>
-                            <select
-                                id="status"
-                                value={data.status}
-                                onChange={(event) => setData('status', event.target.value)}
-                                className="mt-1 w-full rounded-lg border border-zinc-800 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-200 focus:border-amber-500 focus:outline-none"
-                            >
-                                {available_statuses.map((status) => (
-                                    <option key={status} value={status}>
-                                        {statusLabels[status] ?? status}
-                                    </option>
-                                ))}
-                            </select>
-                            <InputError message={errors.status} className="mt-2" />
-                        </div>
-
-                        <div>
-                            <Label htmlFor="priority" className="text-xs uppercase tracking-wide text-zinc-500">
-                                Priority
-                            </Label>
-                            <select
-                                id="priority"
-                                value={data.priority}
-                                onChange={(event) => setData('priority', event.target.value)}
-                                className="mt-1 w-full rounded-lg border border-zinc-800 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-200 focus:border-amber-500 focus:outline-none"
-                            >
-                                {available_priorities.map((priority) => (
-                                    <option key={priority} value={priority}>
-                                        {priorityLabels[priority] ?? priority}
-                                    </option>
-                                ))}
-                            </select>
-                            <InputError message={errors.priority} className="mt-2" />
-                        </div>
-
-                        <div>
-                            <Label htmlFor="target_turn_number" className="text-xs uppercase tracking-wide text-zinc-500">
-                                Target turn
-                            </Label>
-                            <Input
-                                id="target_turn_number"
-                                type="number"
-                                min="1"
-                                value={data.target_turn_number}
-                                onChange={(event) => setData('target_turn_number', event.target.value)}
-                                placeholder="Optional turn number"
-                                className="mt-1 bg-zinc-900/60"
+                            <Textarea
+                                id="details"
+                                value={data.details}
+                                onChange={(event) => setData('details', event.target.value)}
+                                placeholder="Clues, leads, rewards, NPC ties, or twists"
+                                className="mt-1 h-40 bg-zinc-900/60"
                             />
-                            <InputError message={errors.target_turn_number} className="mt-2" />
+                            <InputError message={errors.details} className="mt-2" />
                         </div>
+                    </section>
 
-                        <div>
-                            <Label htmlFor="starts_at" className="text-xs uppercase tracking-wide text-zinc-500">
-                                Starts at
-                            </Label>
-                            <Input
-                                id="starts_at"
-                                type="datetime-local"
-                                value={data.starts_at}
-                                onChange={(event) => setData('starts_at', event.target.value)}
-                                className="mt-1 bg-zinc-900/60"
-                            />
-                            <InputError message={errors.starts_at} className="mt-2" />
-                        </div>
+                    <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/40">
+                        <h2 className="text-lg font-semibold text-zinc-100">Cadence & priority</h2>
 
-                        <div>
-                            <Label htmlFor="completed_at" className="text-xs uppercase tracking-wide text-zinc-500">
-                                Completed at
-                            </Label>
-                            <Input
-                                id="completed_at"
-                                type="datetime-local"
-                                value={data.completed_at}
-                                onChange={(event) => setData('completed_at', event.target.value)}
-                                className="mt-1 bg-zinc-900/60"
-                            />
-                            <InputError message={errors.completed_at} className="mt-2" />
+                        <div className="mt-4 grid gap-5 md:grid-cols-2">
+                            <div>
+                                <Label htmlFor="status" className="text-xs uppercase tracking-wide text-zinc-500">
+                                    Status
+                                </Label>
+                                <select
+                                    id="status"
+                                    value={data.status}
+                                    onChange={(event) => setData('status', event.target.value)}
+                                    className="mt-1 w-full rounded-lg border border-zinc-800 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-200 focus:border-amber-500 focus:outline-none"
+                                >
+                                    {available_statuses.map((status) => (
+                                        <option key={status} value={status}>
+                                            {statusLabels[status] ?? status}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={errors.status} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="priority" className="text-xs uppercase tracking-wide text-zinc-500">
+                                    Priority
+                                </Label>
+                                <select
+                                    id="priority"
+                                    value={data.priority}
+                                    onChange={(event) => setData('priority', event.target.value)}
+                                    className="mt-1 w-full rounded-lg border border-zinc-800 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-200 focus:border-amber-500 focus:outline-none"
+                                >
+                                    {available_priorities.map((priority) => (
+                                        <option key={priority} value={priority}>
+                                            {priorityLabels[priority] ?? priority}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={errors.priority} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="target_turn_number" className="text-xs uppercase tracking-wide text-zinc-500">
+                                    Target turn
+                                </Label>
+                                <Input
+                                    id="target_turn_number"
+                                    type="number"
+                                    min="1"
+                                    value={data.target_turn_number}
+                                    onChange={(event) => setData('target_turn_number', event.target.value)}
+                                    placeholder="Optional turn number"
+                                    className="mt-1 bg-zinc-900/60"
+                                />
+                                <InputError message={errors.target_turn_number} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="starts_at" className="text-xs uppercase tracking-wide text-zinc-500">
+                                    Starts at (UTC)
+                                </Label>
+                                <Input
+                                    id="starts_at"
+                                    type="datetime-local"
+                                    value={data.starts_at}
+                                    onChange={(event) => setData('starts_at', event.target.value)}
+                                    className="mt-1 bg-zinc-900/60"
+                                />
+                                <InputError message={errors.starts_at} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="completed_at" className="text-xs uppercase tracking-wide text-zinc-500">
+                                    Completed at (UTC)
+                                </Label>
+                                <Input
+                                    id="completed_at"
+                                    type="datetime-local"
+                                    value={data.completed_at}
+                                    onChange={(event) => setData('completed_at', event.target.value)}
+                                    className="mt-1 bg-zinc-900/60"
+                                />
+                                <InputError message={errors.completed_at} className="mt-2" />
+                            </div>
                         </div>
+                    </section>
+
+                    <div className="flex items-center justify-between">
+                        <Button type="submit" disabled={processing}>
+                            Save quest
+                        </Button>
+                        <Button asChild variant="ghost">
+                            <Link href={route('campaigns.quests.index', campaign.id)}>Cancel</Link>
+                        </Button>
                     </div>
-                </section>
+                </form>
 
-                <div className="flex items-center justify-end gap-3">
-                    <Button
-                        type="button"
-                        variant="outline"
-                        className="border-zinc-700 text-zinc-200 hover:bg-zinc-800/80"
-                        onClick={() => window.history.back()}
-                    >
-                        Cancel
-                    </Button>
-                    <Button type="submit" disabled={processing} className="bg-emerald-500/20 text-emerald-100">
-                        Save quest
-                    </Button>
-                </div>
-            </form>
+                <AiIdeaPanel
+                    domain="quest"
+                    title="Quest drafting assistant"
+                    description="Feed a few beats and let the AI suggest objectives, complications, and art prompts."
+                    placeholder="Escort refugees through the Bramble Pass"
+                    context={{
+                        campaign_title: campaign.title,
+                        region: regionLookup[data.region_id ?? ''],
+                        status: data.status,
+                        priority: data.priority,
+                        summary: data.summary,
+                    }}
+                    actions={[
+                        {
+                            label: 'Apply quest draft',
+                            onApply: (result: AiIdeaResult) => {
+                                const questData = isStructuredQuest(result.structured) ? result.structured : null;
+                                const detailsSections: string[] = [];
+
+                                if (questData && typeof questData.summary === 'string' && questData.summary !== '') {
+                                    setData('summary', questData.summary);
+                                } else if (typeof result.text === 'string' && result.text !== '') {
+                                    setData('summary', result.text);
+                                }
+
+                                if (questData && typeof questData.title === 'string' && questData.title !== '') {
+                                    setData('title', questData.title);
+                                }
+
+                                if (questData && Array.isArray(questData.objectives)) {
+                                    const items = questData.objectives.filter((item): item is string => typeof item === 'string' && item !== '');
+                                    if (items.length > 0) {
+                                        detailsSections.push('Objectives:', ...items.map((item) => `• ${item}`));
+                                    }
+                                }
+
+                                if (questData && Array.isArray(questData.complications)) {
+                                    const items = questData.complications.filter((item): item is string => typeof item === 'string' && item !== '');
+                                    if (items.length > 0) {
+                                        detailsSections.push('', 'Complications:', ...items.map((item) => `• ${item}`));
+                                    }
+                                }
+
+                                if (questData && Array.isArray(questData.rewards)) {
+                                    const items = questData.rewards.filter((item): item is string => typeof item === 'string' && item !== '');
+                                    if (items.length > 0) {
+                                        detailsSections.push('', 'Rewards:', ...items.map((item) => `• ${item}`));
+                                    }
+                                }
+
+                                if (detailsSections.length > 0) {
+                                    setData('details', detailsSections.join('\n'));
+                                } else if (typeof result.text === 'string' && result.text !== '') {
+                                    setData('details', result.text);
+                                }
+
+                                const statusKey = questData ? matchStatus(questData.status) : null;
+                                if (statusKey) {
+                                    setData('status', statusKey);
+                                }
+                            },
+                        },
+                    ]}
+                />
+            </div>
         </AppLayout>
     );
 }

--- a/backend/resources/js/Pages/CampaignQuests/Edit.tsx
+++ b/backend/resources/js/Pages/CampaignQuests/Edit.tsx
@@ -1,4 +1,4 @@
-import { FormEventHandler } from 'react';
+import { FormEventHandler, useMemo } from 'react';
 
 import { Head, Link, useForm } from '@inertiajs/react';
 
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { InputError } from '@/components/InputError';
+import AiIdeaPanel, { AiIdeaResult } from '@/components/ai/AiIdeaPanel';
 
 type RegionOption = {
     id: number;
@@ -50,6 +51,18 @@ const priorityLabels: Record<string, string> = {
     low: 'Low',
 };
 
+type StructuredQuest = {
+    title?: string;
+    summary?: string;
+    status?: string;
+    objectives?: string[];
+    complications?: string[];
+    rewards?: string[];
+};
+
+const isStructuredQuest = (value: unknown): value is StructuredQuest =>
+    typeof value === 'object' && value !== null;
+
 export default function CampaignQuestEdit({ campaign, quest, available_statuses, available_priorities, regions }: CampaignQuestEditProps) {
     const { data, setData, put, processing, delete: destroy, errors } = useForm({
         title: quest.title,
@@ -64,6 +77,8 @@ export default function CampaignQuestEdit({ campaign, quest, available_statuses,
         archived_at: quest.archived_at ?? '',
     });
 
+    const regionLookup = useMemo(() => Object.fromEntries(regions.map((region) => [String(region.id), region.name])), [regions]);
+
     const submit: FormEventHandler<HTMLFormElement> = (event) => {
         event.preventDefault();
 
@@ -72,6 +87,21 @@ export default function CampaignQuestEdit({ campaign, quest, available_statuses,
 
     const handleDelete = () => {
         destroy(route('campaigns.quests.destroy', [campaign.id, quest.id]));
+    };
+
+    const matchStatus = (value?: string): string | null => {
+        if (!value) {
+            return null;
+        }
+
+        const lower = value.toLowerCase();
+        const direct = available_statuses.find((status) => status.toLowerCase() === lower);
+        if (direct) {
+            return direct;
+        }
+
+        const byLabel = available_statuses.find((status) => (statusLabels[status] ?? status).toLowerCase() === lower);
+        return byLabel ?? null;
     };
 
     return (
@@ -99,187 +129,235 @@ export default function CampaignQuestEdit({ campaign, quest, available_statuses,
                 </div>
             </div>
 
-            <form onSubmit={submit} className="mt-6 space-y-6">
-                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/40">
-                    <h2 className="text-lg font-semibold text-zinc-100">Quest details</h2>
+            <div className="mt-6 grid gap-8 xl:grid-cols-[2fr_1fr]">
+                <form onSubmit={submit} className="space-y-6">
+                    <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/40">
+                        <h2 className="text-lg font-semibold text-zinc-100">Quest details</h2>
 
-                    <div className="mt-4 grid gap-5 md:grid-cols-2">
-                        <div>
-                            <Label htmlFor="title" className="text-xs uppercase tracking-wide text-zinc-500">
-                                Title
+                        <div className="mt-4 grid gap-5 md:grid-cols-2">
+                            <div>
+                                <Label htmlFor="title" className="text-xs uppercase tracking-wide text-zinc-500">
+                                    Title
+                                </Label>
+                                <Input
+                                    id="title"
+                                    value={data.title}
+                                    onChange={(event) => setData('title', event.target.value)}
+                                    className="mt-1 bg-zinc-900/60"
+                                />
+                                <InputError message={errors.title} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="region_id" className="text-xs uppercase tracking-wide text-zinc-500">
+                                    Region
+                                </Label>
+                                <select
+                                    id="region_id"
+                                    value={data.region_id}
+                                    onChange={(event) => setData('region_id', event.target.value)}
+                                    className="mt-1 w-full rounded-lg border border-zinc-800 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-200 focus:border-amber-500 focus:outline-none"
+                                >
+                                    <option value="">Unassigned</option>
+                                    {regions.map((region) => (
+                                        <option key={region.id} value={String(region.id)}>
+                                            {region.name}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={errors.region_id} className="mt-2" />
+                            </div>
+                        </div>
+
+                        <div className="mt-4">
+                            <Label htmlFor="summary" className="text-xs uppercase tracking-wide text-zinc-500">
+                                Summary
                             </Label>
-                            <Input
-                                id="title"
-                                value={data.title}
-                                onChange={(event) => setData('title', event.target.value)}
-                                className="mt-1 bg-zinc-900/60"
+                            <Textarea
+                                id="summary"
+                                value={data.summary}
+                                onChange={(event) => setData('summary', event.target.value)}
+                                className="mt-1 h-32 bg-zinc-900/60"
                             />
-                            <InputError message={errors.title} className="mt-2" />
+                            <InputError message={errors.summary} className="mt-2" />
                         </div>
 
-                        <div>
-                            <Label htmlFor="region_id" className="text-xs uppercase tracking-wide text-zinc-500">
-                                Region
+                        <div className="mt-4">
+                            <Label htmlFor="details" className="text-xs uppercase tracking-wide text-zinc-500">
+                                Details
                             </Label>
-                            <select
-                                id="region_id"
-                                value={data.region_id}
-                                onChange={(event) => setData('region_id', event.target.value)}
-                                className="mt-1 w-full rounded-lg border border-zinc-800 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-200 focus:border-amber-500 focus:outline-none"
-                            >
-                                <option value="">Unassigned</option>
-                                {regions.map((region) => (
-                                    <option key={region.id} value={String(region.id)}>
-                                        {region.name}
-                                    </option>
-                                ))}
-                            </select>
-                            <InputError message={errors.region_id} className="mt-2" />
+                            <Textarea
+                                id="details"
+                                value={data.details}
+                                onChange={(event) => setData('details', event.target.value)}
+                                className="mt-1 h-40 bg-zinc-900/60"
+                            />
+                            <InputError message={errors.details} className="mt-2" />
                         </div>
+                    </section>
+
+                    <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/40">
+                        <h2 className="text-lg font-semibold text-zinc-100">Cadence & priority</h2>
+
+                        <div className="mt-4 grid gap-5 md:grid-cols-2">
+                            <div>
+                                <Label htmlFor="status" className="text-xs uppercase tracking-wide text-zinc-500">
+                                    Status
+                                </Label>
+                                <select
+                                    id="status"
+                                    value={data.status}
+                                    onChange={(event) => setData('status', event.target.value)}
+                                    className="mt-1 w-full rounded-lg border border-zinc-800 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-200 focus:border-amber-500 focus:outline-none"
+                                >
+                                    {available_statuses.map((status) => (
+                                        <option key={status} value={status}>
+                                            {statusLabels[status] ?? status}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={errors.status} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="priority" className="text-xs uppercase tracking-wide text-zinc-500">
+                                    Priority
+                                </Label>
+                                <select
+                                    id="priority"
+                                    value={data.priority}
+                                    onChange={(event) => setData('priority', event.target.value)}
+                                    className="mt-1 w-full rounded-lg border border-zinc-800 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-200 focus:border-amber-500 focus:outline-none"
+                                >
+                                    {available_priorities.map((priority) => (
+                                        <option key={priority} value={priority}>
+                                            {priorityLabels[priority] ?? priority}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={errors.priority} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="target_turn_number" className="text-xs uppercase tracking-wide text-zinc-500">
+                                    Target turn
+                                </Label>
+                                <Input
+                                    id="target_turn_number"
+                                    type="number"
+                                    min="1"
+                                    value={data.target_turn_number}
+                                    onChange={(event) => setData('target_turn_number', event.target.value)}
+                                    className="mt-1 bg-zinc-900/60"
+                                />
+                                <InputError message={errors.target_turn_number} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="starts_at" className="text-xs uppercase tracking-wide text-zinc-500">
+                                    Starts at (UTC)
+                                </Label>
+                                <Input
+                                    id="starts_at"
+                                    type="datetime-local"
+                                    value={data.starts_at}
+                                    onChange={(event) => setData('starts_at', event.target.value)}
+                                    className="mt-1 bg-zinc-900/60"
+                                />
+                                <InputError message={errors.starts_at} className="mt-2" />
+                            </div>
+
+                            <div>
+                                <Label htmlFor="completed_at" className="text-xs uppercase tracking-wide text-zinc-500">
+                                    Completed at (UTC)
+                                </Label>
+                                <Input
+                                    id="completed_at"
+                                    type="datetime-local"
+                                    value={data.completed_at}
+                                    onChange={(event) => setData('completed_at', event.target.value)}
+                                    className="mt-1 bg-zinc-900/60"
+                                />
+                                <InputError message={errors.completed_at} className="mt-2" />
+                            </div>
+                        </div>
+                    </section>
+
+                    <div className="flex items-center justify-between">
+                        <Button type="submit" disabled={processing}>
+                            Save changes
+                        </Button>
+                        <Button asChild variant="ghost">
+                            <Link href={route('campaigns.quests.show', [campaign.id, quest.id])}>Cancel</Link>
+                        </Button>
                     </div>
+                </form>
 
-                    <div className="mt-4">
-                        <Label htmlFor="summary" className="text-xs uppercase tracking-wide text-zinc-500">
-                            Summary
-                        </Label>
-                        <Textarea
-                            id="summary"
-                            value={data.summary}
-                            onChange={(event) => setData('summary', event.target.value)}
-                            className="mt-1 h-32 bg-zinc-900/60"
-                        />
-                        <InputError message={errors.summary} className="mt-2" />
-                    </div>
+                <AiIdeaPanel
+                    domain="quest"
+                    title="Rework this quest"
+                    description="Ask the AI to tighten objectives, add twists, or suggest art prompts as the campaign evolves."
+                    placeholder={`Update complications for ${quest.title}`}
+                    context={{
+                        campaign_title: campaign.title,
+                        title: data.title,
+                        region: regionLookup[data.region_id ?? ''],
+                        status: data.status,
+                        summary: data.summary,
+                    }}
+                    actions={[
+                        {
+                            label: 'Refresh content',
+                            onApply: (result: AiIdeaResult) => {
+                                const questData = isStructuredQuest(result.structured) ? result.structured : null;
+                                const detailsSections: string[] = [];
 
-                    <div className="mt-4">
-                        <Label htmlFor="details" className="text-xs uppercase tracking-wide text-zinc-500">
-                            Details
-                        </Label>
-                        <Textarea
-                            id="details"
-                            value={data.details}
-                            onChange={(event) => setData('details', event.target.value)}
-                            className="mt-1 h-40 bg-zinc-900/60"
-                        />
-                        <InputError message={errors.details} className="mt-2" />
-                    </div>
-                </section>
+                                if (questData && typeof questData.summary === 'string' && questData.summary !== '') {
+                                    setData('summary', questData.summary);
+                                } else if (typeof result.text === 'string' && result.text !== '') {
+                                    setData('summary', result.text);
+                                }
 
-                <section className="rounded-xl border border-zinc-800 bg-zinc-950/60 p-6 shadow-inner shadow-black/40">
-                    <h2 className="text-lg font-semibold text-zinc-100">Cadence & priority</h2>
+                                if (questData && typeof questData.title === 'string' && questData.title !== '') {
+                                    setData('title', questData.title);
+                                }
 
-                    <div className="mt-4 grid gap-5 md:grid-cols-2">
-                        <div>
-                            <Label htmlFor="status" className="text-xs uppercase tracking-wide text-zinc-500">
-                                Status
-                            </Label>
-                            <select
-                                id="status"
-                                value={data.status}
-                                onChange={(event) => setData('status', event.target.value)}
-                                className="mt-1 w-full rounded-lg border border-zinc-800 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-200 focus:border-amber-500 focus:outline-none"
-                            >
-                                {available_statuses.map((status) => (
-                                    <option key={status} value={status}>
-                                        {statusLabels[status] ?? status}
-                                    </option>
-                                ))}
-                            </select>
-                            <InputError message={errors.status} className="mt-2" />
-                        </div>
+                                if (questData && Array.isArray(questData.objectives)) {
+                                    const items = questData.objectives.filter((item): item is string => typeof item === 'string' && item !== '');
+                                    if (items.length > 0) {
+                                        detailsSections.push('Objectives:', ...items.map((item) => `• ${item}`));
+                                    }
+                                }
 
-                        <div>
-                            <Label htmlFor="priority" className="text-xs uppercase tracking-wide text-zinc-500">
-                                Priority
-                            </Label>
-                            <select
-                                id="priority"
-                                value={data.priority}
-                                onChange={(event) => setData('priority', event.target.value)}
-                                className="mt-1 w-full rounded-lg border border-zinc-800 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-200 focus:border-amber-500 focus:outline-none"
-                            >
-                                {available_priorities.map((priority) => (
-                                    <option key={priority} value={priority}>
-                                        {priorityLabels[priority] ?? priority}
-                                    </option>
-                                ))}
-                            </select>
-                            <InputError message={errors.priority} className="mt-2" />
-                        </div>
+                                if (questData && Array.isArray(questData.complications)) {
+                                    const items = questData.complications.filter((item): item is string => typeof item === 'string' && item !== '');
+                                    if (items.length > 0) {
+                                        detailsSections.push('', 'Complications:', ...items.map((item) => `• ${item}`));
+                                    }
+                                }
 
-                        <div>
-                            <Label htmlFor="target_turn_number" className="text-xs uppercase tracking-wide text-zinc-500">
-                                Target turn
-                            </Label>
-                            <Input
-                                id="target_turn_number"
-                                type="number"
-                                min="1"
-                                value={data.target_turn_number}
-                                onChange={(event) => setData('target_turn_number', event.target.value)}
-                                className="mt-1 bg-zinc-900/60"
-                            />
-                            <InputError message={errors.target_turn_number} className="mt-2" />
-                        </div>
+                                if (questData && Array.isArray(questData.rewards)) {
+                                    const items = questData.rewards.filter((item): item is string => typeof item === 'string' && item !== '');
+                                    if (items.length > 0) {
+                                        detailsSections.push('', 'Rewards:', ...items.map((item) => `• ${item}`));
+                                    }
+                                }
 
-                        <div>
-                            <Label htmlFor="starts_at" className="text-xs uppercase tracking-wide text-zinc-500">
-                                Starts at
-                            </Label>
-                            <Input
-                                id="starts_at"
-                                type="datetime-local"
-                                value={data.starts_at}
-                                onChange={(event) => setData('starts_at', event.target.value)}
-                                className="mt-1 bg-zinc-900/60"
-                            />
-                            <InputError message={errors.starts_at} className="mt-2" />
-                        </div>
+                                if (detailsSections.length > 0) {
+                                    setData('details', detailsSections.join('\n'));
+                                } else if (typeof result.text === 'string' && result.text !== '') {
+                                    setData('details', result.text);
+                                }
 
-                        <div>
-                            <Label htmlFor="completed_at" className="text-xs uppercase tracking-wide text-zinc-500">
-                                Completed at
-                            </Label>
-                            <Input
-                                id="completed_at"
-                                type="datetime-local"
-                                value={data.completed_at}
-                                onChange={(event) => setData('completed_at', event.target.value)}
-                                className="mt-1 bg-zinc-900/60"
-                            />
-                            <InputError message={errors.completed_at} className="mt-2" />
-                        </div>
-
-                        <div>
-                            <Label htmlFor="archived_at" className="text-xs uppercase tracking-wide text-zinc-500">
-                                Archived at
-                            </Label>
-                            <Input
-                                id="archived_at"
-                                type="datetime-local"
-                                value={data.archived_at}
-                                onChange={(event) => setData('archived_at', event.target.value)}
-                                className="mt-1 bg-zinc-900/60"
-                            />
-                            <InputError message={errors.archived_at} className="mt-2" />
-                        </div>
-                    </div>
-                </section>
-
-                <div className="flex items-center justify-end gap-3">
-                    <Button
-                        type="button"
-                        variant="outline"
-                        className="border-zinc-700 text-zinc-200 hover:bg-zinc-800/80"
-                        onClick={() => window.history.back()}
-                    >
-                        Cancel
-                    </Button>
-                    <Button type="submit" disabled={processing} className="bg-emerald-500/20 text-emerald-100">
-                        Save changes
-                    </Button>
-                </div>
-            </form>
+                                const statusKey = questData ? matchStatus(questData.status) : null;
+                                if (statusKey) {
+                                    setData('status', statusKey);
+                                }
+                            },
+                        },
+                    ]}
+                />
+            </div>
         </AppLayout>
     );
 }

--- a/backend/resources/js/Pages/Campaigns/TaskBoard.tsx
+++ b/backend/resources/js/Pages/Campaigns/TaskBoard.tsx
@@ -1,4 +1,4 @@
-import { FormEventHandler } from 'react';
+import { FormEventHandler, useMemo } from 'react';
 
 import { Head, Link, router, useForm, usePage } from '@inertiajs/react';
 
@@ -8,6 +8,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { InputError } from '@/components/InputError';
+import AiIdeaPanel, { AiIdeaResult } from '@/components/ai/AiIdeaPanel';
 
 type ColumnMeta = {
     key: string;
@@ -60,6 +61,20 @@ type MemberOption = {
 type StatusOption = {
     key: string;
     label: string;
+};
+
+type StructuredAiTask = {
+    title?: string;
+    description?: string;
+    status?: string;
+};
+
+const isStructuredTask = (value: unknown): value is StructuredAiTask => {
+    if (typeof value !== 'object' || value === null) {
+        return false;
+    }
+
+    return 'title' in value || 'description' in value || 'status' in value;
 };
 
 type PageProps = {
@@ -147,6 +162,30 @@ export default function TaskBoard() {
         }, { preserveScroll: true });
     };
 
+    const existingTaskContext = useMemo(
+        () =>
+            columns.map((column) => ({
+                status: column.label,
+                titles: (tasks[column.key] ?? []).slice(0, 3).map((task) => task.title),
+            })),
+        [columns, tasks]
+    );
+
+    const findStatusKey = (value: string | undefined): string | null => {
+        if (!value) {
+            return null;
+        }
+
+        const lower = value.toLowerCase();
+        const byKey = statuses.find((status) => status.key.toLowerCase() === lower);
+        if (byKey) {
+            return byKey.key;
+        }
+
+        const byLabel = statuses.find((status) => status.label.toLowerCase() === lower);
+        return byLabel ? byLabel.key : null;
+    };
+
     return (
         <AppLayout>
             <Head title={`Task Board · ${campaign.title}`} />
@@ -167,100 +206,143 @@ export default function TaskBoard() {
             </div>
 
             {can_manage && (
-                <section className="mt-8 rounded-xl border border-zinc-800 bg-zinc-950/80 p-6 shadow-inner shadow-black/30">
-                    <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                        <div>
-                            <h2 className="text-lg font-semibold text-zinc-100">Add a new task</h2>
-                            <p className="text-sm text-zinc-500">Anchor work to the upcoming turns so the party keeps pace.</p>
-                        </div>
-                        <span className="text-xs uppercase tracking-wide text-zinc-500">Current turn {campaign.current_turn ?? 0}</span>
-                    </header>
+                <div className="mt-8 grid gap-6 lg:grid-cols-[2fr_1fr]">
+                    <section className="rounded-xl border border-zinc-800 bg-zinc-950/80 p-6 shadow-inner shadow-black/30">
+                        <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                            <div>
+                                <h2 className="text-lg font-semibold text-zinc-100">Add a new task</h2>
+                                <p className="text-sm text-zinc-500">Anchor work to the upcoming turns so the party keeps pace.</p>
+                            </div>
+                            <span className="text-xs uppercase tracking-wide text-zinc-500">Current turn {campaign.current_turn ?? 0}</span>
+                        </header>
 
-                    <form onSubmit={submitCreate} className="mt-6 grid gap-4 md:grid-cols-2">
-                        <div className="md:col-span-2">
-                            <Label htmlFor="title">Title</Label>
-                            <Input
-                                id="title"
-                                value={createForm.data.title}
-                                onChange={(event) => createForm.setData('title', event.target.value)}
-                                placeholder="Secure supply lines through the Bramble Pass"
-                                required
-                            />
-                            <InputError message={createForm.errors.title} className="mt-2" />
-                        </div>
+                        <form onSubmit={submitCreate} className="mt-6 grid gap-4 md:grid-cols-2">
+                            <div className="md:col-span-2">
+                                <Label htmlFor="title">Title</Label>
+                                <Input
+                                    id="title"
+                                    value={createForm.data.title}
+                                    onChange={(event) => createForm.setData('title', event.target.value)}
+                                    placeholder="Secure supply lines through the Bramble Pass"
+                                    required
+                                />
+                                <InputError message={createForm.errors.title} className="mt-2" />
+                            </div>
 
-                        <div className="md:col-span-2">
-                            <Label htmlFor="description">Description</Label>
-                            <Textarea
-                                id="description"
-                                value={createForm.data.description}
-                                onChange={(event) => createForm.setData('description', event.target.value)}
-                                placeholder="Outline what success looks like for the party or support crew."
-                                rows={3}
-                            />
-                            <InputError message={createForm.errors.description} className="mt-2" />
-                        </div>
+                            <div className="md:col-span-2">
+                                <Label htmlFor="description">Description</Label>
+                                <Textarea
+                                    id="description"
+                                    value={createForm.data.description}
+                                    onChange={(event) => createForm.setData('description', event.target.value)}
+                                    placeholder="Outline what success looks like for the party or support crew."
+                                    rows={3}
+                                />
+                                <InputError message={createForm.errors.description} className="mt-2" />
+                            </div>
 
-                        <div>
-                            <Label htmlFor="status">Status</Label>
-                            <select
-                                id="status"
-                                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-950/60 px-3 py-2 text-sm text-zinc-100 shadow-inner focus:border-indigo-500 focus:outline-none"
-                                value={createForm.data.status}
-                                onChange={(event) => createForm.setData('status', event.target.value)}
-                            >
-                                {statuses.map((status) => (
-                                    <option key={status.key} value={status.key}>
-                                        {status.label}
-                                    </option>
-                                ))}
-                            </select>
-                            <InputError message={createForm.errors.status} className="mt-2" />
-                        </div>
+                            <div>
+                                <Label htmlFor="status">Status</Label>
+                                <select
+                                    id="status"
+                                    className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-950/60 px-3 py-2 text-sm text-zinc-100 shadow-inner focus:border-indigo-500 focus:outline-none"
+                                    value={createForm.data.status}
+                                    onChange={(event) => createForm.setData('status', event.target.value)}
+                                >
+                                    {statuses.map((status) => (
+                                        <option key={status.key} value={status.key}>
+                                            {status.label}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={createForm.errors.status} className="mt-2" />
+                            </div>
 
-                        <div>
-                            <Label htmlFor="due_turn_number">Due turn</Label>
-                            <select
-                                id="due_turn_number"
-                                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-950/60 px-3 py-2 text-sm text-zinc-100 shadow-inner focus:border-indigo-500 focus:outline-none"
-                                value={createForm.data.due_turn_number}
-                                onChange={(event) => createForm.setData('due_turn_number', event.target.value)}
-                            >
-                                <option value="">Unassigned</option>
-                                {turn_suggestions.map((turn) => (
-                                    <option key={turn.value} value={turn.value}>
-                                        {turn.label}
-                                    </option>
-                                ))}
-                            </select>
-                            <InputError message={createForm.errors.due_turn_number} className="mt-2" />
-                        </div>
+                            <div>
+                                <Label htmlFor="due_turn_number">Due turn</Label>
+                                <select
+                                    id="due_turn_number"
+                                    className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-950/60 px-3 py-2 text-sm text-zinc-100 shadow-inner focus:border-indigo-500 focus:outline-none"
+                                    value={createForm.data.due_turn_number}
+                                    onChange={(event) => createForm.setData('due_turn_number', event.target.value)}
+                                >
+                                    <option value="">Unassigned</option>
+                                    {turn_suggestions.map((turn) => (
+                                        <option key={turn.value} value={turn.value}>
+                                            {turn.label}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={createForm.errors.due_turn_number} className="mt-2" />
+                            </div>
 
-                        <div>
-                            <Label htmlFor="assigned_user_id">Assigned to</Label>
-                            <select
-                                id="assigned_user_id"
-                                className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-950/60 px-3 py-2 text-sm text-zinc-100 shadow-inner focus:border-indigo-500 focus:outline-none"
-                                value={createForm.data.assigned_user_id}
-                                onChange={(event) => createForm.setData('assigned_user_id', event.target.value)}
-                            >
-                                <option value="">Unassigned</option>
-                                {members.map((member) => (
-                                    <option key={member.id} value={member.id}>
-                                        {member.name} – {member.role}
-                                    </option>
-                                ))}
-                            </select>
-                            <InputError message={createForm.errors.assigned_user_id} className="mt-2" />
-                        </div>
+                            <div>
+                                <Label htmlFor="assigned_user_id">Assigned to</Label>
+                                <select
+                                    id="assigned_user_id"
+                                    className="mt-1 w-full rounded-md border border-zinc-700 bg-zinc-950/60 px-3 py-2 text-sm text-zinc-100 shadow-inner focus:border-indigo-500 focus:outline-none"
+                                    value={createForm.data.assigned_user_id}
+                                    onChange={(event) => createForm.setData('assigned_user_id', event.target.value)}
+                                >
+                                    <option value="">Unassigned</option>
+                                    {members.map((member) => (
+                                        <option key={member.id} value={member.id}>
+                                            {member.name} – {member.role}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={createForm.errors.assigned_user_id} className="mt-2" />
+                            </div>
 
-                        <div className="md:col-span-2 flex justify-end">
-                            <Button type="submit" disabled={createForm.processing}>
-                                Add task
-                            </Button>
-                        </div>
-                    </form>
-                </section>
+                            <div className="md:col-span-2 flex justify-end">
+                                <Button type="submit" disabled={createForm.processing}>
+                                    Add task
+                                </Button>
+                            </div>
+                        </form>
+                    </section>
+
+                    <AiIdeaPanel
+                        domain="campaign_tasks"
+                        title="Ask the strategist"
+                        description="Let the AI storyboard a backlog, align statuses, and prep art prompts for tokens."
+                        placeholder="Secure the Bramble Pass, negotiate with the Wardens..."
+                        context={{
+                            campaign_title: campaign.title,
+                            current_turn: campaign.current_turn,
+                            statuses: statuses.map((status) => status.label),
+                            existing_tasks: existingTaskContext,
+                        }}
+                        actions={[
+                            {
+                                label: 'Fill new task form',
+                                onApply: (result: AiIdeaResult) => {
+                                    const structuredTasks = Array.isArray(result.structured?.tasks)
+                                        ? (result.structured?.tasks as unknown[])
+                                        : [];
+                                    const first = structuredTasks.find((entry) => isStructuredTask(entry));
+
+                                    if (first && typeof first.title === 'string') {
+                                        createForm.setData('title', first.title);
+                                    }
+
+                                    if (first && typeof first.description === 'string') {
+                                        createForm.setData('description', first.description);
+                                    } else if (typeof result.structured?.overview === 'string') {
+                                        createForm.setData('description', result.structured.overview);
+                                    }
+
+                                    if (first && typeof first.status === 'string') {
+                                        const statusKey = findStatusKey(first.status);
+                                        if (statusKey) {
+                                            createForm.setData('status', statusKey);
+                                        }
+                                    }
+                                },
+                            },
+                        ]}
+                    />
+                </div>
             )}
 
             <section className="mt-10 grid gap-6 lg:grid-cols-5">

--- a/backend/resources/js/Pages/Maps/Edit.tsx
+++ b/backend/resources/js/Pages/Maps/Edit.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useMemo, useRef } from 'react';
+
 import { Head, Link, useForm } from '@inertiajs/react';
 
 import AppLayout from '@/Layouts/AppLayout';
@@ -6,6 +8,8 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { InputError } from '@/components/InputError';
+import AiIdeaPanel, { AiIdeaResult } from '@/components/ai/AiIdeaPanel';
 
 type MapEditProps = {
     group: { id: number; name: string };
@@ -46,6 +50,87 @@ export default function MapEdit({ group, regions, map }: MapEditProps) {
         fog_data: map.fog_data ? JSON.stringify(map.fog_data, null, 2) : '',
     });
 
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const orientationOptions = useMemo(() => {
+        if (form.data.base_layer === 'hex') {
+            return [
+                { value: 'pointy', label: 'Pointy-top hex' },
+                { value: 'flat', label: 'Flat-top hex' },
+            ];
+        }
+
+        if (form.data.base_layer === 'square') {
+            return [
+                { value: 'orthogonal', label: 'Orthogonal grid' },
+                { value: 'isometric', label: 'Isometric grid' },
+            ];
+        }
+
+        return [{ value: 'freeform', label: 'Freeform canvas' }];
+    }, [form.data.base_layer]);
+
+    useEffect(() => {
+        if (!orientationOptions.some((option) => option.value === form.data.orientation)) {
+            form.setData('orientation', orientationOptions[0]?.value ?? 'freeform');
+        }
+    }, [form, form.data.orientation, orientationOptions]);
+
+    useEffect(() => {
+        const canvas = canvasRef.current;
+        if (!canvas) {
+            return;
+        }
+
+        const context = canvas.getContext('2d');
+        if (!context) {
+            return;
+        }
+
+        const width = canvas.width;
+        const height = canvas.height;
+        context.clearRect(0, 0, width, height);
+
+        context.fillStyle = '#09090b';
+        context.fillRect(0, 0, width, height);
+
+        context.strokeStyle = 'rgba(148, 163, 184, 0.35)';
+        context.lineWidth = 1;
+
+        if (form.data.base_layer === 'hex') {
+            const size = 20;
+            const hexHeight = size * Math.sqrt(3);
+            for (let row = 0; row < 6; row += 1) {
+                for (let col = 0; col < 6; col += 1) {
+                    const xOffset = form.data.orientation === 'flat' ? size * 1.5 : size;
+                    const yOffset = form.data.orientation === 'flat' ? hexHeight / 2 : hexHeight * 0.75;
+                    const x = size + col * xOffset + (row % 2 === 0 && form.data.orientation === 'pointy' ? 0 : size * 0.75);
+                    const y = hexHeight + row * yOffset;
+                    drawHex(context, x, y, size, form.data.orientation === 'flat');
+                }
+            }
+        } else if (form.data.base_layer === 'square') {
+            const size = 30;
+            for (let row = 0; row < 6; row += 1) {
+                for (let col = 0; col < 6; col += 1) {
+                    const x = 20 + col * size + (form.data.orientation === 'isometric' ? row * (size / 2) : 0);
+                    const y = 20 + row * size;
+                    if (form.data.orientation === 'isometric') {
+                        drawDiamond(context, x, y, size);
+                    } else {
+                        context.strokeRect(x, y, size, size);
+                    }
+                }
+            }
+        } else {
+            context.strokeStyle = 'rgba(250, 204, 21, 0.4)';
+            context.strokeRect(20, 20, width - 40, height - 40);
+            context.font = '12px Inter, sans-serif';
+            context.fillStyle = 'rgba(250, 204, 21, 0.7)';
+            context.fillText('Use freeform overlays for image backdrops.', 30, height / 2);
+        }
+    }, [form.data.base_layer, form.data.orientation]);
+
     const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
         form.put(route('groups.maps.update', [group.id, map.id]));
@@ -66,129 +151,199 @@ export default function MapEdit({ group, regions, map }: MapEditProps) {
                     </Button>
                 </div>
 
-                <form onSubmit={handleSubmit} className="space-y-6">
-                    <div className="space-y-2">
-                        <Label htmlFor="title">Title</Label>
-                        <Input
-                            id="title"
-                            value={form.data.title}
-                            onChange={(event) => form.setData('title', event.target.value)}
-                        />
-                        {form.errors.title && <p className="text-sm text-rose-400">{form.errors.title}</p>}
-                    </div>
-
-                    <div className="grid gap-4 sm:grid-cols-2">
+                <div className="grid gap-8 lg:grid-cols-[1.8fr_1fr]">
+                    <form onSubmit={handleSubmit} className="space-y-6">
                         <div className="space-y-2">
-                            <Label htmlFor="base_layer">Base layer</Label>
-                            <select
-                                id="base_layer"
-                                value={form.data.base_layer}
-                                onChange={(event) => form.setData('base_layer', event.target.value)}
-                                className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
-                            >
-                                <option value="hex">Hex grid</option>
-                                <option value="square">Square grid</option>
-                                <option value="image">Image backdrop</option>
-                            </select>
-                            {form.errors.base_layer && <p className="text-sm text-rose-400">{form.errors.base_layer}</p>}
-                        </div>
-                        <div className="space-y-2">
-                            <Label htmlFor="orientation">Orientation</Label>
-                            <select
-                                id="orientation"
-                                value={form.data.orientation}
-                                onChange={(event) => form.setData('orientation', event.target.value)}
-                                className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
-                            >
-                                <option value="pointy">Pointy-top hex</option>
-                                <option value="flat">Flat-top hex</option>
-                            </select>
-                            {form.errors.orientation && <p className="text-sm text-rose-400">{form.errors.orientation}</p>}
-                        </div>
-                    </div>
-
-                    <div className="grid gap-4 sm:grid-cols-3">
-                        <div className="space-y-2">
-                            <Label htmlFor="width">Width (optional)</Label>
+                            <Label htmlFor="title">Title</Label>
                             <Input
-                                id="width"
-                                type="number"
-                                min={1}
-                                max={200}
-                                value={form.data.width}
-                                onChange={(event) => form.setData('width', event.target.value === '' ? '' : Number(event.target.value))}
+                                id="title"
+                                value={form.data.title}
+                                onChange={(event) => form.setData('title', event.target.value)}
                             />
-                            {form.errors.width && <p className="text-sm text-rose-400">{form.errors.width}</p>}
+                            <InputError message={form.errors.title} />
                         </div>
-                        <div className="space-y-2">
-                            <Label htmlFor="height">Height (optional)</Label>
-                            <Input
-                                id="height"
-                                type="number"
-                                min={1}
-                                max={200}
-                                value={form.data.height}
-                                onChange={(event) => form.setData('height', event.target.value === '' ? '' : Number(event.target.value))}
+
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            <div className="space-y-2">
+                                <Label htmlFor="base_layer">Base layer</Label>
+                                <select
+                                    id="base_layer"
+                                    value={form.data.base_layer}
+                                    onChange={(event) => form.setData('base_layer', event.target.value)}
+                                    className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                                >
+                                    <option value="hex">Hex grid</option>
+                                    <option value="square">Square grid</option>
+                                    <option value="image">Image backdrop</option>
+                                </select>
+                                {form.errors.base_layer && <p className="text-sm text-rose-400">{form.errors.base_layer}</p>}
+                            </div>
+
+                            <div className="space-y-2">
+                                <Label htmlFor="orientation">Orientation</Label>
+                                <select
+                                    id="orientation"
+                                    value={form.data.orientation}
+                                    onChange={(event) => form.setData('orientation', event.target.value)}
+                                    className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                                >
+                                    {orientationOptions.map((option) => (
+                                        <option key={option.value} value={option.value}>
+                                            {option.label}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={form.errors.orientation} />
+                            </div>
+                        </div>
+
+                        <div className="grid gap-4 sm:grid-cols-3">
+                            <div className="space-y-2">
+                                <Label htmlFor="width">Width (optional)</Label>
+                                <Input
+                                    id="width"
+                                    type="number"
+                                    min={1}
+                                    max={200}
+                                    value={form.data.width}
+                                    onChange={(event) =>
+                                        form.setData('width', event.target.value === '' ? '' : Number(event.target.value))
+                                    }
+                                />
+                                <InputError message={form.errors.width} />
+                            </div>
+
+                            <div className="space-y-2">
+                                <Label htmlFor="height">Height (optional)</Label>
+                                <Input
+                                    id="height"
+                                    type="number"
+                                    min={1}
+                                    max={200}
+                                    value={form.data.height}
+                                    onChange={(event) =>
+                                        form.setData('height', event.target.value === '' ? '' : Number(event.target.value))
+                                    }
+                                />
+                                <InputError message={form.errors.height} />
+                            </div>
+
+                            <div className="space-y-2">
+                                <Label htmlFor="region_id">Region (optional)</Label>
+                                <select
+                                    id="region_id"
+                                    value={form.data.region_id}
+                                    onChange={(event) =>
+                                        form.setData('region_id', event.target.value === '' ? '' : Number(event.target.value))
+                                    }
+                                    className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                                >
+                                    <option value="">Unassigned</option>
+                                    {regions.map((region) => (
+                                        <option key={region.id} value={region.id}>
+                                            {region.name}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={form.errors.region_id} />
+                            </div>
+                        </div>
+
+                        <div className="flex items-center gap-2">
+                            <Checkbox
+                                id="gm_only"
+                                checked={form.data.gm_only}
+                                onChange={(event) => form.setData('gm_only', event.target.checked)}
                             />
-                            {form.errors.height && <p className="text-sm text-rose-400">{form.errors.height}</p>}
+                            <Label htmlFor="gm_only" className="text-sm text-zinc-300">
+                                GM-only map (players need invites)
+                            </Label>
                         </div>
+
                         <div className="space-y-2">
-                            <Label htmlFor="region_id">Region (optional)</Label>
-                            <select
-                                id="region_id"
-                                value={form.data.region_id}
-                                onChange={(event) =>
-                                    form.setData('region_id', event.target.value === '' ? '' : Number(event.target.value))
-                                }
-                                className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                            <Label htmlFor="fog_data">Fog configuration JSON (optional)</Label>
+                            <Textarea
+                                id="fog_data"
+                                value={form.data.fog_data}
+                                onChange={(event) => form.setData('fog_data', event.target.value)}
+                            />
+                            <InputError message={form.errors.fog_data} />
+                            <p className="text-xs text-zinc-500">Tip: include keys like mode, opacity, and reveal_radius to guide automations.</p>
+                        </div>
+
+                        <div className="flex items-center gap-3">
+                            <Button type="submit" disabled={form.processing}>
+                                Update map
+                            </Button>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                disabled={form.processing}
+                                onClick={() => form.reset()}
                             >
-                                <option value="">Unassigned</option>
-                                {regions.map((region) => (
-                                    <option key={region.id} value={region.id}>
-                                        {region.name}
-                                    </option>
-                                ))}
-                            </select>
-                            {form.errors.region_id && <p className="text-sm text-rose-400">{form.errors.region_id}</p>}
+                                Reset changes
+                            </Button>
                         </div>
-                    </div>
+                    </form>
 
-                    <div className="flex items-center gap-2">
-                        <Checkbox
-                            id="gm_only"
-                            checked={form.data.gm_only}
-                            onChange={(event) => form.setData('gm_only', event.target.checked)}
+                    <div className="space-y-6">
+                        <div>
+                            <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-300">Grid preview</h2>
+                            <canvas ref={canvasRef} width={260} height={220} className="mt-3 w-full rounded-lg border border-zinc-800 bg-zinc-950" />
+                        </div>
+
+                        <AiIdeaPanel
+                            domain="region_map"
+                            title="Ask the AI cartographer"
+                            description="Request layout beats, fog defaults, and an art prompt to jumpstart this region map."
+                            context={{
+                                title: form.data.title,
+                                base_layer: form.data.base_layer,
+                                orientation: form.data.orientation,
+                                fog_data: form.data.fog_data,
+                            }}
+                            actions={[
+                                {
+                                    label: 'Apply fog suggestions',
+                                    onApply: (result: AiIdeaResult) => {
+                                        const fogSettings = result.structured?.fog_settings;
+                                        if (fogSettings) {
+                                            form.setData('fog_data', JSON.stringify(fogSettings, null, 2));
+                                        }
+                                    },
+                                },
+                            ]}
                         />
-                        <Label htmlFor="gm_only" className="text-sm text-zinc-300">
-                            GM-only map (players need invites)
-                        </Label>
                     </div>
-
-                    <div className="space-y-2">
-                        <Label htmlFor="fog_data">Fog configuration JSON (optional)</Label>
-                        <Textarea
-                            id="fog_data"
-                            value={form.data.fog_data}
-                            onChange={(event) => form.setData('fog_data', event.target.value)}
-                        />
-                        {form.errors.fog_data && <p className="text-sm text-rose-400">{form.errors.fog_data}</p>}
-                    </div>
-
-                    <div className="flex items-center gap-3">
-                        <Button type="submit" disabled={form.processing}>
-                            Update map
-                        </Button>
-                        <Button
-                            type="button"
-                            variant="ghost"
-                            disabled={form.processing}
-                            onClick={() => form.reset()}
-                        >
-                            Reset changes
-                        </Button>
-                    </div>
-                </form>
+                </div>
             </div>
         </AppLayout>
     );
+}
+
+function drawHex(context: CanvasRenderingContext2D, x: number, y: number, size: number, flatTop: boolean) {
+    const angle = Math.PI / 3;
+    context.beginPath();
+    for (let i = 0; i < 6; i += 1) {
+        const theta = angle * i + (flatTop ? Math.PI / 6 : 0);
+        const px = x + size * Math.cos(theta);
+        const py = y + size * Math.sin(theta);
+        if (i === 0) {
+            context.moveTo(px, py);
+        } else {
+            context.lineTo(px, py);
+        }
+    }
+    context.closePath();
+    context.stroke();
+}
+
+function drawDiamond(context: CanvasRenderingContext2D, x: number, y: number, size: number) {
+    context.beginPath();
+    context.moveTo(x, y + size / 2);
+    context.lineTo(x + size / 2, y);
+    context.lineTo(x + size, y + size / 2);
+    context.lineTo(x + size / 2, y + size);
+    context.closePath();
+    context.stroke();
 }

--- a/backend/resources/js/Pages/Regions/Create.tsx
+++ b/backend/resources/js/Pages/Regions/Create.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { InputError } from '@/components/InputError';
+import AiIdeaPanel, { AiIdeaResult } from '@/components/ai/AiIdeaPanel';
 
 type DungeonMasterOption = {
     id: number;
@@ -79,116 +80,148 @@ export default function RegionCreate({ group, worlds, defaults, dungeonMasters }
                 </p>
             </div>
 
-            <form onSubmit={submit} className="space-y-6">
-                <div className="space-y-2">
-                    <Label htmlFor="name">Region name</Label>
-                    <Input
-                        id="name"
-                        value={data.name}
-                        onChange={(event) => setData('name', event.target.value)}
-                        required
-                        autoFocus
-                    />
-                    <InputError message={errors.name} />
-                </div>
-
-                <div className="space-y-2">
-                    <Label htmlFor="summary">Summary</Label>
-                    <Input
-                        id="summary"
-                        value={data.summary}
-                        onChange={(event) => setData('summary', event.target.value)}
-                        placeholder="Shifting desert of clockwork ruins"
-                    />
-                    <InputError message={errors.summary} />
-                </div>
-
-                <div className="space-y-2">
-                    <Label htmlFor="description">Notes</Label>
-                    <textarea
-                        id="description"
-                        value={data.description}
-                        onChange={(event) => setData('description', event.target.value)}
-                        className="min-h-[120px] w-full rounded-md border border-zinc-800 bg-zinc-950/70 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
-                    />
-                    <InputError message={errors.description} />
-                </div>
-
-                <div className="space-y-2">
-                    <Label htmlFor="world_id">World</Label>
-                    <select
-                        id="world_id"
-                        value={data.world_id}
-                        onChange={(event) => handleWorldChange(event.target.value)}
-                        className="w-full rounded-md border border-zinc-800 bg-zinc-950/70 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
-                        required
-                    >
-                        <option value="" disabled>
-                            Select a world
-                        </option>
-                        {worlds.map((world) => (
-                            <option key={world.id} value={world.id}>
-                                {world.name}
-                            </option>
-                        ))}
-                    </select>
-                    <InputError message={errors.world_id} />
-                </div>
-
-                <div className="grid gap-6 sm:grid-cols-2">
+            <div className="grid gap-8 lg:grid-cols-[1.8fr_1fr]">
+                <form onSubmit={submit} className="space-y-6">
                     <div className="space-y-2">
-                        <Label htmlFor="dungeon_master_id">Dungeon master</Label>
+                        <Label htmlFor="name">Region name</Label>
+                        <Input
+                            id="name"
+                            value={data.name}
+                            onChange={(event) => setData('name', event.target.value)}
+                            required
+                            autoFocus
+                        />
+                        <InputError message={errors.name} />
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="summary">Summary</Label>
+                        <Input
+                            id="summary"
+                            value={data.summary}
+                            onChange={(event) => setData('summary', event.target.value)}
+                            placeholder="Shifting desert of clockwork ruins"
+                        />
+                        <InputError message={errors.summary} />
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="description">Notes</Label>
+                        <textarea
+                            id="description"
+                            value={data.description}
+                            onChange={(event) => setData('description', event.target.value)}
+                            className="min-h-[120px] w-full rounded-md border border-zinc-800 bg-zinc-950/70 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        />
+                        <InputError message={errors.description} />
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="world_id">World</Label>
                         <select
-                            id="dungeon_master_id"
-                            value={data.dungeon_master_id}
-                            onChange={(event) => setData('dungeon_master_id', event.target.value)}
+                            id="world_id"
+                            value={data.world_id}
+                            onChange={(event) => handleWorldChange(event.target.value)}
                             className="w-full rounded-md border border-zinc-800 bg-zinc-950/70 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                            required
                         >
-                            <option value="">Unassigned</option>
-                            {dungeonMasters.map((dm) => (
-                                <option key={dm.id} value={dm.id}>
-                                    {dm.name} · {dm.role.replace('-', ' ')}
+                            <option value="" disabled>
+                                Select a world
+                            </option>
+                            {worlds.map((world) => (
+                                <option key={world.id} value={world.id}>
+                                    {world.name}
                                 </option>
                             ))}
                         </select>
-                        <InputError message={errors.dungeon_master_id} />
+                        <InputError message={errors.world_id} />
+                    </div>
+
+                    <div className="grid gap-6 sm:grid-cols-2">
+                        <div className="space-y-2">
+                            <Label htmlFor="dungeon_master_id">Dungeon master</Label>
+                            <select
+                                id="dungeon_master_id"
+                                value={data.dungeon_master_id}
+                                onChange={(event) => setData('dungeon_master_id', event.target.value)}
+                                className="w-full rounded-md border border-zinc-800 bg-zinc-950/70 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                            >
+                                <option value="">Unassigned</option>
+                                {dungeonMasters.map((dm) => (
+                                    <option key={dm.id} value={dm.id}>
+                                        {dm.name} · {dm.role.replace('-', ' ')}
+                                    </option>
+                                ))}
+                            </select>
+                            <InputError message={errors.dungeon_master_id} />
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label htmlFor="turn_duration_hours">Turn cadence</Label>
+                            <Input
+                                id="turn_duration_hours"
+                                type="number"
+                                min={1}
+                                max={168}
+                                value={data.turn_duration_hours}
+                                onChange={(event) => setData('turn_duration_hours', event.target.value)}
+                            />
+                            <InputError message={errors.turn_duration_hours} />
+                        </div>
                     </div>
 
                     <div className="space-y-2">
-                        <Label htmlFor="turn_duration_hours">Turn cadence</Label>
+                        <Label htmlFor="next_turn_at">Next turn (UTC)</Label>
                         <Input
-                            id="turn_duration_hours"
-                            type="number"
-                            min={1}
-                            max={168}
-                            value={data.turn_duration_hours}
-                            onChange={(event) => setData('turn_duration_hours', event.target.value)}
+                            id="next_turn_at"
+                            type="datetime-local"
+                            value={data.next_turn_at}
+                            onChange={(event) => setData('next_turn_at', event.target.value)}
                         />
-                        <InputError message={errors.turn_duration_hours} />
+                        <InputError message={errors.next_turn_at} />
                     </div>
-                </div>
 
-                <div className="space-y-2">
-                    <Label htmlFor="next_turn_at">Next turn (UTC)</Label>
-                    <Input
-                        id="next_turn_at"
-                        type="datetime-local"
-                        value={data.next_turn_at}
-                        onChange={(event) => setData('next_turn_at', event.target.value)}
-                    />
-                    <InputError message={errors.next_turn_at} />
-                </div>
+                    <div className="flex items-center justify-between">
+                        <Button type="submit" disabled={processing}>
+                            Save region
+                        </Button>
 
-                <div className="flex items-center justify-between">
-                    <Button type="submit" disabled={processing}>
-                        Save region
-                    </Button>
+                        <Link href={route('groups.show', group.id)} className="text-sm text-zinc-400 hover:text-zinc-200">
+                            Cancel
+                        </Link>
+                    </div>
+                </form>
 
-                    <Link href={route('groups.show', group.id)} className="text-sm text-zinc-400 hover:text-zinc-200">
-                        Cancel
-                    </Link>
-                </div>
-            </form>
+                <AiIdeaPanel
+                    domain="region"
+                    title="AI region designer"
+                    description="Generate hazards, plot threads, and fog ideas while you configure assignments."
+                    context={{
+                        group_name: group.name,
+                        world_name: worlds.find((world) => world.id.toString() === data.world_id)?.name,
+                        name: data.name,
+                        summary: data.summary,
+                        description: data.description,
+                        dungeon_master: dungeonMasters.find((dm) => dm.id.toString() === data.dungeon_master_id)?.name,
+                    }}
+                    actions={[
+                        {
+                            label: 'Use summary',
+                            onApply: (result: AiIdeaResult) => {
+                                const structuredSummary = result.structured?.summary;
+                                setData('summary', typeof structuredSummary === 'string' ? structuredSummary : result.text);
+                            },
+                        },
+                        {
+                            label: 'Replace notes',
+                            onApply: (result: AiIdeaResult) => {
+                                const structuredDescription = result.structured?.description;
+                                setData('description', typeof structuredDescription === 'string' ? structuredDescription : result.text);
+                            },
+                        },
+                    ]}
+                />
+            </div>
         </AppLayout>
     );
 }

--- a/backend/resources/js/Pages/Regions/Edit.tsx
+++ b/backend/resources/js/Pages/Regions/Edit.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { InputError } from '@/components/InputError';
+import AiIdeaPanel, { AiIdeaResult } from '@/components/ai/AiIdeaPanel';
 
 type DungeonMasterOption = {
     id: number;
@@ -101,115 +102,147 @@ export default function RegionEdit({ group, region, worlds, dungeonMasters }: Re
                 </p>
             </div>
 
-            <form onSubmit={submit} className="space-y-6">
-                <div className="space-y-2">
-                    <Label htmlFor="name">Region name</Label>
-                    <Input
-                        id="name"
-                        value={data.name}
-                        onChange={(event) => setData('name', event.target.value)}
-                        required
-                        autoFocus
-                    />
-                    <InputError message={errors.name} />
-                </div>
-
-                <div className="space-y-2">
-                    <Label htmlFor="summary">Summary</Label>
-                    <Input
-                        id="summary"
-                        value={data.summary}
-                        onChange={(event) => setData('summary', event.target.value)}
-                    />
-                    <InputError message={errors.summary} />
-                </div>
-
-                <div className="space-y-2">
-                    <Label htmlFor="description">Notes</Label>
-                    <textarea
-                        id="description"
-                        value={data.description}
-                        onChange={(event) => setData('description', event.target.value)}
-                        className="min-h-[120px] w-full rounded-md border border-zinc-800 bg-zinc-950/70 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
-                    />
-                    <InputError message={errors.description} />
-                </div>
-
-                <div className="space-y-2">
-                    <Label htmlFor="world_id">World</Label>
-                    <select
-                        id="world_id"
-                        value={data.world_id}
-                        onChange={(event) => handleWorldChange(event.target.value)}
-                        className="w-full rounded-md border border-zinc-800 bg-zinc-950/70 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
-                        required
-                    >
-                        <option value="" disabled>
-                            Select a world
-                        </option>
-                        {worlds.map((world) => (
-                            <option key={world.id} value={world.id}>
-                                {world.name}
-                            </option>
-                        ))}
-                    </select>
-                    <InputError message={errors.world_id} />
-                </div>
-
-                <div className="grid gap-6 sm:grid-cols-2">
+            <div className="grid gap-8 lg:grid-cols-[1.8fr_1fr]">
+                <form onSubmit={submit} className="space-y-6">
                     <div className="space-y-2">
-                        <Label htmlFor="dungeon_master_id">Dungeon master</Label>
+                        <Label htmlFor="name">Region name</Label>
+                        <Input
+                            id="name"
+                            value={data.name}
+                            onChange={(event) => setData('name', event.target.value)}
+                            required
+                            autoFocus
+                        />
+                        <InputError message={errors.name} />
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="summary">Summary</Label>
+                        <Input
+                            id="summary"
+                            value={data.summary}
+                            onChange={(event) => setData('summary', event.target.value)}
+                        />
+                        <InputError message={errors.summary} />
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="description">Notes</Label>
+                        <textarea
+                            id="description"
+                            value={data.description}
+                            onChange={(event) => setData('description', event.target.value)}
+                            className="min-h-[120px] w-full rounded-md border border-zinc-800 bg-zinc-950/70 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        />
+                        <InputError message={errors.description} />
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="world_id">World</Label>
                         <select
-                            id="dungeon_master_id"
-                            value={data.dungeon_master_id}
-                            onChange={(event) => setData('dungeon_master_id', event.target.value)}
+                            id="world_id"
+                            value={data.world_id}
+                            onChange={(event) => handleWorldChange(event.target.value)}
                             className="w-full rounded-md border border-zinc-800 bg-zinc-950/70 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                            required
                         >
-                            <option value="">Unassigned</option>
-                            {dungeonMasters.map((dm) => (
-                                <option key={dm.id} value={dm.id}>
-                                    {dm.name} · {dm.role.replace('-', ' ')}
+                            <option value="" disabled>
+                                Select a world
+                            </option>
+                            {worlds.map((world) => (
+                                <option key={world.id} value={world.id}>
+                                    {world.name}
                                 </option>
                             ))}
                         </select>
-                        <InputError message={errors.dungeon_master_id} />
+                        <InputError message={errors.world_id} />
+                    </div>
+
+                    <div className="grid gap-6 sm:grid-cols-2">
+                        <div className="space-y-2">
+                            <Label htmlFor="dungeon_master_id">Dungeon master</Label>
+                            <select
+                                id="dungeon_master_id"
+                                value={data.dungeon_master_id}
+                                onChange={(event) => setData('dungeon_master_id', event.target.value)}
+                                className="w-full rounded-md border border-zinc-800 bg-zinc-950/70 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                            >
+                                <option value="">Unassigned</option>
+                                {dungeonMasters.map((dm) => (
+                                    <option key={dm.id} value={dm.id}>
+                                        {dm.name} · {dm.role.replace('-', ' ')}
+                                    </option>
+                                ))}
+                            </select>
+                            <InputError message={errors.dungeon_master_id} />
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label htmlFor="turn_duration_hours">Turn cadence</Label>
+                            <Input
+                                id="turn_duration_hours"
+                                type="number"
+                                min={1}
+                                max={168}
+                                value={data.turn_duration_hours}
+                                onChange={(event) => setData('turn_duration_hours', event.target.value)}
+                            />
+                            <InputError message={errors.turn_duration_hours} />
+                        </div>
                     </div>
 
                     <div className="space-y-2">
-                        <Label htmlFor="turn_duration_hours">Turn cadence</Label>
+                        <Label htmlFor="next_turn_at">Next turn (UTC)</Label>
                         <Input
-                            id="turn_duration_hours"
-                            type="number"
-                            min={1}
-                            max={168}
-                            value={data.turn_duration_hours}
-                            onChange={(event) => setData('turn_duration_hours', event.target.value)}
+                            id="next_turn_at"
+                            type="datetime-local"
+                            value={data.next_turn_at}
+                            onChange={(event) => setData('next_turn_at', event.target.value)}
                         />
-                        <InputError message={errors.turn_duration_hours} />
+                        <InputError message={errors.next_turn_at} />
                     </div>
-                </div>
 
-                <div className="space-y-2">
-                    <Label htmlFor="next_turn_at">Next turn (UTC)</Label>
-                    <Input
-                        id="next_turn_at"
-                        type="datetime-local"
-                        value={data.next_turn_at}
-                        onChange={(event) => setData('next_turn_at', event.target.value)}
-                    />
-                    <InputError message={errors.next_turn_at} />
-                </div>
+                    <div className="flex items-center justify-between">
+                        <Button type="submit" disabled={processing}>
+                            Save configuration
+                        </Button>
 
-                <div className="flex items-center justify-between">
-                    <Button type="submit" disabled={processing}>
-                        Save configuration
-                    </Button>
+                        <Link href={route('groups.show', group.id)} className="text-sm text-zinc-400 hover:text-zinc-200">
+                            Back to group
+                        </Link>
+                    </div>
+                </form>
 
-                    <Link href={route('groups.show', group.id)} className="text-sm text-zinc-400 hover:text-zinc-200">
-                        Back to group
-                    </Link>
-                </div>
-            </form>
+                <AiIdeaPanel
+                    domain="region"
+                    title="Reimagine this realm"
+                    description="Send the latest hooks and have the AI refresh hazards, threads, and art prompts."
+                    context={{
+                        group_name: group.name,
+                        world_name: worlds.find((world) => world.id.toString() === data.world_id)?.name,
+                        name: data.name,
+                        summary: data.summary,
+                        description: data.description,
+                        dungeon_master: dungeonMasters.find((dm) => dm.id.toString() === data.dungeon_master_id)?.name,
+                    }}
+                    actions={[
+                        {
+                            label: 'Update summary',
+                            onApply: (result: AiIdeaResult) => {
+                                const structuredSummary = result.structured?.summary;
+                                setData('summary', typeof structuredSummary === 'string' ? structuredSummary : result.text);
+                            },
+                        },
+                        {
+                            label: 'Refresh notes',
+                            onApply: (result: AiIdeaResult) => {
+                                const structuredDescription = result.structured?.description;
+                                setData('description', typeof structuredDescription === 'string' ? structuredDescription : result.text);
+                            },
+                        },
+                    ]}
+                />
+            </div>
         </AppLayout>
     );
 }

--- a/backend/resources/js/Pages/TileTemplates/Create.tsx
+++ b/backend/resources/js/Pages/TileTemplates/Create.tsx
@@ -1,3 +1,5 @@
+import { ChangeEvent, useMemo, useState } from 'react';
+
 import { Head, Link, useForm } from '@inertiajs/react';
 
 import AppLayout from '@/Layouts/AppLayout';
@@ -5,6 +7,8 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { InputError } from '@/components/InputError';
+import AiIdeaPanel, { AiIdeaResult } from '@/components/ai/AiIdeaPanel';
 
 type TileTemplateCreateProps = {
     group: { id: number; name: string };
@@ -20,6 +24,7 @@ type TileTemplateForm = {
     world_id: number | '';
     image_path: string;
     edge_profile: string;
+    image_upload: File | null;
 };
 
 export default function TileTemplateCreate({ group, worlds }: TileTemplateCreateProps) {
@@ -32,18 +37,47 @@ export default function TileTemplateCreate({ group, worlds }: TileTemplateCreate
         world_id: '',
         image_path: '',
         edge_profile: '',
+        image_upload: null,
     });
+
+    const [preview, setPreview] = useState<string | null>(null);
+
+    const selectedWorldName = useMemo(() => {
+        if (form.data.world_id === '') {
+            return null;
+        }
+
+        const found = worlds.find((world) => world.id === form.data.world_id);
+        return found ? found.name : null;
+    }, [form.data.world_id, worlds]);
 
     const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
-        form.post(route('groups.tile-templates.store', group.id));
+        form.post(route('groups.tile-templates.store', group.id), {
+            forceFormData: true,
+        });
+    };
+
+    const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0] ?? null;
+        form.setData('image_upload', file);
+
+        if (preview) {
+            URL.revokeObjectURL(preview);
+        }
+
+        if (file) {
+            setPreview(URL.createObjectURL(file));
+        } else {
+            setPreview(null);
+        }
     };
 
     return (
         <AppLayout>
             <Head title={`New tile template · ${group.name}`} />
 
-            <div className="mx-auto max-w-3xl">
+            <div className="mx-auto max-w-5xl">
                 <div className="mb-6 flex items-center justify-between">
                     <div>
                         <h1 className="text-2xl font-semibold text-zinc-100">New tile template</h1>
@@ -54,123 +88,182 @@ export default function TileTemplateCreate({ group, worlds }: TileTemplateCreate
                     </Button>
                 </div>
 
-                <form onSubmit={handleSubmit} className="space-y-6">
-                    <div className="space-y-2">
-                        <Label htmlFor="name">Name</Label>
-                        <Input
-                            id="name"
-                            value={form.data.name}
-                            onChange={(event) => form.setData('name', event.target.value)}
-                            placeholder="Luminous grassland"
-                        />
-                        {form.errors.name && <p className="text-sm text-rose-400">{form.errors.name}</p>}
-                    </div>
+                <div className="grid gap-8 lg:grid-cols-[1.8fr_1fr]">
+                    <form onSubmit={handleSubmit} className="space-y-6">
+                        <div className="space-y-2">
+                            <Label htmlFor="name">Name</Label>
+                            <Input
+                                id="name"
+                                value={form.data.name}
+                                onChange={(event) => form.setData('name', event.target.value)}
+                                placeholder="Luminous grassland"
+                            />
+                            <InputError message={form.errors.name} />
+                        </div>
 
-                    <div className="grid gap-4 sm:grid-cols-2">
-                        <div className="space-y-2">
-                            <Label htmlFor="key">Key (optional)</Label>
-                            <Input
-                                id="key"
-                                value={form.data.key}
-                                onChange={(event) => form.setData('key', event.target.value)}
-                                placeholder="grass-basic"
-                            />
-                            {form.errors.key && <p className="text-sm text-rose-400">{form.errors.key}</p>}
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            <div className="space-y-2">
+                                <Label htmlFor="key">Key (optional)</Label>
+                                <Input
+                                    id="key"
+                                    value={form.data.key}
+                                    onChange={(event) => form.setData('key', event.target.value)}
+                                    placeholder="grass-basic"
+                                />
+                                <InputError message={form.errors.key} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="terrain_type">Terrain type</Label>
+                                <Input
+                                    id="terrain_type"
+                                    value={form.data.terrain_type}
+                                    onChange={(event) => form.setData('terrain_type', event.target.value)}
+                                    placeholder="grassland"
+                                />
+                                <InputError message={form.errors.terrain_type} />
+                            </div>
                         </div>
-                        <div className="space-y-2">
-                            <Label htmlFor="terrain_type">Terrain type</Label>
-                            <Input
-                                id="terrain_type"
-                                value={form.data.terrain_type}
-                                onChange={(event) => form.setData('terrain_type', event.target.value)}
-                                placeholder="grassland"
-                            />
-                            {form.errors.terrain_type && <p className="text-sm text-rose-400">{form.errors.terrain_type}</p>}
-                        </div>
-                    </div>
 
-                    <div className="grid gap-4 sm:grid-cols-3">
-                        <div className="space-y-2">
-                            <Label htmlFor="movement_cost">Movement cost</Label>
-                            <Input
-                                id="movement_cost"
-                                type="number"
-                                min={0}
-                                max={20}
-                                value={form.data.movement_cost}
-                                onChange={(event) => form.setData('movement_cost', Number(event.target.value))}
-                            />
-                            {form.errors.movement_cost && <p className="text-sm text-rose-400">{form.errors.movement_cost}</p>}
+                        <div className="grid gap-4 sm:grid-cols-3">
+                            <div className="space-y-2">
+                                <Label htmlFor="movement_cost">Movement cost</Label>
+                                <Input
+                                    id="movement_cost"
+                                    type="number"
+                                    min={0}
+                                    max={20}
+                                    value={form.data.movement_cost}
+                                    onChange={(event) => form.setData('movement_cost', Number(event.target.value))}
+                                />
+                                <InputError message={form.errors.movement_cost} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="defense_bonus">Defense bonus</Label>
+                                <Input
+                                    id="defense_bonus"
+                                    type="number"
+                                    min={0}
+                                    max={20}
+                                    value={form.data.defense_bonus}
+                                    onChange={(event) => form.setData('defense_bonus', Number(event.target.value))}
+                                />
+                                <InputError message={form.errors.defense_bonus} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="world_id">World scope</Label>
+                                <select
+                                    id="world_id"
+                                    value={form.data.world_id}
+                                    onChange={(event) =>
+                                        form.setData('world_id', event.target.value === '' ? '' : Number(event.target.value))
+                                    }
+                                    className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                                >
+                                    <option value="">Shared across worlds</option>
+                                    {worlds.map((world) => (
+                                        <option key={world.id} value={world.id}>
+                                            {world.name}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={form.errors.world_id} />
+                            </div>
                         </div>
-                        <div className="space-y-2">
-                            <Label htmlFor="defense_bonus">Defense bonus</Label>
-                            <Input
-                                id="defense_bonus"
-                                type="number"
-                                min={0}
-                                max={20}
-                                value={form.data.defense_bonus}
-                                onChange={(event) => form.setData('defense_bonus', Number(event.target.value))}
-                            />
-                            {form.errors.defense_bonus && <p className="text-sm text-rose-400">{form.errors.defense_bonus}</p>}
+
+                        <div className="grid gap-4 md:grid-cols-2">
+                            <div className="space-y-2">
+                                <Label htmlFor="image_upload">Upload tile art (optional)</Label>
+                                <Input id="image_upload" type="file" accept="image/png,image/jpeg" onChange={handleFileChange} />
+                                <InputError message={form.errors.image_upload as string} />
+                                <p className="text-xs text-zinc-500">PNG or JPG up to 5MB. We will store it under the group&apos;s public tiles.</p>
+                                {preview && (
+                                    <div className="mt-3 overflow-hidden rounded-lg border border-zinc-700/60 bg-zinc-900/60 p-2">
+                                        <img src={preview} alt="Tile preview" className="mx-auto h-40 w-40 object-cover" />
+                                    </div>
+                                )}
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="image_path">Existing asset path (optional)</Label>
+                                <Input
+                                    id="image_path"
+                                    value={form.data.image_path}
+                                    onChange={(event) => form.setData('image_path', event.target.value)}
+                                    placeholder="tiles/grassland.png"
+                                />
+                                <InputError message={form.errors.image_path} />
+                                <p className="text-xs text-zinc-500">If you host art elsewhere, drop in a relative or CDN path.</p>
+                            </div>
                         </div>
+
                         <div className="space-y-2">
-                            <Label htmlFor="world_id">World scope</Label>
-                            <select
-                                id="world_id"
-                                value={form.data.world_id}
-                                onChange={(event) =>
-                                    form.setData('world_id', event.target.value === '' ? '' : Number(event.target.value))
-                                }
-                                className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                            <Label htmlFor="edge_profile">Edge profile JSON (optional)</Label>
+                            <Textarea
+                                id="edge_profile"
+                                value={form.data.edge_profile}
+                                onChange={(event) => form.setData('edge_profile', event.target.value)}
+                                placeholder='{"north":"road","south":"road"}'
+                            />
+                            <InputError message={form.errors.edge_profile} />
+                            <p className="text-xs text-zinc-500">Describe how this tile links to neighbors: road, river, wall, portal…</p>
+                        </div>
+
+                        <div className="flex items-center gap-3">
+                            <Button type="submit" disabled={form.processing}>
+                                Save template
+                            </Button>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                disabled={form.processing}
+                                onClick={() => {
+                                    form.reset();
+                                    setPreview(null);
+                                }}
                             >
-                                <option value="">Shared across worlds</option>
-                                {worlds.map((world) => (
-                                    <option key={world.id} value={world.id}>
-                                        {world.name}
-                                    </option>
-                                ))}
-                            </select>
-                            {form.errors.world_id && <p className="text-sm text-rose-400">{form.errors.world_id}</p>}
+                                Reset
+                            </Button>
                         </div>
-                    </div>
+                    </form>
 
-                    <div className="space-y-2">
-                        <Label htmlFor="image_path">Image path (optional)</Label>
-                        <Input
-                            id="image_path"
-                            value={form.data.image_path}
-                            onChange={(event) => form.setData('image_path', event.target.value)}
-                            placeholder="tiles/grassland.png"
-                        />
-                        {form.errors.image_path && <p className="text-sm text-rose-400">{form.errors.image_path}</p>}
-                    </div>
-
-                    <div className="space-y-2">
-                        <Label htmlFor="edge_profile">Edge profile JSON (optional)</Label>
-                        <Textarea
-                            id="edge_profile"
-                            value={form.data.edge_profile}
-                            onChange={(event) => form.setData('edge_profile', event.target.value)}
-                            placeholder='{"north":"road","south":"road"}'
-                        />
-                        {form.errors.edge_profile && <p className="text-sm text-rose-400">{form.errors.edge_profile}</p>}
-                    </div>
-
-                    <div className="flex items-center gap-3">
-                        <Button type="submit" disabled={form.processing}>
-                            Save template
-                        </Button>
-                        <Button
-                            type="button"
-                            variant="ghost"
-                            disabled={form.processing}
-                            onClick={() => form.reset()}
-                        >
-                            Reset
-                        </Button>
-                    </div>
-                </form>
+                    <AiIdeaPanel
+                        domain="tile_template"
+                        title="AI tile architect"
+                        description="Seed terrain ideas, connection hints, and art prompts without leaving the editor."
+                        context={{
+                            group_name: group.name,
+                            world_name: selectedWorldName,
+                            terrain_type: form.data.terrain_type,
+                            movement_cost: form.data.movement_cost,
+                            defense_bonus: form.data.defense_bonus,
+                            description: form.data.edge_profile,
+                        }}
+                        actions={[
+                            {
+                                label: 'Apply terrain stats',
+                                onApply: (result: AiIdeaResult) => {
+                                    const { structured } = result;
+                                    if (structured) {
+                                        if (typeof structured.terrain_type === 'string') {
+                                            form.setData('terrain_type', structured.terrain_type);
+                                        }
+                                        if (typeof structured.movement_cost === 'number') {
+                                            form.setData('movement_cost', structured.movement_cost);
+                                        }
+                                        if (typeof structured.defense_bonus === 'number') {
+                                            form.setData('defense_bonus', structured.defense_bonus);
+                                        }
+                                        if (structured.edge_profile) {
+                                            form.setData('edge_profile', JSON.stringify(structured.edge_profile, null, 2));
+                                        }
+                                        if (typeof structured.description === 'string' && !form.data.image_path) {
+                                            form.setData('key', structured.description.slice(0, 32).toLowerCase().replace(/[^a-z0-9-]+/g, '-'));
+                                        }
+                                    }
+                                },
+                            },
+                        ]}
+                    />
+                </div>
             </div>
         </AppLayout>
     );

--- a/backend/resources/js/Pages/TileTemplates/Edit.tsx
+++ b/backend/resources/js/Pages/TileTemplates/Edit.tsx
@@ -1,3 +1,5 @@
+import { ChangeEvent, useMemo, useState } from 'react';
+
 import { Head, Link, useForm } from '@inertiajs/react';
 
 import AppLayout from '@/Layouts/AppLayout';
@@ -5,6 +7,8 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { InputError } from '@/components/InputError';
+import AiIdeaPanel, { AiIdeaResult } from '@/components/ai/AiIdeaPanel';
 
 type TileTemplateEditProps = {
     group: { id: number; name: string };
@@ -24,13 +28,14 @@ type TileTemplateEditProps = {
 
 type TileTemplateForm = {
     name: string;
-    key: string | null;
+    key: string;
     terrain_type: string;
     movement_cost: number | string;
     defense_bonus: number | string;
     world_id: number | '';
     image_path: string;
     edge_profile: string;
+    image_upload: File | null;
 };
 
 export default function TileTemplateEdit({ group, worlds, template }: TileTemplateEditProps) {
@@ -43,140 +48,234 @@ export default function TileTemplateEdit({ group, worlds, template }: TileTempla
         world_id: template.world_id ?? '',
         image_path: template.image_path ?? '',
         edge_profile: template.edge_profile ? JSON.stringify(template.edge_profile, null, 2) : '',
+        image_upload: null,
     });
+
+    const [preview, setPreview] = useState<string | null>(null);
+
+    const selectedWorldName = useMemo(() => {
+        if (form.data.world_id === '') {
+            return null;
+        }
+
+        const found = worlds.find((world) => world.id === form.data.world_id);
+        return found ? found.name : null;
+    }, [form.data.world_id, worlds]);
+
+    const existingImage = useMemo(() => {
+        if (preview) {
+            return preview;
+        }
+
+        if (form.data.image_path) {
+            return form.data.image_path.startsWith('http')
+                ? form.data.image_path
+                : `/storage/${form.data.image_path}`;
+        }
+
+        return null;
+    }, [form.data.image_path, preview]);
 
     const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
-        form.put(route('groups.tile-templates.update', [group.id, template.id]));
+        form.put(route('groups.tile-templates.update', [group.id, template.id]), {
+            forceFormData: true,
+        });
+    };
+
+    const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0] ?? null;
+        form.setData('image_upload', file);
+
+        if (preview) {
+            URL.revokeObjectURL(preview);
+        }
+
+        if (file) {
+            setPreview(URL.createObjectURL(file));
+        } else {
+            setPreview(null);
+        }
     };
 
     return (
         <AppLayout>
             <Head title={`Edit ${template.name} · ${group.name}`} />
 
-            <div className="mx-auto max-w-3xl">
+            <div className="mx-auto max-w-5xl">
                 <div className="mb-6 flex items-center justify-between">
                     <div>
                         <h1 className="text-2xl font-semibold text-zinc-100">Edit tile template</h1>
-                        <p className="text-sm text-zinc-400">Tune how this tile behaves across {group.name}&apos;s boards.</p>
+                        <p className="text-sm text-zinc-400">Adjust stats, world scope, or map art for this reusable tile.</p>
                     </div>
                     <Button asChild variant="outline" className="border-zinc-700 text-sm">
                         <Link href={route('groups.show', group.id)}>Back to group</Link>
                     </Button>
                 </div>
 
-                <form onSubmit={handleSubmit} className="space-y-6">
-                    <div className="space-y-2">
-                        <Label htmlFor="name">Name</Label>
-                        <Input
-                            id="name"
-                            value={form.data.name}
-                            onChange={(event) => form.setData('name', event.target.value)}
-                        />
-                        {form.errors.name && <p className="text-sm text-rose-400">{form.errors.name}</p>}
-                    </div>
+                <div className="grid gap-8 lg:grid-cols-[1.8fr_1fr]">
+                    <form onSubmit={handleSubmit} className="space-y-6">
+                        <div className="space-y-2">
+                            <Label htmlFor="name">Name</Label>
+                            <Input id="name" value={form.data.name} onChange={(event) => form.setData('name', event.target.value)} />
+                            <InputError message={form.errors.name} />
+                        </div>
 
-                    <div className="grid gap-4 sm:grid-cols-2">
-                        <div className="space-y-2">
-                            <Label htmlFor="key">Key (optional)</Label>
-                            <Input
-                                id="key"
-                                value={form.data.key ?? ''}
-                                onChange={(event) => form.setData('key', event.target.value)}
-                            />
-                            {form.errors.key && <p className="text-sm text-rose-400">{form.errors.key}</p>}
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            <div className="space-y-2">
+                                <Label htmlFor="key">Key (optional)</Label>
+                                <Input
+                                    id="key"
+                                    value={form.data.key}
+                                    onChange={(event) => form.setData('key', event.target.value)}
+                                />
+                                <InputError message={form.errors.key} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="terrain_type">Terrain type</Label>
+                                <Input
+                                    id="terrain_type"
+                                    value={form.data.terrain_type}
+                                    onChange={(event) => form.setData('terrain_type', event.target.value)}
+                                />
+                                <InputError message={form.errors.terrain_type} />
+                            </div>
                         </div>
-                        <div className="space-y-2">
-                            <Label htmlFor="terrain_type">Terrain type</Label>
-                            <Input
-                                id="terrain_type"
-                                value={form.data.terrain_type}
-                                onChange={(event) => form.setData('terrain_type', event.target.value)}
-                            />
-                            {form.errors.terrain_type && <p className="text-sm text-rose-400">{form.errors.terrain_type}</p>}
-                        </div>
-                    </div>
 
-                    <div className="grid gap-4 sm:grid-cols-3">
-                        <div className="space-y-2">
-                            <Label htmlFor="movement_cost">Movement cost</Label>
-                            <Input
-                                id="movement_cost"
-                                type="number"
-                                min={0}
-                                max={20}
-                                value={form.data.movement_cost}
-                                onChange={(event) => form.setData('movement_cost', Number(event.target.value))}
-                            />
-                            {form.errors.movement_cost && <p className="text-sm text-rose-400">{form.errors.movement_cost}</p>}
+                        <div className="grid gap-4 sm:grid-cols-3">
+                            <div className="space-y-2">
+                                <Label htmlFor="movement_cost">Movement cost</Label>
+                                <Input
+                                    id="movement_cost"
+                                    type="number"
+                                    min={0}
+                                    max={20}
+                                    value={form.data.movement_cost}
+                                    onChange={(event) => form.setData('movement_cost', Number(event.target.value))}
+                                />
+                                <InputError message={form.errors.movement_cost} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="defense_bonus">Defense bonus</Label>
+                                <Input
+                                    id="defense_bonus"
+                                    type="number"
+                                    min={0}
+                                    max={20}
+                                    value={form.data.defense_bonus}
+                                    onChange={(event) => form.setData('defense_bonus', Number(event.target.value))}
+                                />
+                                <InputError message={form.errors.defense_bonus} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="world_id">World scope</Label>
+                                <select
+                                    id="world_id"
+                                    value={form.data.world_id}
+                                    onChange={(event) =>
+                                        form.setData('world_id', event.target.value === '' ? '' : Number(event.target.value))
+                                    }
+                                    className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                                >
+                                    <option value="">Shared across worlds</option>
+                                    {worlds.map((world) => (
+                                        <option key={world.id} value={world.id}>
+                                            {world.name}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={form.errors.world_id} />
+                            </div>
                         </div>
-                        <div className="space-y-2">
-                            <Label htmlFor="defense_bonus">Defense bonus</Label>
-                            <Input
-                                id="defense_bonus"
-                                type="number"
-                                min={0}
-                                max={20}
-                                value={form.data.defense_bonus}
-                                onChange={(event) => form.setData('defense_bonus', Number(event.target.value))}
-                            />
-                            {form.errors.defense_bonus && <p className="text-sm text-rose-400">{form.errors.defense_bonus}</p>}
+
+                        <div className="grid gap-4 md:grid-cols-2">
+                            <div className="space-y-2">
+                                <Label htmlFor="image_upload">Upload tile art (optional)</Label>
+                                <Input id="image_upload" type="file" accept="image/png,image/jpeg" onChange={handleFileChange} />
+                                <InputError message={form.errors.image_upload as string} />
+                                <p className="text-xs text-zinc-500">Drop in a new PNG/JPG up to 5MB to replace the current art.</p>
+                                {existingImage && (
+                                    <div className="mt-3 overflow-hidden rounded-lg border border-zinc-700/60 bg-zinc-900/60 p-2">
+                                        <img src={existingImage} alt="Tile preview" className="mx-auto h-40 w-40 object-cover" />
+                                    </div>
+                                )}
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="image_path">Existing asset path (optional)</Label>
+                                <Input
+                                    id="image_path"
+                                    value={form.data.image_path}
+                                    onChange={(event) => form.setData('image_path', event.target.value)}
+                                />
+                                <InputError message={form.errors.image_path} />
+                                <p className="text-xs text-zinc-500">Leave blank if you plan to use the uploaded file above.</p>
+                            </div>
                         </div>
+
                         <div className="space-y-2">
-                            <Label htmlFor="world_id">World scope</Label>
-                            <select
-                                id="world_id"
-                                value={form.data.world_id}
-                                onChange={(event) =>
-                                    form.setData('world_id', event.target.value === '' ? '' : Number(event.target.value))
-                                }
-                                className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none focus:ring-0"
+                            <Label htmlFor="edge_profile">Edge profile JSON (optional)</Label>
+                            <Textarea
+                                id="edge_profile"
+                                value={form.data.edge_profile}
+                                onChange={(event) => form.setData('edge_profile', event.target.value)}
+                            />
+                            <InputError message={form.errors.edge_profile} />
+                        </div>
+
+                        <div className="flex items-center gap-3">
+                            <Button type="submit" disabled={form.processing}>
+                                Update template
+                            </Button>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                disabled={form.processing}
+                                onClick={() => {
+                                    form.reset();
+                                    setPreview(null);
+                                }}
                             >
-                                <option value="">Shared across worlds</option>
-                                {worlds.map((world) => (
-                                    <option key={world.id} value={world.id}>
-                                        {world.name}
-                                    </option>
-                                ))}
-                            </select>
-                            {form.errors.world_id && <p className="text-sm text-rose-400">{form.errors.world_id}</p>}
+                                Reset changes
+                            </Button>
                         </div>
-                    </div>
+                    </form>
 
-                    <div className="space-y-2">
-                        <Label htmlFor="image_path">Image path (optional)</Label>
-                        <Input
-                            id="image_path"
-                            value={form.data.image_path}
-                            onChange={(event) => form.setData('image_path', event.target.value)}
-                        />
-                        {form.errors.image_path && <p className="text-sm text-rose-400">{form.errors.image_path}</p>}
-                    </div>
-
-                    <div className="space-y-2">
-                        <Label htmlFor="edge_profile">Edge profile JSON (optional)</Label>
-                        <Textarea
-                            id="edge_profile"
-                            value={form.data.edge_profile}
-                            onChange={(event) => form.setData('edge_profile', event.target.value)}
-                        />
-                        {form.errors.edge_profile && <p className="text-sm text-rose-400">{form.errors.edge_profile}</p>}
-                    </div>
-
-                    <div className="flex items-center gap-3">
-                        <Button type="submit" disabled={form.processing}>
-                            Update template
-                        </Button>
-                        <Button
-                            type="button"
-                            variant="ghost"
-                            disabled={form.processing}
-                            onClick={() => form.reset()}
-                        >
-                            Reset changes
-                        </Button>
-                    </div>
-                </form>
+                    <AiIdeaPanel
+                        domain="tile_template"
+                        title="Revise with AI"
+                        description="Let the assistant tune stats and edges for this tile while you focus on the map."
+                        context={{
+                            group_name: group.name,
+                            world_name: selectedWorldName,
+                            terrain_type: form.data.terrain_type,
+                            movement_cost: form.data.movement_cost,
+                            defense_bonus: form.data.defense_bonus,
+                            description: form.data.edge_profile,
+                        }}
+                        actions={[
+                            {
+                                label: 'Apply suggestions',
+                                onApply: (result: AiIdeaResult) => {
+                                    const { structured } = result;
+                                    if (structured) {
+                                        if (typeof structured.terrain_type === 'string') {
+                                            form.setData('terrain_type', structured.terrain_type);
+                                        }
+                                        if (typeof structured.movement_cost === 'number') {
+                                            form.setData('movement_cost', structured.movement_cost);
+                                        }
+                                        if (typeof structured.defense_bonus === 'number') {
+                                            form.setData('defense_bonus', structured.defense_bonus);
+                                        }
+                                        if (structured.edge_profile) {
+                                            form.setData('edge_profile', JSON.stringify(structured.edge_profile, null, 2));
+                                        }
+                                    }
+                                },
+                            },
+                        ]}
+                    />
+                </div>
             </div>
         </AppLayout>
     );

--- a/backend/resources/js/Pages/Worlds/Create.tsx
+++ b/backend/resources/js/Pages/Worlds/Create.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { InputError } from '@/components/InputError';
+import AiIdeaPanel, { AiIdeaResult } from '@/components/ai/AiIdeaPanel';
 
 type WorldCreateProps = {
     group: {
@@ -49,65 +50,96 @@ export default function WorldCreate({ group, defaults }: WorldCreateProps) {
                 </p>
             </div>
 
-            <form onSubmit={submit} className="space-y-6">
-                <div className="space-y-2">
-                    <Label htmlFor="name">World name</Label>
-                    <Input
-                        id="name"
-                        value={data.name}
-                        onChange={(event) => setData('name', event.target.value)}
-                        required
-                        autoFocus
-                    />
-                    <InputError message={errors.name} />
-                </div>
+            <div className="grid gap-8 lg:grid-cols-[1.8fr_1fr]">
+                <form onSubmit={submit} className="space-y-6">
+                    <div className="space-y-2">
+                        <Label htmlFor="name">World name</Label>
+                        <Input
+                            id="name"
+                            value={data.name}
+                            onChange={(event) => setData('name', event.target.value)}
+                            required
+                            autoFocus
+                        />
+                        <InputError message={errors.name} />
+                    </div>
 
-                <div className="space-y-2">
-                    <Label htmlFor="summary">Summary</Label>
-                    <Input
-                        id="summary"
-                        value={data.summary}
-                        onChange={(event) => setData('summary', event.target.value)}
-                        placeholder="Shared dreamscape of the Sapphire Archive"
-                    />
-                    <InputError message={errors.summary} />
-                </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="summary">Summary</Label>
+                        <Input
+                            id="summary"
+                            value={data.summary}
+                            onChange={(event) => setData('summary', event.target.value)}
+                            placeholder="Shared dreamscape of the Sapphire Archive"
+                        />
+                        <InputError message={errors.summary} />
+                    </div>
 
-                <div className="space-y-2">
-                    <Label htmlFor="description">Lore notes</Label>
-                    <textarea
-                        id="description"
-                        value={data.description}
-                        onChange={(event) => setData('description', event.target.value)}
-                        className="min-h-[140px] w-full rounded-md border border-zinc-800 bg-zinc-950/70 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
-                    />
-                    <InputError message={errors.description} />
-                </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="description">Lore notes</Label>
+                        <textarea
+                            id="description"
+                            value={data.description}
+                            onChange={(event) => setData('description', event.target.value)}
+                            className="min-h-[140px] w-full rounded-md border border-zinc-800 bg-zinc-950/70 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        />
+                        <InputError message={errors.description} />
+                    </div>
 
-                <div className="space-y-2">
-                    <Label htmlFor="default_turn_duration_hours">Default turn cadence (hours)</Label>
-                    <Input
-                        id="default_turn_duration_hours"
-                        type="number"
-                        min={1}
-                        max={168}
-                        value={data.default_turn_duration_hours}
-                        onChange={(event) => setData('default_turn_duration_hours', Number(event.target.value))}
-                        required
-                    />
-                    <InputError message={errors.default_turn_duration_hours} />
-                </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="default_turn_duration_hours">Default turn cadence (hours)</Label>
+                        <Input
+                            id="default_turn_duration_hours"
+                            type="number"
+                            min={1}
+                            max={168}
+                            value={data.default_turn_duration_hours}
+                            onChange={(event) => setData('default_turn_duration_hours', Number(event.target.value))}
+                            required
+                        />
+                        <InputError message={errors.default_turn_duration_hours} />
+                    </div>
 
-                <div className="flex items-center justify-between">
-                    <Button type="submit" disabled={processing}>
-                        Create world
-                    </Button>
+                    <div className="flex items-center justify-between">
+                        <Button type="submit" disabled={processing}>
+                            Create world
+                        </Button>
 
-                    <Link href={route('groups.show', group.id)} className="text-sm text-zinc-400 hover:text-zinc-200">
-                        Cancel
-                    </Link>
-                </div>
-            </form>
+                        <Link href={route('groups.show', group.id)} className="text-sm text-zinc-400 hover:text-zinc-200">
+                            Cancel
+                        </Link>
+                    </div>
+                </form>
+
+                <AiIdeaPanel
+                    domain="world"
+                    title="Need a spark?"
+                    description="Let the AI sketch lore, turn hooks, and art prompts from just a few words."
+                    context={{
+                        group_name: group.name,
+                        name: data.name,
+                        summary: data.summary,
+                        description: data.description,
+                        turn_duration: data.default_turn_duration_hours,
+                    }}
+                    actions={[
+                        {
+                            label: 'Use as summary',
+                            onApply: (result: AiIdeaResult) => {
+                                const structuredSummary = result.structured?.summary;
+                                setData('summary', typeof structuredSummary === 'string' ? structuredSummary : result.text);
+                            },
+                        },
+                        {
+                            label: 'Fill lore notes',
+                            onApply: (result: AiIdeaResult) => {
+                                const structuredDescription = result.structured?.description;
+                                setData('description', typeof structuredDescription === 'string' ? structuredDescription : result.text);
+                            },
+                        },
+                    ]}
+                />
+            </div>
         </AppLayout>
     );
 }

--- a/backend/resources/js/Pages/Worlds/Edit.tsx
+++ b/backend/resources/js/Pages/Worlds/Edit.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { InputError } from '@/components/InputError';
+import AiIdeaPanel, { AiIdeaResult } from '@/components/ai/AiIdeaPanel';
 
 type WorldPayload = {
     id: number;
@@ -55,63 +56,94 @@ export default function WorldEdit({ group, world }: WorldEditProps) {
                 </p>
             </div>
 
-            <form onSubmit={submit} className="space-y-6">
-                <div className="space-y-2">
-                    <Label htmlFor="name">World name</Label>
-                    <Input
-                        id="name"
-                        value={data.name}
-                        onChange={(event) => setData('name', event.target.value)}
-                        required
-                    />
-                    <InputError message={errors.name} />
-                </div>
+            <div className="grid gap-8 lg:grid-cols-[1.8fr_1fr]">
+                <form onSubmit={submit} className="space-y-6">
+                    <div className="space-y-2">
+                        <Label htmlFor="name">World name</Label>
+                        <Input
+                            id="name"
+                            value={data.name}
+                            onChange={(event) => setData('name', event.target.value)}
+                            required
+                        />
+                        <InputError message={errors.name} />
+                    </div>
 
-                <div className="space-y-2">
-                    <Label htmlFor="summary">Summary</Label>
-                    <Input
-                        id="summary"
-                        value={data.summary}
-                        onChange={(event) => setData('summary', event.target.value)}
-                    />
-                    <InputError message={errors.summary} />
-                </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="summary">Summary</Label>
+                        <Input
+                            id="summary"
+                            value={data.summary}
+                            onChange={(event) => setData('summary', event.target.value)}
+                        />
+                        <InputError message={errors.summary} />
+                    </div>
 
-                <div className="space-y-2">
-                    <Label htmlFor="description">Lore notes</Label>
-                    <textarea
-                        id="description"
-                        value={data.description}
-                        onChange={(event) => setData('description', event.target.value)}
-                        className="min-h-[140px] w-full rounded-md border border-zinc-800 bg-zinc-950/70 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
-                    />
-                    <InputError message={errors.description} />
-                </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="description">Lore notes</Label>
+                        <textarea
+                            id="description"
+                            value={data.description}
+                            onChange={(event) => setData('description', event.target.value)}
+                            className="min-h-[140px] w-full rounded-md border border-zinc-800 bg-zinc-950/70 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                        />
+                        <InputError message={errors.description} />
+                    </div>
 
-                <div className="space-y-2">
-                    <Label htmlFor="default_turn_duration_hours">Default turn cadence (hours)</Label>
-                    <Input
-                        id="default_turn_duration_hours"
-                        type="number"
-                        min={1}
-                        max={168}
-                        value={data.default_turn_duration_hours}
-                        onChange={(event) => setData('default_turn_duration_hours', Number(event.target.value))}
-                        required
-                    />
-                    <InputError message={errors.default_turn_duration_hours} />
-                </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="default_turn_duration_hours">Default turn cadence (hours)</Label>
+                        <Input
+                            id="default_turn_duration_hours"
+                            type="number"
+                            min={1}
+                            max={168}
+                            value={data.default_turn_duration_hours}
+                            onChange={(event) => setData('default_turn_duration_hours', Number(event.target.value))}
+                            required
+                        />
+                        <InputError message={errors.default_turn_duration_hours} />
+                    </div>
 
-                <div className="flex items-center justify-between">
-                    <Button type="submit" disabled={processing}>
-                        Save world
-                    </Button>
+                    <div className="flex items-center justify-between">
+                        <Button type="submit" disabled={processing}>
+                            Save world
+                        </Button>
 
-                    <Link href={route('groups.show', group.id)} className="text-sm text-zinc-400 hover:text-zinc-200">
-                        Back to group
-                    </Link>
-                </div>
-            </form>
+                        <Link href={route('groups.show', group.id)} className="text-sm text-zinc-400 hover:text-zinc-200">
+                            Back to group
+                        </Link>
+                    </div>
+                </form>
+
+                <AiIdeaPanel
+                    domain="world"
+                    title="Fresh inspiration"
+                    description="Bring in short prompts or player feedback and let the AI refill your summary and lore."
+                    context={{
+                        group_name: group.name,
+                        name: data.name,
+                        summary: data.summary,
+                        description: data.description,
+                        turn_duration: data.default_turn_duration_hours,
+                    }}
+                    actions={[
+                        {
+                            label: 'Apply summary',
+                            onApply: (result: AiIdeaResult) => {
+                                const structuredSummary = result.structured?.summary;
+                                setData('summary', typeof structuredSummary === 'string' ? structuredSummary : result.text);
+                            },
+                        },
+                        {
+                            label: 'Refresh lore notes',
+                            onApply: (result: AiIdeaResult) => {
+                                const structuredDescription = result.structured?.description;
+                                setData('description', typeof structuredDescription === 'string' ? structuredDescription : result.text);
+                            },
+                        },
+                    ]}
+                />
+            </div>
         </AppLayout>
     );
 }

--- a/backend/resources/js/components/ai/AiIdeaPanel.tsx
+++ b/backend/resources/js/components/ai/AiIdeaPanel.tsx
@@ -1,0 +1,221 @@
+import { useState } from 'react';
+
+import { usePage } from '@inertiajs/react';
+
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+
+export type AiIdeaResult = {
+    text: string;
+    structured?: Record<string, unknown> | null;
+};
+
+export type AiIdeaAction = {
+    label: string;
+    onApply: (result: AiIdeaResult) => void;
+};
+
+type AiIdeaPanelProps = {
+    domain: string;
+    title: string;
+    description?: string;
+    placeholder?: string;
+    context?: Record<string, unknown>;
+    className?: string;
+    actions?: AiIdeaAction[];
+    defaultPrompt?: string;
+};
+
+type PageProps = {
+    csrf_token?: string;
+};
+
+export function AiIdeaPanel({
+    domain,
+    title,
+    description,
+    placeholder,
+    context,
+    className,
+    actions = [],
+    defaultPrompt = '',
+}: AiIdeaPanelProps) {
+    const { props } = usePage<PageProps>();
+    const csrfToken = props.csrf_token ?? document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
+
+    const [prompt, setPrompt] = useState(defaultPrompt);
+    const [result, setResult] = useState<AiIdeaResult | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const handleGenerate = async () => {
+        setLoading(true);
+        setError(null);
+
+        try {
+            const response = await fetch(route('ai.assist'), {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': csrfToken,
+                    Accept: 'application/json',
+                },
+                body: JSON.stringify({
+                    domain,
+                    prompt,
+                    context,
+                }),
+            });
+
+            if (!response.ok) {
+                throw new Error('AI assistant is unavailable right now.');
+            }
+
+            const data = (await response.json()) as { idea: string; structured?: Record<string, unknown> | null };
+            setResult({ text: data.idea, structured: data.structured ?? null });
+        } catch (exception) {
+            setError(exception instanceof Error ? exception.message : 'Failed to contact the AI assistant.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleCopy = (value: string) => {
+        navigator.clipboard?.writeText(value).catch(() => {
+            setError('Copy to clipboard failed—select and copy manually.');
+        });
+    };
+
+    return (
+        <section className={cn('space-y-4 rounded-xl border border-indigo-700/40 bg-indigo-950/40 p-6', className)}>
+            <header className="space-y-1">
+                <h2 className="text-lg font-semibold text-indigo-100">{title}</h2>
+                {description && <p className="text-sm text-indigo-200/80">{description}</p>}
+            </header>
+
+            <div className="space-y-2">
+                <label htmlFor={`${domain}-prompt`} className="text-xs uppercase tracking-wide text-indigo-200/70">
+                    Give the AI a nudge (optional)
+                </label>
+                <Textarea
+                    id={`${domain}-prompt`}
+                    value={prompt}
+                    onChange={(event) => setPrompt(event.target.value)}
+                    placeholder={placeholder ?? 'A few mood words, objectives, or constraints...'}
+                    rows={3}
+                    className="border-indigo-700/40 bg-indigo-950/70 text-sm text-indigo-100 placeholder:text-indigo-300/60 focus:border-amber-400 focus:ring-amber-400/40"
+                />
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3">
+                <Button type="button" onClick={handleGenerate} disabled={loading} className="bg-amber-500/20 text-amber-100 hover:bg-amber-500/30">
+                    {loading ? 'Summoning ideas…' : 'Summon AI idea'}
+                </Button>
+                {result && (
+                    <Button
+                        type="button"
+                        variant="outline"
+                        className="border-indigo-500/40 text-indigo-100 hover:bg-indigo-900/40"
+                        onClick={() => handleCopy(result.text)}
+                    >
+                        Copy raw response
+                    </Button>
+                )}
+                {actions.map((action) => (
+                    <Button
+                        key={action.label}
+                        type="button"
+                        variant="outline"
+                        disabled={!result}
+                        className="border-emerald-500/40 text-emerald-100 hover:bg-emerald-500/20 disabled:opacity-60"
+                        onClick={() => result && action.onApply(result)}
+                    >
+                        {action.label}
+                    </Button>
+                ))}
+            </div>
+
+            {error && <p className="text-sm text-rose-300">{error}</p>}
+
+            {result && (
+                <div className="space-y-4 rounded-lg border border-indigo-700/40 bg-indigo-950/60 p-4">
+                    <div>
+                        <h3 className="text-sm font-semibold uppercase tracking-wide text-indigo-200">AI suggestion</h3>
+                        <p className="mt-2 whitespace-pre-line text-sm text-indigo-100/90">{result.text}</p>
+                    </div>
+
+                    {result.structured && (
+                        <div className="space-y-3">
+                            <h4 className="text-xs uppercase tracking-wide text-indigo-200/80">Structured fields</h4>
+                            <div className="space-y-2 text-sm text-indigo-100/90">
+                                {Object.entries(result.structured).map(([key, value]) => (
+                                    <div key={key} className="rounded-md border border-indigo-700/30 bg-indigo-950/80 p-3">
+                                        <div className="flex items-center justify-between gap-4">
+                                            <span className="text-xs uppercase tracking-wide text-indigo-300">{key}</span>
+                                            {typeof value === 'string' && (
+                                                <Button
+                                                    type="button"
+                                                    variant="ghost"
+                                                    size="sm"
+                                                    className="h-7 text-xs text-amber-200 hover:text-amber-100"
+                                                    onClick={() => handleCopy(value)}
+                                                >
+                                                    Copy
+                                                </Button>
+                                            )}
+                                        </div>
+                                        <pre className="mt-2 whitespace-pre-wrap break-words font-sans text-sm leading-5 text-indigo-100/90">
+                                            {formatValue(value)}
+                                        </pre>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+
+                    {result.structured?.image_prompt && typeof result.structured.image_prompt === 'string' && (
+                        <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-100">
+                            <div className="flex items-center justify-between">
+                                <span className="font-semibold">A1111 image prompt</span>
+                                <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-7 text-xs text-amber-100 hover:text-amber-50"
+                                    onClick={() => handleCopy(String(result.structured?.image_prompt))}
+                                >
+                                    Copy prompt
+                                </Button>
+                            </div>
+                            <p className="mt-2 whitespace-pre-wrap text-amber-100/90">
+                                {String(result.structured.image_prompt)}
+                            </p>
+                            <p className="mt-2 text-xs uppercase tracking-wide text-amber-200/80">
+                                Ready for 512x512 renders in Automatic1111.
+                            </p>
+                        </div>
+                    )}
+                </div>
+            )}
+        </section>
+    );
+}
+
+function formatValue(value: unknown): string {
+    if (typeof value === 'string') {
+        return value;
+    }
+
+    if (Array.isArray(value)) {
+        return value.map((entry) => (typeof entry === 'string' ? `• ${entry}` : JSON.stringify(entry))).join('\n');
+    }
+
+    if (typeof value === 'object' && value !== null) {
+        return JSON.stringify(value, null, 2);
+    }
+
+    return String(value ?? '');
+}
+
+export default AiIdeaPanel;

--- a/backend/resources/js/components/ui/badge.tsx
+++ b/backend/resources/js/components/ui/badge.tsx
@@ -1,0 +1,18 @@
+import { PropsWithChildren } from 'react';
+
+import { cn } from '@/lib/utils';
+
+type BadgeProps = PropsWithChildren<{ className?: string; variant?: 'default' | 'secondary' | 'outline' }>; 
+
+export function Badge({ className, variant = 'default', children }: BadgeProps) {
+    const base = 'inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide';
+    const palette = {
+        default: 'bg-amber-500/20 text-amber-100',
+        secondary: 'bg-indigo-500/20 text-indigo-100',
+        outline: 'border border-zinc-500/60 text-zinc-200',
+    }[variant];
+
+    return <span className={cn(base, palette, className)}>{children}</span>;
+}
+
+export default Badge;

--- a/backend/resources/js/lib/utils.ts
+++ b/backend/resources/js/lib/utils.ts
@@ -4,3 +4,23 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs));
 }
+
+export function formatTimestamp(value?: string | null): string {
+    if (!value) {
+        return 'unknown';
+    }
+
+    const date = new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+        return 'unknown';
+    }
+
+    return date.toLocaleString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+    });
+}

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Auth\AuthenticatedSessionController;
 use App\Http\Controllers\AnalyticsEventController;
 use App\Http\Controllers\Auth\RegisteredUserController;
 use App\Http\Controllers\Admin\BugReportController as AdminBugReportController;
+use App\Http\Controllers\Admin\UserRoleController;
 use App\Http\Controllers\BugReportController;
 use App\Http\Controllers\CampaignController;
 use App\Http\Controllers\CampaignDigestPreviewController;
@@ -47,6 +48,7 @@ use App\Http\Controllers\SearchController;
 use App\Http\Controllers\UserPreferenceController;
 use App\Http\Controllers\NotificationCenterController;
 use App\Http\Controllers\WorldController;
+use App\Http\Controllers\AiCreativeController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -65,6 +67,7 @@ Route::middleware('guest')->group(function (): void {
 Route::middleware('auth')->group(function (): void {
     Route::get('/dashboard', fn () => Inertia::render('Dashboard'))->name('dashboard');
     Route::post('analytics/events', [AnalyticsEventController::class, 'store'])->name('analytics.events.store');
+    Route::post('ai/assist', AiCreativeController::class)->name('ai.assist');
     Route::get('/notifications', [NotificationCenterController::class, 'index'])->name('notifications.index');
     Route::patch('/notifications/{notification}/read', [NotificationCenterController::class, 'markAsRead'])->name('notifications.read');
     Route::post('/notifications/read-all', [NotificationCenterController::class, 'markAll'])->name('notifications.read-all');
@@ -208,6 +211,8 @@ Route::middleware('auth')->group(function (): void {
         Route::get('bug-reports/{bugReport}', [AdminBugReportController::class, 'show'])->name('bug-reports.show');
         Route::patch('bug-reports/{bugReport}', [AdminBugReportController::class, 'update'])->name('bug-reports.update');
         Route::post('bug-reports/{bugReport}/comments', [AdminBugReportController::class, 'comment'])->name('bug-reports.comment');
+        Route::get('users', [UserRoleController::class, 'index'])->name('users.index');
+        Route::patch('users/{user}', [UserRoleController::class, 'update'])->name('users.update');
     });
     Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])->name('logout');
 });


### PR DESCRIPTION
## Summary
- seed a demo support admin and add a console for toggling support roles
- add creative AI endpoints, prompts, and a reusable panel for summoning structured ideas
- embed the AI helper into world, region, tile, map, quest, and lore editors while improving map orientation handling

## Testing
- php artisan test *(fails: missing vendor/autoload.php in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f3ce901fa8833286e9fda406123bd9